### PR TITLE
Enable redemption set mapping for CK

### DIFF
--- a/data/ignore.yaml
+++ b/data/ignore.yaml
@@ -68,6 +68,11 @@ cardKingdom:
   '313172': Final Fantasy Collector Booster Box (Non-English JAPANESE)
   '315940': 'Magic: The Gathering 2025 Land Station'
   '313173': Final Fantasy Collector Booster Pack (Non-English JAPANESE)
+  '300433': Bloomburrow - Complete FOIL Set (Factory Sealed)
+  '210891': Conspiracy - Take the Crown - Complete Foil Set (Factory Sealed)
+  '210890': Conspiracy - Take the Crown - Complete Set (Factory Sealed)
+  '230608': Modern Horizons - Complete FOIL Set (Factory Sealed)
+  '230607': Modern Horizons - Complete Set (Factory Sealed)
 cardMarket:
   250451: 'Duel Decks: Ajani vs. Nicol Bolas - Ajani Deck (without Ajani)'
   250452: 'Duel Decks: Ajani vs. Nicol Bolas - Nicol Bolas Deck (without Nicol Bolas)'

--- a/data/products/10E.yaml
+++ b/data/products/10E.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Tenth Edition MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241647'
     subtype: REDEMPTION
   Tenth Edition MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241646'
     subtype: REDEMPTION
   Tenth Edition Sample Deck Ajani Goldmane:
     category: DECK

--- a/data/products/5DN.yaml
+++ b/data/products/5DN.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Fifth Dawn MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241626'
     subtype: REDEMPTION
   Fifth Dawn MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241625'
     subtype: REDEMPTION
   Fifth Dawn Theme Deck Display:
     category: DECK_BOX

--- a/data/products/7ED.yaml
+++ b/data/products/7ED.yaml
@@ -36,11 +36,13 @@ products:
     subtype: DRAFT
   Seventh Edition MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241604'
     subtype: REDEMPTION
   Seventh Edition MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241603'
     subtype: REDEMPTION
   Seventh Edition Sampler Booster:
     category: BOOSTER_PACK

--- a/data/products/8ED.yaml
+++ b/data/products/8ED.yaml
@@ -54,11 +54,13 @@ products:
     subtype: PROMOTIONAL
   Eighth Edition MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241620'
     subtype: REDEMPTION
   Eighth Edition MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241619'
     subtype: REDEMPTION
   Eighth Edition Sampler Booster:
     category: BOOSTER_PACK

--- a/data/products/9ED.yaml
+++ b/data/products/9ED.yaml
@@ -62,11 +62,13 @@ products:
     subtype: FAT_PACK
   Ninth Edition MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241631'
     subtype: REDEMPTION
   Ninth Edition MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241630'
     subtype: REDEMPTION
   Ninth Edition Sampler Booster:
     category: BOOSTER_PACK

--- a/data/products/AER.yaml
+++ b/data/products/AER.yaml
@@ -45,11 +45,13 @@ products:
     subtype: DEFAULT
   Aether Revolt MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '212311'
     subtype: REDEMPTION
   Aether Revolt MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '211546'
     subtype: REDEMPTION
   Aether Revolt Planeswalker Deck Ajani:
     category: DECK

--- a/data/products/AFR.yaml
+++ b/data/products/AFR.yaml
@@ -120,11 +120,13 @@ products:
     subtype: GIFT_BUNDLE
   Adventures in the Forgotten Realms MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '249663'
     subtype: REDEMPTION
   Adventures in the Forgotten Realms MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '249664'
     subtype: REDEMPTION
   Adventures in the Forgotten Realms Prerelease Pack:
     category: LIMITED

--- a/data/products/AKH.yaml
+++ b/data/products/AKH.yaml
@@ -71,11 +71,13 @@ products:
     subtype: LAND_STATION
   Amonkhet MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '212399'
     subtype: REDEMPTION
   Amonkhet MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '212400'
     subtype: REDEMPTION
   Amonkhet Planeswalker Deck Display:
     category: DECK_BOX

--- a/data/products/ALA.yaml
+++ b/data/products/ALA.yaml
@@ -105,11 +105,13 @@ products:
     subtype: INTRO
   Shards of Alara MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223053'
     subtype: REDEMPTION
   Shards of Alara MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223052'
     subtype: REDEMPTION
   Shards of Alara Premium Foil Booster Box:
     category: BOOSTER_BOX

--- a/data/products/APC.yaml
+++ b/data/products/APC.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Apocalypse MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241606'
     subtype: REDEMPTION
   Apocalypse MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241605'
     subtype: REDEMPTION
   Apocalypse Theme Deck Burial:
     category: DECK

--- a/data/products/ARB.yaml
+++ b/data/products/ARB.yaml
@@ -104,11 +104,13 @@ products:
     subtype: INTRO
   Alara Reborn MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223057'
     subtype: REDEMPTION
   Alara Reborn MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223056'
     subtype: REDEMPTION
   Alara Reborn Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/AVR.yaml
+++ b/data/products/AVR.yaml
@@ -154,11 +154,13 @@ products:
     subtype: INTRO
   Avacyn Restored MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210858'
     subtype: REDEMPTION
   Avacyn Restored MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210874'
     subtype: REDEMPTION
   Avacyn Restored Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/BFZ.yaml
+++ b/data/products/BFZ.yaml
@@ -141,9 +141,11 @@ products:
     subtype: INTRO
   Battle for Zendikar MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210364'
     subtype: REDEMPTION
   Battle for Zendikar MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210866'
     subtype: REDEMPTION

--- a/data/products/BLB.yaml
+++ b/data/products/BLB.yaml
@@ -58,7 +58,8 @@ products:
     subtype: PROMOTIONAL
   Bloomburrow MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '300432'
     subtype: REDEMPTION
   Bloomburrow MTGO Redemption Foil:
     category: BOX_SET

--- a/data/products/BNG.yaml
+++ b/data/products/BNG.yaml
@@ -153,11 +153,13 @@ products:
     subtype: INTRO
   Born of the Gods MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210882'
     subtype: REDEMPTION
   Born of the Gods MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210853'
     subtype: REDEMPTION
   Born of the Gods Prerelease Kit Destined To Conquer:
     category: LIMITED

--- a/data/products/BOK.yaml
+++ b/data/products/BOK.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Betrayers of Kamigawa MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '219828'
     subtype: REDEMPTION
   Betrayers of Kamigawa MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241627'
     subtype: REDEMPTION
   Betrayers of Kamigawa Theme Deck Dark Devotion:
     category: DECK

--- a/data/products/BRO.yaml
+++ b/data/products/BRO.yaml
@@ -11,11 +11,13 @@ products:
     subtype: LAND_STATION
   The Brothers War MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '274801'
     subtype: REDEMPTION
   The Brothers War MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '274800'
     subtype: REDEMPTION
   The Brothers' War Bundle:
     category: BUNDLE

--- a/data/products/CHK.yaml
+++ b/data/products/CHK.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Champions of Kamigawa MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '219829'
     subtype: REDEMPTION
   Champions of Kamigawa MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '228583'
     subtype: REDEMPTION
   Champions of Kamigawa Theme Deck Display:
     category: DECK_BOX

--- a/data/products/CON_.yaml
+++ b/data/products/CON_.yaml
@@ -105,11 +105,13 @@ products:
     subtype: INTRO
   Conflux MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223901'
     subtype: REDEMPTION
   Conflux MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241654'
     subtype: REDEMPTION
   Conflux Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/CSP.yaml
+++ b/data/products/CSP.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Coldsnap MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241639'
     subtype: REDEMPTION
   Coldsnap MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241638'
     subtype: REDEMPTION
   Coldsnap Theme Deck Aurochs Stampede:
     category: DECK

--- a/data/products/DGM.yaml
+++ b/data/products/DGM.yaml
@@ -137,11 +137,13 @@ products:
     subtype: INTRO
   Dragons Maze MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210847'
     subtype: REDEMPTION
   Dragons Maze MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210852'
     subtype: REDEMPTION
   Dragons Maze Prerelease Guild Kit 10 Pack:
     category: LIMITED_CASE

--- a/data/products/DIS.yaml
+++ b/data/products/DIS.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Dissension MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241637'
     subtype: REDEMPTION
   Dissension MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241636'
     subtype: REDEMPTION
   Dissension Theme Deck Azorius Ascendant:
     category: DECK

--- a/data/products/DKA.yaml
+++ b/data/products/DKA.yaml
@@ -153,11 +153,13 @@ products:
     subtype: INTRO
   Dark Ascension MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210846'
     subtype: REDEMPTION
   Dark Ascension MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210860'
     subtype: REDEMPTION
   Dark Ascension Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/DMU.yaml
+++ b/data/products/DMU.yaml
@@ -130,11 +130,13 @@ products:
     subtype: JUMPSTART
   Dominaria United MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '264063'
     subtype: REDEMPTION
   Dominaria United MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '264062'
     subtype: REDEMPTION
   Dominaria United Prerelease Pack:
     category: LIMITED

--- a/data/products/DOM.yaml
+++ b/data/products/DOM.yaml
@@ -53,11 +53,13 @@ products:
     subtype: DEFAULT
   Dominaria MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '219038'
     subtype: REDEMPTION
   Dominaria MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '218502'
     subtype: REDEMPTION
   Dominaria Planeswalker Deck Chandra:
     category: DECK

--- a/data/products/DSK.yaml
+++ b/data/products/DSK.yaml
@@ -62,7 +62,8 @@ products:
     subtype: PROMOTIONAL
   Duskmourn House of Horror MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '300735'
     subtype: REDEMPTION
   Duskmourn House of Horror MTGO Redemption Foil:
     category: BOX_SET

--- a/data/products/DST.yaml
+++ b/data/products/DST.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Darksteel MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241624'
     subtype: REDEMPTION
   Darksteel MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241623'
     subtype: REDEMPTION
   Darksteel Theme Deck Display:
     category: DECK_BOX

--- a/data/products/DTK.yaml
+++ b/data/products/DTK.yaml
@@ -134,11 +134,13 @@ products:
     subtype: INTRO
   Dragons of Tarkir MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210849'
     subtype: REDEMPTION
   Dragons of Tarkir MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210868'
     subtype: REDEMPTION
   Dragons of Tarkir Prerelease Kit Atarka Battle with Savagery:
     category: LIMITED

--- a/data/products/ELD.yaml
+++ b/data/products/ELD.yaml
@@ -177,11 +177,13 @@ products:
     subtype: GIFT_BUNDLE
   Throne of Eldraine MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '228554'
     subtype: REDEMPTION
   Throne of Eldraine MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '228553'
     subtype: REDEMPTION
   Throne of Eldraine Planeswalker Deck Display:
     category: DECK_BOX

--- a/data/products/EVE.yaml
+++ b/data/products/EVE.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Eventide MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241598'
     subtype: REDEMPTION
   Eventide MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241597'
     subtype: REDEMPTION
   Eventide Theme Deck Battle Blitz:
     category: DECK

--- a/data/products/FRF.yaml
+++ b/data/products/FRF.yaml
@@ -131,11 +131,13 @@ products:
     subtype: INTRO
   Fate Reforged MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210848'
     subtype: REDEMPTION
   Fate Reforged MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '211510'
     subtype: REDEMPTION
   Fate Reforged Prerelease Kit Abzan Battle with Endurance:
     category: LIMITED

--- a/data/products/FUT.yaml
+++ b/data/products/FUT.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Future Sight MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241645'
     subtype: REDEMPTION
   Future Sight MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241644'
     subtype: REDEMPTION
   Future Sight Theme Deck Display:
     category: DECK_BOX

--- a/data/products/GPT.yaml
+++ b/data/products/GPT.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Guildpact MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241635'
     subtype: REDEMPTION
   Guildpact MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241634'
     subtype: REDEMPTION
   Guildpact Theme Deck Code of the Orzhov:
     category: DECK

--- a/data/products/GRN.yaml
+++ b/data/products/GRN.yaml
@@ -48,11 +48,13 @@ products:
     subtype: DEFAULT
   Guilds of Ravnica MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '222251'
     subtype: REDEMPTION
   Guilds of Ravnica MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '222250'
     subtype: REDEMPTION
   Guilds of Ravnica Mythic Edition:
     category: BOOSTER_BOX

--- a/data/products/GTC.yaml
+++ b/data/products/GTC.yaml
@@ -173,11 +173,13 @@ products:
     subtype: INTRO
   Gatecrash MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210855'
     subtype: REDEMPTION
   Gatecrash MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210870'
     subtype: REDEMPTION
   Gatecrash Prerelease Kit Boros:
     category: LIMITED

--- a/data/products/HOU.yaml
+++ b/data/products/HOU.yaml
@@ -48,11 +48,13 @@ products:
     subtype: DEFAULT
   Hour of Devastation MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '213467'
     subtype: REDEMPTION
   Hour of Devastation MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '213466'
     subtype: REDEMPTION
   Hour of Devastation Planeswalker Deck Display:
     category: DECK_BOX

--- a/data/products/IKO.yaml
+++ b/data/products/IKO.yaml
@@ -98,11 +98,13 @@ products:
     subtype: DRAFT
   Ikoria Lair of Behemoths MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '233884'
     subtype: REDEMPTION
   Ikoria Lair of Behemoths MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '233883'
     subtype: REDEMPTION
   Ikoria Lair of Behemoths Prerelease Pack:
     category: LIMITED

--- a/data/products/INV.yaml
+++ b/data/products/INV.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Invasion MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241600'
     subtype: REDEMPTION
   Invasion MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241599'
     subtype: REDEMPTION
   Invasion Theme Deck Blowout:
     category: DECK

--- a/data/products/ISD.yaml
+++ b/data/products/ISD.yaml
@@ -146,11 +146,13 @@ products:
     subtype: INTRO
   Innistrad MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210884'
     subtype: REDEMPTION
   Innistrad MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210864'
     subtype: REDEMPTION
   Innistrad Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/JOU.yaml
+++ b/data/products/JOU.yaml
@@ -211,9 +211,11 @@ products:
     subtype: PRERELEASE
   Journey into Nyx MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210881'
     subtype: REDEMPTION
   Journey into Nyx MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210856'
     subtype: REDEMPTION

--- a/data/products/JUD.yaml
+++ b/data/products/JUD.yaml
@@ -41,11 +41,13 @@ products:
     subtype: FAT_PACK
   Judgment MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241612'
     subtype: REDEMPTION
   Judgment MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241611'
     subtype: REDEMPTION
   Judgment Theme Deck Air Razers:
     category: DECK

--- a/data/products/KHM.yaml
+++ b/data/products/KHM.yaml
@@ -83,11 +83,13 @@ products:
     subtype: DRAFT
   Kaldheim MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241591'
     subtype: REDEMPTION
   Kaldheim MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241590'
     subtype: REDEMPTION
   Kaldheim Prerelease Pack:
     category: LIMITED

--- a/data/products/KLD.yaml
+++ b/data/products/KLD.yaml
@@ -79,11 +79,13 @@ products:
     subtype: DEFAULT
   Kaladesh MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210360'
     subtype: REDEMPTION
   Kaladesh MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210365'
     subtype: REDEMPTION
   Kaladesh Planeswalker Deck Chandra:
     category: DECK

--- a/data/products/KTK.yaml
+++ b/data/products/KTK.yaml
@@ -138,11 +138,13 @@ products:
     subtype: INTRO
   Khans of Tarkir MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210888'
     subtype: REDEMPTION
   Khans of Tarkir MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210872'
     subtype: REDEMPTION
   Khans of Tarkir Prerelease Kit Abzan Battle with Endurance:
     category: LIMITED

--- a/data/products/LCI.yaml
+++ b/data/products/LCI.yaml
@@ -129,11 +129,13 @@ products:
     subtype: GIFT_BUNDLE
   The Lost Caverns of Ixalan MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '288155'
     subtype: REDEMPTION
   The Lost Caverns of Ixalan MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '288154'
     subtype: REDEMPTION
   The Lost Caverns of Ixalan Prerelease Pack:
     category: LIMITED

--- a/data/products/LGN.yaml
+++ b/data/products/LGN.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Legions MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241616'
     subtype: REDEMPTION
   Legions MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241615'
     subtype: REDEMPTION
   Legions Theme Deck Display:
     category: DECK_BOX

--- a/data/products/LRW.yaml
+++ b/data/products/LRW.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Lorwyn MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241649'
     subtype: REDEMPTION
   Lorwyn MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241648'
     subtype: REDEMPTION
   Lorwyn Theme Deck Boggart Feast:
     category: DECK

--- a/data/products/M19.yaml
+++ b/data/products/M19.yaml
@@ -68,11 +68,13 @@ products:
     subtype: GIFT_BUNDLE
   Core Set 2019 MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '221344'
     subtype: REDEMPTION
   Core Set 2019 MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '221343'
     subtype: REDEMPTION
   Core Set 2019 Planeswalker Deck Ajani:
     category: DECK

--- a/data/products/M20.yaml
+++ b/data/products/M20.yaml
@@ -67,11 +67,13 @@ products:
     subtype: LAND_STATION
   Core Set 2020 MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '228502'
     subtype: REDEMPTION
   Core Set 2020 MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '228501'
     subtype: REDEMPTION
   Core Set 2020 Planeswalker Deck Ajani:
     category: DECK

--- a/data/products/M21.yaml
+++ b/data/products/M21.yaml
@@ -95,11 +95,13 @@ products:
     subtype: DRAFT
   Core Set 2021 MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '233881'
     subtype: REDEMPTION
   Core Set 2021 MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '233882'
     subtype: REDEMPTION
   Core Set 2021 Planeswalker Deck Basri:
     category: DECK

--- a/data/products/MBS.yaml
+++ b/data/products/MBS.yaml
@@ -144,11 +144,13 @@ products:
     subtype: INTRO
   Mirrodin Besieged MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210877'
     subtype: REDEMPTION
   Mirrodin Besieged MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210859'
     subtype: REDEMPTION
   Mirrodin Besieged Mirran Faction Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/MID.yaml
+++ b/data/products/MID.yaml
@@ -94,11 +94,13 @@ products:
     subtype: DRAFT
   Innistrad Midnight Hunt MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '251916'
     subtype: REDEMPTION
   Innistrad Midnight Hunt MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '251915'
     subtype: REDEMPTION
   Innistrad Midnight Hunt Prerelease Pack:
     category: LIMITED

--- a/data/products/MKM.yaml
+++ b/data/products/MKM.yaml
@@ -62,11 +62,13 @@ products:
     subtype: PROMOTIONAL
   Murders at Karlov Manor MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '291403'
     subtype: REDEMPTION
   Murders at Karlov Manor MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '291404'
     subtype: REDEMPTION
   Murders at Karlov Manor Play Booster Box:
     category: BOOSTER_BOX

--- a/data/products/MOM.yaml
+++ b/data/products/MOM.yaml
@@ -115,7 +115,8 @@ products:
     subtype: JUMPSTART
   March of the Machine MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '275000'
     subtype: REDEMPTION
   March of the Machine MTGO Redemption Foil:
     category: BOX_SET

--- a/data/products/MOR.yaml
+++ b/data/products/MOR.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Morningtide MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241651'
     subtype: REDEMPTION
   Morningtide MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241650'
     subtype: REDEMPTION
   Morningtide Theme Deck Battalion:
     category: DECK

--- a/data/products/MRD.yaml
+++ b/data/products/MRD.yaml
@@ -41,11 +41,13 @@ products:
     subtype: FAT_PACK
   Mirrodin MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241621'
     subtype: REDEMPTION
   Mirrodin MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241622'
     subtype: REDEMPTION
   Mirrodin Theme Deck Bait and Bludgeon:
     category: DECK

--- a/data/products/NEO.yaml
+++ b/data/products/NEO.yaml
@@ -92,11 +92,13 @@ products:
     subtype: DRAFT
   Kamigawa Neon Dynasty MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '257923'
     subtype: REDEMPTION
   Kamigawa Neon Dynasty MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '257922'
     subtype: REDEMPTION
   Kamigawa Neon Dynasty Prerelease Pack:
     category: LIMITED

--- a/data/products/NPH.yaml
+++ b/data/products/NPH.yaml
@@ -143,11 +143,13 @@ products:
     subtype: INTRO
   New Phyrexia MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210880'
     subtype: REDEMPTION
   New Phyrexia MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210861'
     subtype: REDEMPTION
   New Phyrexia Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/ODY.yaml
+++ b/data/products/ODY.yaml
@@ -41,11 +41,13 @@ products:
     subtype: FAT_PACK
   Odyssey MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241608'
     subtype: REDEMPTION
   Odyssey MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241607'
     subtype: REDEMPTION
   Odyssey Theme Deck Display:
     category: DECK_BOX

--- a/data/products/OGW.yaml
+++ b/data/products/OGW.yaml
@@ -120,11 +120,13 @@ products:
     subtype: INTRO
   Oath of the Gatewatch MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210363'
     subtype: REDEMPTION
   Oath of the Gatewatch MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210873'
     subtype: REDEMPTION
   Oath of the Gatewatch Prerelease Pack:
     category: LIMITED

--- a/data/products/ONE.yaml
+++ b/data/products/ONE.yaml
@@ -145,11 +145,13 @@ products:
     subtype: JUMPSTART
   Phyrexia All Will Be One MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '274802'
     subtype: REDEMPTION
   Phyrexia All Will Be One MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '274803'
     subtype: REDEMPTION
   Phyrexia All Will Be One Prerelease Pack:
     category: LIMITED

--- a/data/products/ONS.yaml
+++ b/data/products/ONS.yaml
@@ -41,11 +41,13 @@ products:
     subtype: FAT_PACK
   Onslaught MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241614'
     subtype: REDEMPTION
   Onslaught MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241613'
     subtype: REDEMPTION
   Onslaught Theme Deck Bait and Switch:
     category: DECK

--- a/data/products/OTJ.yaml
+++ b/data/products/OTJ.yaml
@@ -61,11 +61,13 @@ products:
     subtype: PROMOTIONAL
   Outlaws of Thunder Junction MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '293776'
     subtype: REDEMPTION
   Outlaws of Thunder Junction MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '293777'
     subtype: REDEMPTION
   Outlaws of Thunder Junction Play Booster Box:
     category: BOOSTER_BOX

--- a/data/products/PLC.yaml
+++ b/data/products/PLC.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Planar Chaos MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241643'
     subtype: REDEMPTION
   Planar Chaos MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241642'
     subtype: REDEMPTION
   Planar Chaos Theme Deck Display:
     category: DECK_BOX

--- a/data/products/PLS.yaml
+++ b/data/products/PLS.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Planeshift MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241602'
     subtype: REDEMPTION
   Planeshift MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241601'
     subtype: REDEMPTION
   Planeshift Theme Deck Barrage:
     category: DECK

--- a/data/products/RAV.yaml
+++ b/data/products/RAV.yaml
@@ -30,11 +30,13 @@ products:
     subtype: DRAFT
   Ravnica City of Guilds MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241633'
     subtype: REDEMPTION
   Ravnica City of Guilds MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241632'
     subtype: REDEMPTION
   Ravnica Fat Pack:
     category: BUNDLE

--- a/data/products/RIX.yaml
+++ b/data/products/RIX.yaml
@@ -48,11 +48,13 @@ products:
     subtype: DEFAULT
   Rivals of Ixalan MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '217135'
     subtype: REDEMPTION
   Rivals of Ixalan MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '217136'
     subtype: REDEMPTION
   Rivals of Ixalan Planeswalker Deck Angrath:
     category: DECK

--- a/data/products/RNA.yaml
+++ b/data/products/RNA.yaml
@@ -81,11 +81,13 @@ products:
     subtype: DECK_BUILDERS_TOOLKIT
   Ravnica Allegiance MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223965'
     subtype: REDEMPTION
   Ravnica Allegiance MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223966'
     subtype: REDEMPTION
   Ravnica Allegiance Mythic Edition:
     category: BUNDLE

--- a/data/products/ROE.yaml
+++ b/data/products/ROE.yaml
@@ -116,11 +116,13 @@ products:
     subtype: INTRO
   Rise of the Eldrazi MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241659'
     subtype: REDEMPTION
   Rise of the Eldrazi MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241658'
     subtype: REDEMPTION
   Rise of the Eldrazi Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/RTR.yaml
+++ b/data/products/RTR.yaml
@@ -194,11 +194,13 @@ products:
     subtype: INTRO
   Return to Ravnica MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210857'
     subtype: REDEMPTION
   Return to Ravnica MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210865'
     subtype: REDEMPTION
   Return to Ravnica Prerelease Pack Azorius:
     category: LIMITED

--- a/data/products/SCG.yaml
+++ b/data/products/SCG.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Scourge MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241618'
     subtype: REDEMPTION
   Scourge MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241617'
     subtype: REDEMPTION
   Scourge Theme Deck Display:
     category: DECK_BOX

--- a/data/products/SHM.yaml
+++ b/data/products/SHM.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Shadowmoor MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241653'
     subtype: REDEMPTION
   Shadowmoor MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241652'
     subtype: REDEMPTION
   Shadowmoor Theme Deck Army of Entropy:
     category: DECK

--- a/data/products/SNC.yaml
+++ b/data/products/SNC.yaml
@@ -121,11 +121,13 @@ products:
     subtype: DRAFT
   Streets of New Capenna MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '260362'
     subtype: REDEMPTION
   Streets of New Capenna MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '260361'
     subtype: REDEMPTION
   Streets of New Capenna Prerelease Pack Brokers:
     category: LIMITED

--- a/data/products/SOI.yaml
+++ b/data/products/SOI.yaml
@@ -146,11 +146,13 @@ products:
     subtype: INTRO
   Shadows over Innistrad MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210362'
     subtype: REDEMPTION
   Shadows over Innistrad MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210885'
     subtype: REDEMPTION
   Shadows over Innistrad Prerelease Pack:
     category: LIMITED

--- a/data/products/SOK.yaml
+++ b/data/products/SOK.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Saviors of Kamigawa MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241629'
     subtype: REDEMPTION
   Saviors of Kamigawa MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241628'
     subtype: REDEMPTION
   Saviors of Kamigawa Theme Deck Critical Mass:
     category: DECK

--- a/data/products/SOM.yaml
+++ b/data/products/SOM.yaml
@@ -118,11 +118,13 @@ products:
     subtype: INTRO
   Scars of Mirrodin MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210883'
     subtype: REDEMPTION
   Scars of Mirrodin MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210871'
     subtype: REDEMPTION
   Scars of Mirrodin Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/STX.yaml
+++ b/data/products/STX.yaml
@@ -78,11 +78,13 @@ products:
     subtype: DRAFT
   Strixhaven School of Mages MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '245435'
     subtype: REDEMPTION
   Strixhaven School of Mages MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '245434'
     subtype: REDEMPTION
   Strixhaven School of Mages Prerelease Pack Lorehold:
     category: LIMITED

--- a/data/products/THB.yaml
+++ b/data/products/THB.yaml
@@ -92,11 +92,13 @@ products:
     subtype: DRAFT
   Theros Beyond Death MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '231850'
     subtype: REDEMPTION
   Theros Beyond Death MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '231849'
     subtype: REDEMPTION
   Theros Beyond Death Planeswalker Deck Ashiok:
     category: DECK

--- a/data/products/THS.yaml
+++ b/data/products/THS.yaml
@@ -145,11 +145,13 @@ products:
     subtype: INTRO
   Theros MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210854'
     subtype: REDEMPTION
   Theros MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '210869'
     subtype: REDEMPTION
   Theros Prerelease Kit Path of Ambition:
     category: LIMITED

--- a/data/products/TOR.yaml
+++ b/data/products/TOR.yaml
@@ -42,11 +42,13 @@ products:
     subtype: FAT_PACK
   Torment MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241610'
     subtype: REDEMPTION
   Torment MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241609'
     subtype: REDEMPTION
   Torment Theme Deck Display:
     category: DECK_BOX

--- a/data/products/TSP.yaml
+++ b/data/products/TSP.yaml
@@ -49,11 +49,13 @@ products:
     subtype: GIFT_BUNDLE
   Time Spiral MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241641'
     subtype: REDEMPTION
   Time Spiral MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241640'
     subtype: REDEMPTION
   Time Spiral Theme Deck Display:
     category: DECK_BOX

--- a/data/products/VOW.yaml
+++ b/data/products/VOW.yaml
@@ -119,11 +119,13 @@ products:
     subtype: GIFT_BUNDLE
   Innistrad Crimson Vow MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '253552'
     subtype: REDEMPTION
   Innistrad Crimson Vow MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '253551'
     subtype: REDEMPTION
   Innistrad Crimson Vow Prerelease Pack:
     category: LIMITED

--- a/data/products/WAR.yaml
+++ b/data/products/WAR.yaml
@@ -71,11 +71,13 @@ products:
     subtype: DRAFT
   War of the Spark MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '225508'
     subtype: REDEMPTION
   War of the Spark MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '225509'
     subtype: REDEMPTION
   War of the Spark Mythic Edition:
     category: BUNDLE

--- a/data/products/WOE.yaml
+++ b/data/products/WOE.yaml
@@ -102,11 +102,13 @@ products:
     subtype: DRAFT
   Wilds of Eldraine MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '283508'
     subtype: REDEMPTION
   Wilds of Eldraine MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '283507'
     subtype: REDEMPTION
   Wilds of Eldraine Prerelease Pack:
     category: LIMITED

--- a/data/products/WWK.yaml
+++ b/data/products/WWK.yaml
@@ -109,11 +109,13 @@ products:
     subtype: INTRO
   Worldwake MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241657'
     subtype: REDEMPTION
   Worldwake MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241656'
     subtype: REDEMPTION
   Worldwake Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/XLN.yaml
+++ b/data/products/XLN.yaml
@@ -73,11 +73,13 @@ products:
     subtype: DECK_BUILDERS_TOOLKIT
   Ixalan MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '217133'
     subtype: REDEMPTION
   Ixalan MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '217134'
     subtype: REDEMPTION
   Ixalan Planeswalker Deck Huatli:
     category: DECK

--- a/data/products/ZEN.yaml
+++ b/data/products/ZEN.yaml
@@ -116,11 +116,13 @@ products:
     subtype: INTRO
   Zendikar MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '223902'
     subtype: REDEMPTION
   Zendikar MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '241655'
     subtype: REDEMPTION
   Zendikar Six Card Booster Pack:
     category: BOOSTER_PACK

--- a/data/products/ZNR.yaml
+++ b/data/products/ZNR.yaml
@@ -96,11 +96,13 @@ products:
     subtype: DRAFT
   Zendikar Rising MTGO Redemption:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '236867'
     subtype: REDEMPTION
   Zendikar Rising MTGO Redemption Foil:
     category: BOX_SET
-    identifiers: {}
+    identifiers:
+      cardKingdomId: '236866'
     subtype: REDEMPTION
   Zendikar Rising Prerelease Pack:
     category: LIMITED

--- a/scripts/load_new_products.py
+++ b/scripts/load_new_products.py
@@ -23,7 +23,6 @@ def get_cardKingdom():
     r = requests.get(sealed_url)
     ck_data = json.loads(r.content)
     output_data = ck_data['data']
-    output_data = [x for x in output_data if "Set (Factory Sealed)" not in x['name']]
     output_data = [x for x in output_data if "Pure Bulk:" not in x['name']]
     return output_data
 


### PR DESCRIPTION
These are just the MTGO boxes, with a few minor exception that are ignored.
There are a couple of missing ids still, as their related product is being added in #368