### PR TITLE
RFC too much card mapping

### DIFF
--- a/scripts/card_to_product_compiler.py
+++ b/scripts/card_to_product_compiler.py
@@ -137,9 +137,8 @@ class MtgjsonCardLinker:
                 }
             ]
             """
-            return self.get_cards_in_sealed_product(
-                content["set"].upper(), content.get("uuid")
-            )
+            # do nothing, cards need not to be mapped to products containing products
+            return []
 
         if content_key == "deck":
             """
@@ -179,11 +178,8 @@ class MtgjsonCardLinker:
                         self.get_cards_in_deck(deck["set"].upper(), deck["name"])
                     )
                 for sealed in config.get("sealed", []):
-                    return_value.update(
-                        self.get_cards_in_sealed_product(
-                            sealed["set"].upper(), sealed.get("uuid", None)
-                        )
-                    )
+                    # do nothing, like above
+                    return_value = return_value
                 for pack in config.get("pack", []):
                     return_value.update(
                         self.get_cards_in_pack(


### PR DESCRIPTION
the `sourceProducts` list is becoming a bit bloated

for example, Synthesis Pod (Extended Art) is currently mapped to

Phyrexia All Will Be One Collector Booster Sample Pack
Phyrexia All Will Be One Commander Deck Rebellion Rising
Phyrexia All Will Be One Commander Decks Set of 2
Phyrexia All Will Be One Collector Booster Box Case
Phyrexia All Will Be One Collector Booster Box
Phyrexia All Will Be One Collector Booster Pack
Phyrexia All Will Be One Commander Deck Corrupting Influence
Phyrexia All Will Be One Commander Deck Display

while it's technically true that this card can be found in ALL the products above, there is a LOT of repetition - ie since the card can be found in the collector booster pack, it theng ets added to the collector booster box and collector booster case, and similarly, since it is found in the sample pack, it gets added to BOTH decks, and then to the set-of-2 and then to the commander display....

This RFC proposes to filter out any sealed product contained in a sealed product, which is probably a bit extreme

as @axxroytovu put it well

> Originally, the intention was to have a maximal list of all possible products that could contain the specific card printing. So if I wanted a copy of a generic card, it could be found in the play booster, collector booster, both kinds of booster box and box case, the bundle, prerelease packs, and maybe a supplemental product. 
>
> **Pros**: this always answers the question “can I find this card if I buy this product?” **Cons**: it contains a lot of product links. Some cards have a very low rate for some products. 
> 
> It sounds like you want a “minimal” product linkage that only goes to the first tier of depth. So a card would link to a booster pack but not the booster box. This would be a minimum set, but would miss a lot of intermediate products like bundles. 
> 
> **Pros**: list is cleaner and only highlights the “primary” way to get a card. **Cons**: will miss some product linkages. Some products will have no cards associated.

maybe a middle ground could be reached? ie mark some products as "primary" automatically so that filtering can happen on downstream? I am open to ideas