### PR TITLE
Card2product validate recursion

### DIFF
--- a/scripts/card_to_product_compiler.py
+++ b/scripts/card_to_product_compiler.py
@@ -89,6 +89,10 @@ class MtgjsonCardLinker:
     def get_cards_in_content_type(
         self, content_key: str, content: Dict[str, Any]
     ) -> List[Card]:
+
+        if content_key not in ["card", "pack", "sealed", "deck", "variable", "other"]:
+            raise ValueError(f"Unknown content_key: {content_key}")
+
         if content_key == "card":
             """
             "card": [


### PR DESCRIPTION
Opening a PR because I'm a bit hesitant on the logic and need feedback about this.

Right now the card mapper silently ignored any sealed product contained by another sealed product since the function was called with the wrong content_type (it was using set_code instead of deck/pack/card ect)

This went unnoticed because the resulting map contained the minimum common sealed product containing the card (ie a card was found in a Booster Pack product but not in a Booster Box) which is ... questionable?

From a user perspective is simpler to know that a card is found in the booster pack, and the fact that said booster pack could be found in the containing booster box should be a property of the booster box, not of the card. However, theoretically it's true that a card is found both in the booster pack and booster box, so it makes sense that the sourceProducts lists both.

Right now the PR restores the correct code behavior and exposes all the information possible so that downstream can decide what to show, but what was the original code intention? And what do we want to do? 