### PR TITLE
fix TDM Play Booster Box Case content

### DIFF
--- a/data/contents/TDM.yaml
+++ b/data/contents/TDM.yaml
@@ -54,7 +54,7 @@ products:
   Tarkir Dragonstorm Play Booster Box Case:
     sealed:
     - count: 6
-      name: Tarkir Dragonstorm Collector Booster Box
+      name: Tarkir Dragonstorm Play Booster Box
       set: tdm
   Tarkir Dragonstorm Play Booster Pack:
     card_count: 14


### PR DESCRIPTION
## Summary

The `Tarkir Dragonstorm Play Booster Box Case` entry in `data/contents/TDM.yaml` declared its `sealed` child as `Tarkir Dragonstorm Collector Booster Box`. A Play case must contain Play Booster Boxes, not Collector ones.

As a sanity check, the `Tarkir Dragonstorm Collector Booster Box Case` (correctly mapped) also points to the same Collector Booster Box — which meant both the Play case and the Collector case resolved to identical contents in the published `TDM.json`, which is structurally impossible.

This is the same class of fix as #426 (Marvels Spider Man Play Booster Box Case).

## Verification

- Grepped every `Play Booster Box Case:` entry under `data/contents/` — TDM was the only mismatch; ECL, FDN, TMT, EOE, TLA, MH3, DSK, SOS, MKM, BLB, FIN, etc. all correctly reference their corresponding Play Booster Box.
