### PR TITLE
Rename DPA decks to only contain the name of the deck

### DIFF
--- a/data/contents/DPA.yaml
+++ b/data/contents/DPA.yaml
@@ -13,7 +13,7 @@ products:
   Duels of the Planeswalkers Ears of the Elves Nissa Revane Deck:
     card_count: 60
     deck:
-    - name: Ears of the Elves - The Nissa Revane Deck
+    - name: Ears of the Elves
       set: dpa
     sealed:
     - count: 1
@@ -22,7 +22,7 @@ products:
   Duels of the Planeswalkers Eyes of Shadow Liliana Vess Deck:
     card_count: 60
     deck:
-    - name: Eyes of Shadow - The Liliana Vess Deck
+    - name: Eyes of Shadow
       set: dpa
     sealed:
     - count: 1
@@ -31,7 +31,7 @@ products:
   Duels of the Planeswalkers Hands of Flame Chandra Nalaar Deck:
     card_count: 60
     deck:
-    - name: Hands of Flame - The Chandra Nalaar Deck
+    - name: Hands of Flame
       set: dpa
     sealed:
     - count: 1
@@ -41,7 +41,7 @@ products:
   Duels of the Planeswalkers Teeth of the Predator Garruk Wildspeaker Deck:
     card_count: 60
     deck:
-    - name: Teeth of the Predator - the Garruk Wildspeaker Deck
+    - name: Teeth of the Predator
       set: dpa
     sealed:
     - count: 1
@@ -50,7 +50,7 @@ products:
   Duels of the Planeswalkers Thoughts of the Wind Jace Beleren Deck:
     card_count: 60
     deck:
-    - name: Thoughts of the Wind - The Jace Beleren Deck
+    - name: Thoughts of the Wind
       set: dpa
     sealed:
     - count: 1


### PR DESCRIPTION
Anything after the dash is redundant and this brings this set closer to how other decks are handled (ie a short identifiable name).

pending on https://github.com/taw/magic-preconstructed-decks/pull/75