### PR TITLE
Fixes to the foil name tags in SLD

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -3121,14 +3121,14 @@ products:
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop EVERYTHING IS ON FIRE (Rainbow Foil):
+  Secret Lair Drop EVERYTHING IS ON FIRE Rainbow Foil:
     card_count: 5
     deck:
     - name: EVERYTHING IS ON FIRE foil
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop EVERYTHING IS ON FIRE (Raised Foil):
+  Secret Lair Drop EVERYTHING IS ON FIRE Raised Foil:
     card_count: 5
     deck:
     - name: EVERYTHING IS ON FIRE Raised foil
@@ -7274,14 +7274,14 @@ products:
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop vroooOOOMMMMMM! (Rainbow Foil):
+  Secret Lair Drop vroooOOOMMMMMM! Rainbow Foil:
     card_count: 5
     deck:
     - name: vroooOOOMMMMMM foil
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop vroooOOOMMMMMM! (Raised Foil):
+  Secret Lair Drop vroooOOOMMMMMM! Raised Foil:
     card_count: 5
     deck:
     - name: vroooOOOMMMMMM Raised foil

--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -641,13 +641,13 @@ products:
   Secret Lair Bundle Equinox Superdrop 2024 Fallout Bundle Foil:
     sealed:
     - count: 1
-      name: Secret Lair Drop Secret Lair x Fallout Vault Boy Foil
+      name: Secret Lair Drop Secret Lair x Fallout Vault Boy Rainbow Foil
       set: sld
     - count: 1
-      name: Secret Lair Drop Secret Lair x Fallout SPECIAL Foil
+      name: Secret Lair Drop Secret Lair x Fallout SPECIAL Rainbow Foil
       set: sld
     - count: 1
-      name: Secret Lair Drop Secret Lair x Fallout Points of Interest Foil
+      name: Secret Lair Drop Secret Lair x Fallout Points of Interest Rainbow Foil
       set: sld
   Secret Lair Bundle Equinox Superdrop 2024 Sunlight and Moonbeams:
     sealed:
@@ -679,13 +679,13 @@ products:
       set: sld
     sealed:
     - count: 1
-      name: Secret Lair Drop Secret Lair x Fallout Vault Boy Foil
+      name: Secret Lair Drop Secret Lair x Fallout Vault Boy Rainbow Foil
       set: sld
     - count: 1
-      name: Secret Lair Drop Secret Lair x Fallout SPECIAL Foil
+      name: Secret Lair Drop Secret Lair x Fallout SPECIAL Rainbow Foil
       set: sld
     - count: 1
-      name: Secret Lair Drop Secret Lair x Fallout Points of Interest Foil
+      name: Secret Lair Drop Secret Lair x Fallout Points of Interest Rainbow Foil
       set: sld
     - count: 1
       name: Secret Lair Drop Featuring Phoebe Wahl Rainbow Foil
@@ -1166,10 +1166,10 @@ products:
   Secret Lair Bundle Secretversary Superdrop 2023 Goodie Bag Loaded with Foils:
     sealed:
     - count: 1
-      name: Secret Lair Drop Secret Lair x Jurassic World Life Breaks Free Foil
+      name: Secret Lair Drop Secret Lair x Jurassic World Life Breaks Free Rainbow Foil
       set: sld
     - count: 1
-      name: Secret Lair Drop Secret Lair x Jurassic World Dr Ian Malcolm Foil
+      name: Secret Lair Drop Secret Lair x Jurassic World Dr Ian Malcolm Rainbow Foil
       set: sld
     - count: 1
       name: Secret Lair Drop Secret Lair x Tomb Raider Foil
@@ -1178,13 +1178,13 @@ products:
       name: Secret Lair Drop Through the Wormhole Galaxy Foil
       set: sld
     - count: 1
-      name: Secret Lair Drop Showcase The Lost Caverns of Ixalan Foil
+      name: Secret Lair Drop Showcase The Lost Caverns of Ixalan Rainbow Foil
       set: sld
     - count: 1
       name: Secret Lair Drop Mycosynthwave Foil
       set: sld
     - count: 1
-      name: Secret Lair Drop Tales of the Time Stoppers Foil
+      name: Secret Lair Drop Tales of the Time Stoppers Rainbow Foil
       set: sld
     - count: 1
       name: Secret Lair Drop Gift Wrapped Foil
@@ -1730,7 +1730,7 @@ products:
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop Adventures of the Little Witch Foil:
+  Secret Lair Drop Adventures of the Little Witch Rainbow Foil:
     card_count: 4
     deck:
     - name: Adventures of the Little Witch foil
@@ -5208,7 +5208,7 @@ products:
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop Secret Lair x Fallout Points of Interest Foil:
+  Secret Lair Drop Secret Lair x Fallout Points of Interest Rainbow Foil:
     card_count: 5
     deck:
     - name: Fallout Points of Interest foil
@@ -5222,7 +5222,7 @@ products:
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop Secret Lair x Fallout SPECIAL Foil:
+  Secret Lair Drop Secret Lair x Fallout SPECIAL Rainbow Foil:
     card_count: 7
     deck:
     - name: Fallout SPECIAL foil
@@ -5236,7 +5236,7 @@ products:
       set: sld
     other:
     - name: Bonus card unknown
-  Secret Lair Drop Secret Lair x Fallout Vault Boy Foil:
+  Secret Lair Drop Secret Lair x Fallout Vault Boy Rainbow Foil:
     card_count: 4
     deck:
     - name: Fallout Vault Boy foil
@@ -5406,7 +5406,7 @@ products:
     deck:
     - name: Jurassic World Dr Ian Malcolm
       set: sld
-  Secret Lair Drop Secret Lair x Jurassic World Dr Ian Malcolm Foil:
+  Secret Lair Drop Secret Lair x Jurassic World Dr Ian Malcolm Rainbow Foil:
     card:
     - foil: true
       name: Chaos Warp
@@ -5425,7 +5425,7 @@ products:
     deck:
     - name: Jurassic World Life Breaks Free
       set: sld
-  Secret Lair Drop Secret Lair x Jurassic World Life Breaks Free Foil:
+  Secret Lair Drop Secret Lair x Jurassic World Life Breaks Free Rainbow Foil:
     card:
     - foil: true
       name: Colossal Dreadmaw
@@ -5968,7 +5968,7 @@ products:
     deck:
     - name: Sheldons Spellbook
       set: sld
-  Secret Lair Drop Sheldons Spellbook Foil:
+  Secret Lair Drop Sheldons Spellbook Rainbow Foil:
     card:
     - foil: true
       name: Keen Duelist
@@ -6233,7 +6233,7 @@ products:
     deck:
     - name: Showcase The Lost Caverns of Ixalan
       set: sld
-  Secret Lair Drop Showcase The Lost Caverns of Ixalan Foil:
+  Secret Lair Drop Showcase The Lost Caverns of Ixalan Rainbow Foil:
     card_count: 5
     deck:
     - name: Showcase The Lost Caverns of Ixalan foil
@@ -6554,7 +6554,7 @@ products:
     deck:
     - name: Tales of the Time Stoppers
       set: sld
-  Secret Lair Drop Tales of the Time Stoppers Foil:
+  Secret Lair Drop Tales of the Time Stoppers Rainbow Foil:
     card_count: 4
     deck:
     - name: Tales of the Time Stoppers foil
@@ -6785,7 +6785,7 @@ products:
     deck:
     - name: The Strange Sands Forest
       set: sld
-  Secret Lair Drop The Strange Sands Forest Foil:
+  Secret Lair Drop The Strange Sands Forest Rainbow Foil:
     card_count: 10
     deck:
     - name: The Strange Sands Forest foil
@@ -6795,7 +6795,7 @@ products:
     deck:
     - name: The Strange Sands Island
       set: sld
-  Secret Lair Drop The Strange Sands Island Foil:
+  Secret Lair Drop The Strange Sands Island Rainbow Foil:
     card_count: 10
     deck:
     - name: The Strange Sands Island foil
@@ -6805,7 +6805,7 @@ products:
     deck:
     - name: The Strange Sands Mountain
       set: sld
-  Secret Lair Drop The Strange Sands Mountain Foil:
+  Secret Lair Drop The Strange Sands Mountain Rainbow Foil:
     card_count: 10
     deck:
     - name: The Strange Sands Mountain foil
@@ -6815,7 +6815,7 @@ products:
     deck:
     - name: The Strange Sands Plains
       set: sld
-  Secret Lair Drop The Strange Sands Plains Foil:
+  Secret Lair Drop The Strange Sands Plains Rainbow Foil:
     card_count: 10
     deck:
     - name: The Strange Sands Plains foil
@@ -6825,7 +6825,7 @@ products:
     deck:
     - name: The Strange Sands Swamp
       set: sld
-  Secret Lair Drop The Strange Sands Swamp Foil:
+  Secret Lair Drop The Strange Sands Swamp Rainbow Foil:
     card_count: 10
     deck:
     - name: The Strange Sands Swamp foil

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -2105,13 +2105,13 @@ products:
       tcgplayerProductId: '632020'
     release_date: '2025-04-29'
     subtype: SECRET_LAIR
-  Secret Lair Drop EVERYTHING IS ON FIRE (Rainbow Foil):
+  Secret Lair Drop EVERYTHING IS ON FIRE Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '632019'
     release_date: '2025-04-29'
     subtype: SECRET_LAIR
-  Secret Lair Drop EVERYTHING IS ON FIRE (Raised Foil):
+  Secret Lair Drop EVERYTHING IS ON FIRE Raised Foil:
     category: BOX_SET
     identifiers:
       mcmId: '823320'
@@ -5457,13 +5457,13 @@ products:
       tcgplayerProductId: '632016'
     release_date: '2025-04-29'
     subtype: SECRET_LAIR
-  Secret Lair Drop vroooOOOMMMMMM! (Rainbow Foil):
+  Secret Lair Drop vroooOOOMMMMMM! Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '632015'
     release_date: '2025-04-29'
     subtype: SECRET_LAIR
-  Secret Lair Drop vroooOOOMMMMMM! (Raised Foil):
+  Secret Lair Drop vroooOOOMMMMMM! Raised Foil:
     category: BOX_SET
     identifiers:
       mcmId: '823351'

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -1166,7 +1166,7 @@ products:
       tcgplayerProductId: '629761'
     release_date: '2025-04-23'
     subtype: SECRET_LAIR
-  Secret Lair Drop Adventures of the Little Witch Foil:
+  Secret Lair Drop Adventures of the Little Witch Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '629762'
@@ -3742,7 +3742,7 @@ products:
       tcgplayerProductId: '545711'
     release_date: '2024-04-25'
     subtype: SECRET_LAIR
-  Secret Lair Drop Secret Lair x Fallout Points of Interest Foil:
+  Secret Lair Drop Secret Lair x Fallout Points of Interest Rainbow Foil:
     category: BOX_SET
     identifiers:
       csiId: '386537'
@@ -3757,7 +3757,7 @@ products:
       tcgplayerProductId: '545713'
     release_date: '2024-04-25'
     subtype: SECRET_LAIR
-  Secret Lair Drop Secret Lair x Fallout SPECIAL Foil:
+  Secret Lair Drop Secret Lair x Fallout SPECIAL Rainbow Foil:
     category: BOX_SET
     identifiers:
       cardtraderId: '290279'
@@ -3774,7 +3774,7 @@ products:
       tcgplayerProductId: '545709'
     release_date: '2024-04-25'
     subtype: SECRET_LAIR
-  Secret Lair Drop Secret Lair x Fallout Vault Boy Foil:
+  Secret Lair Drop Secret Lair x Fallout Vault Boy Rainbow Foil:
     category: BOX_SET
     identifiers:
       csiId: '386531'
@@ -4307,7 +4307,7 @@ products:
       tcgplayerProductId: '539212'
     release_date: '2024-04-12'
     subtype: SECRET_LAIR
-  Secret Lair Drop Sheldons Spellbook Foil:
+  Secret Lair Drop Sheldons Spellbook Rainbow Foil:
     category: BOX_SET
     identifiers:
       cardtraderId: '280580'
@@ -4560,7 +4560,7 @@ products:
       tcgplayerProductId: '528396'
     release_date: '2023-09-23'
     subtype: SECRET_LAIR
-  Secret Lair Drop Showcase The Lost Caverns of Ixalan Foil:
+  Secret Lair Drop Showcase The Lost Caverns of Ixalan Rainbow Foil:
     category: BOX_SET
     identifiers:
       csiId: '377671'
@@ -5039,7 +5039,7 @@ products:
       tcgplayerProductId: '610794'
     release_date: '2025-01-15'
     subtype: SECRET_LAIR
-  Secret Lair Drop The Strange Sands Forest Foil:
+  Secret Lair Drop The Strange Sands Forest Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '610795'
@@ -5052,7 +5052,7 @@ products:
       tcgplayerProductId: '610788'
     release_date: '2025-01-15'
     subtype: SECRET_LAIR
-  Secret Lair Drop The Strange Sands Island Foil:
+  Secret Lair Drop The Strange Sands Island Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '610789'
@@ -5065,7 +5065,7 @@ products:
       tcgplayerProductId: '610792'
     release_date: '2025-01-15'
     subtype: SECRET_LAIR
-  Secret Lair Drop The Strange Sands Mountain Foil:
+  Secret Lair Drop The Strange Sands Mountain Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '610793'
@@ -5078,7 +5078,7 @@ products:
       tcgplayerProductId: '610786'
     release_date: '2025-01-15'
     subtype: SECRET_LAIR
-  Secret Lair Drop The Strange Sands Plains Foil:
+  Secret Lair Drop The Strange Sands Plains Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '610787'
@@ -5091,7 +5091,7 @@ products:
       tcgplayerProductId: '610790'
     release_date: '2025-01-15'
     subtype: SECRET_LAIR
-  Secret Lair Drop The Strange Sands Swamp Foil:
+  Secret Lair Drop The Strange Sands Swamp Rainbow Foil:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '610791'


### PR DESCRIPTION
Just some cleanup to avoid adding () as they may interfere with name matches, and some more correct Rainbow tagging since we started tracking them