### PR TITLE
RFC: Adding Language to products

### DIFF
--- a/data/contents/DRK.yaml
+++ b/data/contents/DRK.yaml
@@ -10,3 +10,13 @@ products:
     pack:
     - code: default
       set: drk
+  The Dark Italian Booster Box:
+    sealed:
+    - count: 60
+      name: The Dark Italian Booster Pack
+      set: drk
+  The Dark Italian Booster Pack:
+    card_count: 8
+    pack:
+    - code: default
+      set: drk

--- a/data/contents/LEG.yaml
+++ b/data/contents/LEG.yaml
@@ -5,14 +5,18 @@ products:
     - count: 36
       name: Legends Booster Pack
       set: leg
-  Legends Booster Box (Non-English ITALIAN):
-    sealed:
-    - count: 36
-      name: Legends Booster Pack (Non-English ITALIAN)
-      set: leg
   Legends Booster Pack:
     card_count: 15
     pack:
     - code: default
       set: leg
-  Legends Booster Pack (Non-English ITALIAN): []
+  Legends Italian Booster Box:
+    sealed:
+    - count: 36
+      name: Legends Italian Booster Pack
+      set: leg
+  Legends Italian Booster Pack:
+    card_count: 15
+    pack:
+    - code: default
+      set: leg

--- a/data/new_product_template.yaml
+++ b/data/new_product_template.yaml
@@ -1,8 +1,9 @@
 code:
 products:
   {name}:
+    language:
     category:
     subtype:
     release_date:
     purchase_url:
-      location: 
+      location:

--- a/data/products/DD2.yaml
+++ b/data/products/DD2.yaml
@@ -7,6 +7,7 @@ products:
       tcgplayerProductId: '32804'
     subtype: DUEL
   Duel Deck Jace vs Chandra Japanese:
+    language: Japanese
     category: MULTI_DECK
     identifiers:
       cardKingdomId: '132597'

--- a/data/products/DRK.yaml
+++ b/data/products/DRK.yaml
@@ -12,3 +12,11 @@ products:
       cardKingdomId: '1464'
       tcgplayerProductId: '27371'
     subtype: DEFAULT
+  The Dark Italian Booster Box:
+    language: Italian
+    category: BOOSTER_BOX
+    subtype: DEFAULT
+  The Dark Italian Booster Pack:
+    language: Italian
+    category: BOOSTER_PACK
+    subtype: DEFAULT

--- a/data/products/LEG.yaml
+++ b/data/products/LEG.yaml
@@ -7,6 +7,7 @@ products:
       tcgplayerProductId: '27286'
     subtype: DEFAULT
   Legends Booster Box (Non-English ITALIAN):
+    language: Italian
     category: BOOSTER_BOX
     identifiers:
       cardKingdomId: '238460'
@@ -18,6 +19,7 @@ products:
       tcgplayerProductId: '27348'
     subtype: DEFAULT
   Legends Booster Pack (Non-English ITALIAN):
+    language: Italian
     category: BOOSTER_PACK
     identifiers:
       cardKingdomId: '186216'

--- a/data/products/LEG.yaml
+++ b/data/products/LEG.yaml
@@ -6,19 +6,19 @@ products:
       cardKingdomId: '238459'
       tcgplayerProductId: '27286'
     subtype: DEFAULT
-  Legends Booster Box (Non-English ITALIAN):
-    language: Italian
-    category: BOOSTER_BOX
-    identifiers:
-      cardKingdomId: '238460'
-    subtype: DEFAULT
   Legends Booster Pack:
     category: BOOSTER_PACK
     identifiers:
       cardKingdomId: '124075'
       tcgplayerProductId: '27348'
     subtype: DEFAULT
-  Legends Booster Pack (Non-English ITALIAN):
+  Legends Italian Booster Box:
+    language: Italian
+    category: BOOSTER_BOX
+    identifiers:
+      cardKingdomId: '238460'
+    subtype: DEFAULT
+  Legends Italian Booster Pack:
     language: Italian
     category: BOOSTER_PACK
     identifiers:

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -927,11 +927,13 @@ products:
       tcgplayerProductId: '267766'
     subtype: SECRET_LAIR
   Secret Lair February Superdrop Pictures of the Floating World:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '267774'
     subtype: SECRET_LAIR
   Secret Lair February Superdrop Pictures of the Floating World Foil Edition:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '267775'
@@ -1305,21 +1307,25 @@ products:
       tcgplayerProductId: '205230'
     subtype: SECRET_LAIR
   Secret Lair Phyrexian Faves:
+    language: Phyrexian
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '480457'
     subtype: SECRET_LAIR
   Secret Lair Phyrexian Faves Foil:
+    language: Phyrexian
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '480456'
     subtype: SECRET_LAIR
   Secret Lair Phyrexian Praetors Compleat Edition Foil:
+    language: Phyrexian
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '242345'
     subtype: SECRET_LAIR
   Secret Lair Phyrexian Praetors Compleat Edition Non Foil:
+    language: Phyrexian
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '242346'
@@ -1714,11 +1720,13 @@ products:
       tcgplayerProductId: '450535'
     subtype: SECRET_LAIR
   Secret Lair Special Guest Junji Ito Japanese:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '450534'
     subtype: SECRET_LAIR
   Secret Lair Special Guest Junji Ito Japanese Foil Etched Edition:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '450533'
@@ -1774,11 +1782,13 @@ products:
       tcgplayerProductId: '450539'
     subtype: SECRET_LAIR
   Secret Lair Special Guest Yoji Shinkawa Japanese:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '450538'
     subtype: SECRET_LAIR
   Secret Lair Special Guest Yoji Shinkawa Japanese Foil Edition:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '450537'
@@ -1965,6 +1975,7 @@ products:
       tcgplayerProductId: '258456'
     subtype: SECRET_LAIR
   Secret Lair The Godzilla Lands:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '213819'
@@ -2017,11 +2028,13 @@ products:
     release_date: '2023-09-06'
     subtype: SECRET_LAIR
   Secret Lair The Tokyo Lands:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '275805'
     subtype: SECRET_LAIR
   Secret Lair The Tokyo Lands Etched Foil:
+    language: Japanese
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '275804'

--- a/data/products/STX.yaml
+++ b/data/products/STX.yaml
@@ -48,21 +48,25 @@ products:
     release_date: '2021-04-23'
     subtype: DEFAULT
   Strixhaven School of Mages Japanese Language Draft Booster Box:
+    language: Japanese
     category: BOOSTER_BOX
     identifiers: {}
     release_date: '2021-04-23'
     subtype: DEFAULT
   Strixhaven School of Mages Japanese Language Draft Booster Pack:
+    language: Japanese
     category: BOOSTER_PACK
     identifiers: {}
     release_date: '2021-04-23'
     subtype: DEFAULT
   Strixhaven School of Mages Japanese Language Set Booster Box:
+    language: Japanese
     category: BOOSTER_BOX
     identifiers: {}
     release_date: '2021-04-23'
     subtype: SET
   Strixhaven School of Mages Japanese Language Set Booster Pack:
+    language: Japanese
     category: BOOSTER_PACK
     identifiers: {}
     release_date: '2021-04-23'


### PR DESCRIPTION
this is meant as a starting place to define the main language of the product, so that it's possible to display or pick the right copy of the card for certain products