### PR TITLE
MB1; Rename retail draft booster to the name of the sheet

### DIFF
--- a/data/contents/MB1.yaml
+++ b/data/contents/MB1.yaml
@@ -28,5 +28,5 @@ products:
   Mystery Booster Booster Pack (Retail Edition):
     card_count: 15
     pack:
-    - code: retail
+    - code: draft
       set: mb1


### PR DESCRIPTION
Alternative solution to https://github.com/taw/magic-search-engine/pull/314