### PR TITLE
Add Lorwyn Eclipsed Collector Booster Omega Pack

### DIFF
--- a/data/products/ECL.yaml
+++ b/data/products/ECL.yaml
@@ -73,6 +73,12 @@ products:
     identifiers:
       tcgplayerProductId: '656325'
     subtype: UNKNOWN
+  Lorwyn Eclipsed Collector Booster Omega Pack:
+    category: BOOSTER_PACK
+    identifiers:
+      tcgplayerProductId: '656321'
+    release_date: '2026-01-23'
+    subtype: COLLECTOR
   Lorwyn Eclipsed Collector Booster Pack:
     category: BOOSTER_PACK
     identifiers:


### PR DESCRIPTION
Added Collector Booster Omega Pack for Lorwyn Eclipsed (ECL).
TCGPlayer product ID: 656321
https://www.tcgplayer.com/product/656321/magic-lorwyn-eclipsed-lorwyn-eclipsed-collector-booster-omega-pack