### PR TITLE
remove duplicates from ECC

### DIFF
--- a/data/products/ECC.yaml
+++ b/data/products/ECC.yaml
@@ -1,15 +1,5 @@
 code: ecc
 products:
-  Lorwyn Eclipsed Commander Commander Deck Blight Curse:
-    category: DECK
-    identifiers: {}
-    release_date: '2026-01-23'
-    subtype: COMMANDER
-  Lorwyn Eclipsed Commander Commander Deck Dance of the Elements:
-    category: DECK
-    identifiers: {}
-    release_date: '2026-01-23'
-    subtype: COMMANDER
   Lorwyn Eclipsed Commander Deck Blight Curse:
     category: DECK
     identifiers:


### PR DESCRIPTION
I previously had a PR that removed these on January 26, but it seems to have regressed. Here's the history: https://github.com/mtgjson/mtg-sealed-content/commits/main/data/products/ECC.yaml

Here are the commits that removed the dupes:

https://github.com/mtgjson/mtg-sealed-content/commit/04dd9775c28f44aba666097dd822194196942095

https://github.com/mtgjson/mtg-sealed-content/commit/10e9cb98d0dec788aa01aaa7a46fb7df3e5e8e90

Then this commit added them back: https://github.com/mtgjson/mtg-sealed-content/commit/247dff903ee8e9c0ffee435d087c2fb4c55d0dd0