### PR TITLE
Rename GN2 set differently, fix tcgId and release date

### DIFF
--- a/data/contents/GN2.yaml
+++ b/data/contents/GN2.yaml
@@ -1,6 +1,6 @@
 code: gn2
 products:
-  Magic Game Night Set:
+  Magic Game Night 2019 Set:
     card_count: 300
     deck:
     - name: Aerial Acrobatics

--- a/data/products/GN2.yaml
+++ b/data/products/GN2.yaml
@@ -1,9 +1,9 @@
 code: gn2
 products:
-  Magic Game Night Set:
+  Magic Game Night 2019 Set:
     category: BOX_SET
     identifiers:
       cardKingdomId: '228607'
-      tcgplayerProductId: '175171'
-    release_date: '2018-11-16'
+      tcgplayerProductId: '199357'
+    release_date: '2019-11-15'
     subtype: UNKNOWN


### PR DESCRIPTION
Fix #78.

Not sure if we want to enforce more name uniqueness elsewhere.