### PR TITLE
Fixed SOS Prerelease pack names for consistency with all other sets

### DIFF
--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -121,7 +121,7 @@ products:
     - name: Deck box
     - name: Spindown die
     pack:
-    - code: lorehold-prerelease
+    - code: prerelease-lorehold
       set: sos
     sealed:
     - count: 5
@@ -133,7 +133,7 @@ products:
     - name: Deck box
     - name: Spindown die
     pack:
-    - code: prismari-prerelease
+    - code: prerelease-prismari
       set: sos
     sealed:
     - count: 5
@@ -145,7 +145,7 @@ products:
     - name: Deck box
     - name: Spindown die
     pack:
-    - code: quandrix-prerelease
+    - code: prerelease-quandrix
       set: sos
     sealed:
     - count: 5
@@ -174,7 +174,7 @@ products:
     - name: Deck box
     - name: Spindown die
     pack:
-    - code: silverquill-prerelease
+    - code: prerelease-silverquill
       set: sos
     sealed:
     - count: 5
@@ -186,7 +186,7 @@ products:
     - name: Deck box
     - name: Spindown die
     pack:
-    - code: witherbloom-prerelease
+    - code: prerelease-witherbloom
       set: sos
     sealed:
     - count: 5


### PR DESCRIPTION
[Fixed as discussed here](https://github.com/taw/magic-search-engine/issues/433#issuecomment-4345942578).