### PR TITLE
fix: update product categories and subtypes across multiple sets, update fixups and product definitions

### DIFF
--- a/data/products/DFT.yaml
+++ b/data/products/DFT.yaml
@@ -35,7 +35,7 @@ products:
       tcgplayerProductId: '604253'
     subtype: COLLECTOR
   Aetherdrift Collector Booster Box Case:
-    category: BOOSTER_BOX
+    category: BOOSTER_CASE
     identifiers:
       tcgplayerProductId: '604254'
     subtype: COLLECTOR

--- a/data/products/ECL.yaml
+++ b/data/products/ECL.yaml
@@ -12,13 +12,13 @@ products:
     release_date: '2026-01-23'
     subtype: THEME
   Lorwyn Eclipsed 60-Card Theme Deck Display:
-    category: UNKNOWN
+    category: DECK_BOX
     identifiers:
       cardtraderId: '352411'
       tcgplayerProductId: '656332'
     subtype: THEME
   Lorwyn Eclipsed 60-Card Theme Deck Display Case:
-    category: UNKNOWN
+    category: DECK_BOX
     identifiers:
       tcgplayerProductId: '656334'
     subtype: THEME
@@ -56,7 +56,7 @@ products:
     release_date: '2026-01-23'
     subtype: DEFAULT
   Lorwyn Eclipsed Bundle Case:
-    category: BUNDLE
+    category: BUNDLE_CASE
     identifiers:
       tcgplayerProductId: '656342'
     subtype: DEFAULT
@@ -74,10 +74,10 @@ products:
     release_date: '2026-01-23'
     subtype: COLLECTOR
   Lorwyn Eclipsed Collector Booster Box Case:
-    category: UNKNOWN
+    category: BOOSTER_CASE
     identifiers:
       tcgplayerProductId: '656325'
-    subtype: UNKNOWN
+    subtype: COLLECTOR
   Lorwyn Eclipsed Collector Booster Pack:
     category: BOOSTER_PACK
     identifiers:
@@ -91,7 +91,7 @@ products:
     release_date: '2026-01-23'
     subtype: COLLECTOR
   Lorwyn Eclipsed Draft Night:
-    category: BUNDLE
+    category: LIMITED
     identifiers:
       abuId: '2656218'
       cardKingdomId: '321617'
@@ -101,12 +101,12 @@ products:
       scgId: SLD-MTG-DRAFTNIGHT-ECL-EN
       tcgplayerProductId: '656343'
     release_date: '2026-01-23'
-    subtype: DEFAULT
+    subtype: DRAFT
   Lorwyn Eclipsed Draft Night Case:
-    category: UNKNOWN
+    category: LIMITED_CASE
     identifiers:
       tcgplayerProductId: '656348'
-    subtype: UNKNOWN
+    subtype: DRAFT
   Lorwyn Eclipsed MTGO Redemption:
     category: BOX_SET
     identifiers:
@@ -125,11 +125,11 @@ products:
     release_date: '2026-01-23'
     subtype: PLAY
   Lorwyn Eclipsed Play Booster Box Case:
-    category: UNKNOWN
+    category: BOOSTER_CASE
     identifiers:
       scgId: SLD-MTG-BBX-ECLPLAYCASE-EN
       tcgplayerProductId: '656315'
-    subtype: UNKNOWN
+    subtype: PLAY
   Lorwyn Eclipsed Play Booster Pack:
     category: BOOSTER_PACK
     identifiers:

--- a/data/products/EOE.yaml
+++ b/data/products/EOE.yaml
@@ -29,7 +29,7 @@ products:
       tcgplayerProductId: '619672'
     subtype: COLLECTOR
   Edge of Eternities Collector Booster Box Case:
-    category: BOOSTER_BOX
+    category: BOOSTER_CASE
     identifiers:
       tcgplayerProductId: '619694'
     subtype: COLLECTOR

--- a/data/products/MAT.yaml
+++ b/data/products/MAT.yaml
@@ -37,7 +37,7 @@ products:
     identifiers:
       tcgplayerProductId: '489221'
     release_date: '2023-05-12'
-    subtype: OTHER
+    subtype: COLLECTOR
   March of the Machine The Aftermath Collector Booster Pack:
     category: BOOSTER_PACK
     identifiers:

--- a/data/products/MSH.yaml
+++ b/data/products/MSH.yaml
@@ -1,19 +1,19 @@
 code: msh
 products:
   Marvel Super Heroes Beginner Box:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       cardtraderId: '370625'
       mcmId: '869508'
       miniaturemarketId: 019c06a2a79f733fa39031207956adee
       scgId: SLD-MTG-BXS-MSHBEGINNER-EN
       tcgplayerProductId: '675613'
-    subtype: UNKNOWN
+    subtype: STARTER
   Marvel Super Heroes Beginner Box Case:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '675614'
-    subtype: UNKNOWN
+    subtype: STARTER
   Marvel Super Heroes Bundle:
     category: BUNDLE
     identifiers:
@@ -22,12 +22,12 @@ products:
       miniaturemarketId: 019c06a268fb70b5a070c45a8729f9bd
       scgId: SLD-MTG-BUN-MSH-EN
       tcgplayerProductId: '675615'
-    subtype: UNKNOWN
+    subtype: DEFAULT
   Marvel Super Heroes Bundle Case:
-    category: BUNDLE
+    category: BUNDLE_CASE
     identifiers:
       tcgplayerProductId: '675616'
-    subtype: UNKNOWN
+    subtype: DEFAULT
   Marvel Super Heroes Collector Booster Box:
     category: BOOSTER_BOX
     identifiers:
@@ -55,19 +55,19 @@ products:
       tcgplayerProductId: '675605'
     subtype: COLLECTOR
   Marvel Super Heroes Draft Night:
-    category: UNKNOWN
+    category: LIMITED
     identifiers:
       cardtraderId: '370623'
       mcmId: '869507'
       miniaturemarketId: 019c06a29dd4722981ba3d6a41018cff
       scgId: SLD-MTG-DFT-MSH-EN
       tcgplayerProductId: '675625'
-    subtype: UNKNOWN
+    subtype: DRAFT
   Marvel Super Heroes Draft Night Case:
-    category: UNKNOWN
+    category: LIMITED_CASE
     identifiers:
       tcgplayerProductId: '675626'
-    subtype: UNKNOWN
+    subtype: DRAFT
   Marvel Super Heroes Gift Bundle:
     category: BUNDLE
     identifiers:
@@ -75,12 +75,12 @@ products:
       mcmId: '869525'
       scgId: SLD-MTG-BUN-MSHGIFT-EN
       tcgplayerProductId: '675617'
-    subtype: UNKNOWN
+    subtype: GIFT_BUNDLE
   Marvel Super Heroes Gift Bundle Case:
-    category: BUNDLE
+    category: BUNDLE_CASE
     identifiers:
       tcgplayerProductId: '675618'
-    subtype: UNKNOWN
+    subtype: GIFT_BUNDLE
   Marvel Super Heroes Jumpstart Booster Box:
     category: BOOSTER_BOX
     identifiers:
@@ -89,12 +89,12 @@ products:
       miniaturemarketId: 019c06a2560a7194afe63628f18840e4
       scgId: SLD-MTG-BBX-MSHJUMPSTART-EN
       tcgplayerProductId: '675623'
-    subtype: UNKNOWN
+    subtype: JUMPSTART
   Marvel Super Heroes Jumpstart Booster Box Case:
     category: BOOSTER_CASE
     identifiers:
       tcgplayerProductId: '675624'
-    subtype: UNKNOWN
+    subtype: JUMPSTART
   Marvel Super Heroes Jumpstart Booster Pack:
     category: BOOSTER_PACK
     identifiers:
@@ -102,7 +102,7 @@ products:
       mcmId: '869491'
       scgId: SLD-MTG-PCK-MSHJUMPSTART-EN
       tcgplayerProductId: '675622'
-    subtype: UNKNOWN
+    subtype: JUMPSTART
   Marvel Super Heroes Play Booster Box:
     category: BOOSTER_BOX
     identifiers:
@@ -136,30 +136,30 @@ products:
       tcgplayerProductId: '675610'
     subtype: PRERELEASE
   Marvel Super Heroes Prerelease Pack Case:
-    category: LIMITED
+    category: LIMITED_CASE
     identifiers:
       tcgplayerProductId: '675611'
     subtype: PRERELEASE
   Marvel Super Heroes Scene Box Case:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '675621'
-    subtype: UNKNOWN
+    subtype: OTHER
   Marvel Super Heroes Scene Box Heroes United:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       cardtraderId: '370628'
       mcmId: '869509'
       miniaturemarketId: 019c06a28b077313ba2c21dc4eb74aa3
       scgId: SLD-MTG-BXS-MSHSCENE-EN-UNITED
       tcgplayerProductId: '675619'
-    subtype: UNKNOWN
+    subtype: OTHER
   Marvel Super Heroes Scene Box Villains Unleashed:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       cardtraderId: '370629'
       mcmId: '869510'
       miniaturemarketId: 019c06a29492727c83a73ba32bd5330d
       scgId: SLD-MTG-BXS-MSHSCENE-EN-VILLAINS
       tcgplayerProductId: '675620'
-    subtype: UNKNOWN
+    subtype: OTHER

--- a/data/products/SOS.yaml
+++ b/data/products/SOS.yaml
@@ -1,12 +1,12 @@
 code: sos
 products:
   Secrets of Strixhaven 60-Card Theme Deck Display:
-    category: DECK
+    category: DECK_BOX
     identifiers:
       tcgplayerProductId: '675581'
     subtype: THEME
   Secrets of Strixhaven 60-Card Theme Deck Display Case:
-    category: DECK
+    category: DECK_BOX
     identifiers:
       tcgplayerProductId: '675582'
     subtype: THEME
@@ -37,12 +37,12 @@ products:
       miniaturemarketId: 019c06a14c5a737fa0dfa955d8c70f5b
       scgId: SLD-MTG-BUN-SOS-EN
       tcgplayerProductId: '675561'
-    subtype: UNKNOWN
+    subtype: DEFAULT
   Secrets of Strixhaven Bundle Case:
-    category: BUNDLE
+    category: BUNDLE_CASE
     identifiers:
       tcgplayerProductId: '675562'
-    subtype: UNKNOWN
+    subtype: DEFAULT
   Secrets of Strixhaven Codex Bundle:
     category: BUNDLE
     identifiers:
@@ -52,7 +52,7 @@ products:
       tcgplayerProductId: '675563'
     subtype: UNKNOWN
   Secrets of Strixhaven Codex Bundle Case:
-    category: BUNDLE
+    category: BUNDLE_CASE
     identifiers:
       tcgplayerProductId: '675564'
     subtype: UNKNOWN
@@ -87,7 +87,7 @@ products:
       tcgplayerProductId: '675557'
     subtype: COLLECTOR
   Secrets of Strixhaven Draft Night:
-    category: UNKNOWN
+    category: LIMITED
     identifiers:
       cardKingdomId: '324620'
       cardtraderId: '370615'
@@ -95,12 +95,12 @@ products:
       miniaturemarketId: 019c06a15fa870a7b84d4d59ad0a32c5
       scgId: SLD-MTG-DFT-SOS-EN
       tcgplayerProductId: '675565'
-    subtype: UNKNOWN
+    subtype: DRAFT
   Secrets of Strixhaven Draft Night Case:
-    category: UNKNOWN
+    category: LIMITED_CASE
     identifiers:
       tcgplayerProductId: '675566'
-    subtype: UNKNOWN
+    subtype: DRAFT
   Secrets of Strixhaven Play Booster Box:
     category: BOOSTER_BOX
     identifiers:
@@ -178,29 +178,29 @@ products:
       cardKingdomId: '324625'
       scgId: SLD-MTG-STD-SOS-EN-SETOF2
       tcgplayerProductId: '675583'
-    subtype: UNKNOWN
+    subtype: THEME
   Welcome Deck 2026 Black Deck:
     category: DECK
     identifiers:
       cardtraderId: '380934'
-    subtype: UNKNOWN
+    subtype: WELCOME
   Welcome Deck 2026 Blue Deck:
     category: DECK
     identifiers:
       cardtraderId: '380933'
-    subtype: UNKNOWN
+    subtype: WELCOME
   Welcome Deck 2026 Green Deck:
     category: DECK
     identifiers:
       cardtraderId: '380936'
-    subtype: UNKNOWN
+    subtype: WELCOME
   Welcome Deck 2026 Red Deck:
     category: DECK
     identifiers:
       cardtraderId: '380935'
-    subtype: UNKNOWN
+    subtype: WELCOME
   Welcome Deck 202666 Red Deck:
     category: DECK
     identifiers:
       cardtraderId: '380932'
-    subtype: UNKNOWN
+    subtype: WELCOME

--- a/data/products/TLA.yaml
+++ b/data/products/TLA.yaml
@@ -12,10 +12,10 @@ products:
       tcgplayerProductId: '648682'
     subtype: STARTER
   Avatar The Last Airbender Beginner Box Case:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '662272'
-    subtype: UNKNOWN
+    subtype: STARTER
   Avatar The Last Airbender Bundle:
     category: BUNDLE
     identifiers:

--- a/data/products/TMT.yaml
+++ b/data/products/TMT.yaml
@@ -70,13 +70,13 @@ products:
       scgId: SLD-MTG-BUN-TMTDRAFT-EN
       tcgplayerProductId: '657860'
     release_date: '2026-03-06'
-    subtype: DRAFT_SET
+    subtype: DRAFT
   Teenage Mutant Ninja Turtles Draft Night Case:
     category: LIMITED_CASE
     identifiers:
       tcgplayerProductId: '657861'
     release_date: '2026-03-06'
-    subtype: DRAFT_SET
+    subtype: DRAFT
   Teenage Mutant Ninja Turtles Enemy Deck:
     category: DECK
     identifiers: {}
@@ -164,35 +164,35 @@ products:
     release_date: '2026-03-06'
     subtype: THEME
   Teenage Mutant Ninja Turtles Tin Donatello:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '684671'
-    subtype: UNKNOWN
+    subtype: OTHER
   Teenage Mutant Ninja Turtles Tin Leonardo:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '684672'
-    subtype: UNKNOWN
+    subtype: OTHER
   Teenage Mutant Ninja Turtles Tin Michelangelo:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '684669'
-    subtype: UNKNOWN
+    subtype: OTHER
   Teenage Mutant Ninja Turtles Tin Raphael:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '684670'
-    subtype: UNKNOWN
+    subtype: OTHER
   Teenage Mutant Ninja Turtles Tin Set of 5:
     category: SUBSET
     identifiers:
       tcgplayerProductId: '684674'
-    subtype: UNKNOWN
+    subtype: OTHER
   Teenage Mutant Ninja Turtles Tin Shredder:
-    category: UNKNOWN
+    category: BOX_SET
     identifiers:
       tcgplayerProductId: '684673'
-    subtype: UNKNOWN
+    subtype: OTHER
   Teenage Mutant Ninja Turtles Turtle Team-Up:
     category: MULTI_DECK
     identifiers:

--- a/scripts/check_product_fuzzy.py
+++ b/scripts/check_product_fuzzy.py
@@ -34,6 +34,97 @@ for contentfile in Path("data/products").glob("*.yaml"):
     for product_name in known_data["products"].keys():
         known_products.append((product_name, contentfile))
 
+
+def infer_product_definition(product_name):
+    category = "UNKNOWN"
+    subtype = "UNKNOWN"
+
+    if "Draft Night Case" in product_name:
+        category = "LIMITED_CASE"
+        subtype = "DRAFT"
+    elif "Draft Night" in product_name:
+        category = "LIMITED"
+        subtype = "DRAFT"
+    elif "Gift Bundle Case" in product_name:
+        category = "BUNDLE_CASE"
+        subtype = "GIFT_BUNDLE"
+    elif "Gift Bundle" in product_name:
+        category = "BUNDLE"
+        subtype = "GIFT_BUNDLE"
+    elif "Jumpstart Booster Box Case" in product_name:
+        category = "BOOSTER_CASE"
+        subtype = "JUMPSTART"
+    elif "Jumpstart Booster Box" in product_name:
+        category = "BOOSTER_BOX"
+        subtype = "JUMPSTART"
+    elif "Jumpstart Booster Pack" in product_name:
+        category = "BOOSTER_PACK"
+        subtype = "JUMPSTART"
+    elif "Beginner Box Case" in product_name:
+        category = "BOX_SET"
+        subtype = "STARTER"
+    elif "Beginner Box" in product_name:
+        category = "BOX_SET"
+        subtype = "STARTER"
+    elif "Scene Box Case" in product_name:
+        category = "BOX_SET"
+        subtype = "OTHER"
+    elif "Scene Box" in product_name:
+        category = "BOX_SET"
+        subtype = "OTHER"
+    elif "Theme Deck Display Case" in product_name:
+        category = "DECK_BOX"
+        subtype = "THEME"
+    elif "Theme Deck Display" in product_name:
+        category = "DECK_BOX"
+        subtype = "THEME"
+    elif "Welcome Deck" in product_name:
+        category = "DECK"
+        subtype = "WELCOME"
+    elif "Prerelease Pack Case" in product_name:
+        category = "LIMITED_CASE"
+        subtype = "PRERELEASE"
+    elif "Booster Box Case" in product_name:
+        category = "BOOSTER_CASE"
+    elif "Booster Box" in product_name:
+        category = "BOOSTER_BOX"
+    elif "Booster Pack" in product_name:
+        category = "BOOSTER_PACK"
+    elif "Bundle Case" in product_name:
+        category = "BUNDLE_CASE"
+    elif "Bundle" in product_name:
+        category = "BUNDLE"
+    elif "Set of" in product_name:
+        category = "SUBSET"
+    elif "Deck" in product_name:
+        category = "DECK"
+    elif "Prerelease" in product_name:
+        category = "LIMITED"
+    elif "Redemption" in product_name:
+        category = "BOX_SET"
+
+    if subtype == "UNKNOWN":
+        if "Collector Booster" in product_name:
+            subtype = "COLLECTOR"
+        elif "Play Booster" in product_name:
+            subtype = "PLAY"
+        elif "Set Booster" in product_name:
+            subtype = "SET"
+        elif "Commander" in product_name:
+            subtype = "COMMANDER"
+        elif "Prerelease" in product_name:
+            subtype = "PRERELEASE"
+        elif "Theme" in product_name:
+            subtype = "THEME"
+        elif "Redemption" in product_name:
+            subtype = "REDEMPTION"
+
+    if "Secret Lair" in product_name and "Bundle" in product_name:
+        category = "BOX_SET"
+        subtype = "SECRET_LAIR_BUNDLE"
+
+    return category, subtype
+
 index = 0
 offset = 0
 while index < len(review_products):
@@ -146,43 +237,7 @@ while index < len(review_products):
         else:
             content = {"code": set_code.lower(), "products": {}}
 
-        category = "UNKNOWN"
-        if "Booster Box Case" in product_name:
-            category = "BOOSTER_CASE"
-        elif "Booster Box" in product_name:
-            category = "BOOSTER_BOX"
-        elif "Booster Pack" in product_name:
-            category = "BOOSTER_PACK"
-        elif "Bundle" in product_name:
-            category = "BUNDLE"
-        elif "Set of" in product_name:
-            category = "SUBSET"
-        elif "Deck" in product_name:
-            category = "DECK"
-        elif "Prerelease" in product_name:
-            category = "LIMITED"
-        elif "Redemption" in product_name:
-            category = "BOX_SET"
-
-        subtype = "UNKNOWN"
-        if "Collector Booster" in product_name:
-            subtype = "COLLECTOR"
-        elif "Play Booster" in product_name:
-            subtype = "PLAY"
-        elif "Set Booster" in product_name:
-            subtype = "SET"
-        elif "Commander" in product_name:
-            subtype = "COMMANDER"
-        elif "Prerelease" in product_name:
-            subtype = "PRERELEASE"
-        elif "Theme" in product_name:
-            subtype = "THEME"
-        elif "Redemption" in product_name:
-            subtype = "REDEMPTION"
-
-        if "Secret Lair" in product_name and "Bundle" in product_name:
-            category = "BOX_SET"
-            subtype = "SECRET_LAIR_BUNDLE"
+        category, subtype = infer_product_definition(product_name)
 
         content["products"][product_name] = {
             "category": category,

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -52,6 +52,18 @@ skip_names = [
 ]
 
 
+category_fixups = {
+    "BOX": "BOX_SET",
+}
+
+subtype_fixups = {
+    "BOX_SET": "OTHER",
+    "COMMANDER_DECK": "COMMANDER",
+    "THEME_DECK": "THEME",
+    "WELCOME_DECK": "WELCOME",
+}
+
+
 def add_product(set_code, name, deck):
     products_path = Path(f"data/products/{set_code.upper()}.yaml")
 
@@ -75,6 +87,9 @@ def add_product(set_code, name, deck):
         new_product["subtype"] = deck["type"].upper().replace(" ", "_")
         new_product["release_date"] = deck["release_date"]
 
+        if new_product["category"] in category_fixups:
+            new_product["category"] = category_fixups[new_product["category"]]
+
         # Override fields for specific sets
         if set_code in ["sld", "slc"]:
             new_product["category"] = "BOX_SET"
@@ -82,10 +97,15 @@ def add_product(set_code, name, deck):
 
         # Fixup subtypes
         # XXX maybe we should propagate these types from upstream instead of having our own?
-        if new_product["subtype"] == "THEME_DECK":
-            new_product["subtype"] = "THEME"
-        elif new_product["subtype"] == "COMMANDER_DECK":
-            new_product["subtype"] = "COMMANDER"
+        if new_product["subtype"] in subtype_fixups:
+            new_product["subtype"] = subtype_fixups[new_product["subtype"]]
+
+        if name.endswith("Draft Night Case"):
+            new_product["category"] = "LIMITED_CASE"
+            new_product["subtype"] = "DRAFT"
+        elif name.endswith("Draft Night"):
+            new_product["category"] = "LIMITED"
+            new_product["subtype"] = "DRAFT"
 
         products["products"][name] = new_product
 


### PR DESCRIPTION
Adjusted a batch of sealed product category/subtype inconsistencies, mainly around Draft Night and a few similar product families. I also updated the import/matching scripts so new products are more likely to get the correct type automatically