### PR TITLE
Added JP Versions of SLD Final Fantasy Rainbow Foil and Non-foils

### DIFF
--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -4002,14 +4002,14 @@ products:
       cardtraderId: '278419'
       csiId: '377604'
       mcmId: '746109'
-      tcgplayerProductId: 518828
+      tcgplayerProductId: '518828'
     release_date: '2023-11-30'
     subtype: SECRET_LAIR
   Secret Lair Drop Secret Lair x Creepshow Foil:
     category: BOX_SET
     identifiers:
       csiId: '377605'
-      tcgplayerProductId: 518827
+      tcgplayerProductId: '518827'
     release_date: '2023-11-30'
     subtype: SECRET_LAIR
   Secret Lair Drop Secret Lair x Doctor Who Regeneration:
@@ -4032,14 +4032,14 @@ products:
       cardtraderId: '290314'
       csiId: '377597'
       mcmId: '746111'
-      tcgplayerProductId: 518834
+      tcgplayerProductId: '518834'
     release_date: '2023-12-18'
     subtype: SECRET_LAIR
   Secret Lair Drop Secret Lair x Doctor Who The Dalek Lands Foil:
     category: BOX_SET
     identifiers:
       csiId: '377598'
-      tcgplayerProductId: 518835
+      tcgplayerProductId: '518835'
     release_date: '2023-12-18'
     subtype: SECRET_LAIR
   Secret Lair Drop Secret Lair x Doctor Who The Weeping Angels:
@@ -4048,14 +4048,14 @@ products:
       cardtraderId: '290311'
       csiId: '377599'
       mcmId: '746112'
-      tcgplayerProductId: 518833
+      tcgplayerProductId: '518833'
     release_date: '2023-12-18'
     subtype: SECRET_LAIR
   Secret Lair Drop Secret Lair x Doctor Who The Weeping Angels Foil:
     category: BOX_SET
     identifiers:
       csiId: '377600'
-      tcgplayerProductId: 518831
+      tcgplayerProductId: '518831'
     release_date: '2023-11-30'
     subtype: SECRET_LAIR
   Secret Lair Drop Secret Lair x Dungeons and Dragons An Exhibition of Adventure:


### PR DESCRIPTION
JP versions of Final Fantasy SLD are different products Added them with TCGplayer Product IDs. 