### PR TITLE
Add The Hobbit (HOB) sealed products from TCGPlayer

### DIFF
--- a/data/contents/HOB.yaml
+++ b/data/contents/HOB.yaml
@@ -1,0 +1,108 @@
+code: hob
+products:
+  The Hobbit Bundle:
+    card_count: 1
+    other:
+    - name: Spindown die
+    - name: 40 card land pack
+    - name: Card storage box
+    pack:
+    - code: bundle-promo
+      set: hob
+    sealed:
+    - count: 9
+      name: The Hobbit Play Booster Pack
+      set: hob
+  The Hobbit Bundle Case:
+    sealed:
+    - count: 6
+      name: The Hobbit Bundle
+      set: hob
+  The Hobbit Collector Booster Box:
+    sealed:
+    - count: 12
+      name: The Hobbit Collector Booster Pack
+      set: hob
+  The Hobbit Collector Booster Box Case:
+    sealed:
+    - count: 6
+      name: The Hobbit Collector Booster Box
+      set: hob
+  The Hobbit Collector Booster Box Master Case: []
+  The Hobbit Collector Booster Pack:
+    card_count: 15
+    pack:
+    - code: collector
+      set: hob
+  The Hobbit Draft Night: []
+  The Hobbit Draft Night Case: []
+  The Hobbit Gift Bundle:
+    card_count: 1
+    other:
+    - name: Spindown die
+    - name: 40 card land pack
+    - name: Card storage box
+    pack:
+    - code: bundle-promo
+      set: hob
+    sealed:
+    - count: 9
+      name: The Hobbit Play Booster Pack
+      set: hob
+    - count: 1
+      name: The Hobbit Collector Booster Pack
+      set: hob
+  The Hobbit Gift Bundle Case:
+    sealed:
+    - count: 6
+      name: The Hobbit Gift Bundle
+      set: hob
+  The Hobbit Play Booster Box:
+    sealed:
+    - count: 30
+      name: The Hobbit Play Booster Pack
+      set: hob
+  The Hobbit Play Booster Box Case:
+    sealed:
+    - count: 6
+      name: The Hobbit Play Booster Box
+      set: hob
+  The Hobbit Play Booster Pack:
+    card_count: 14
+    pack:
+    - code: play
+      set: hob
+  The Hobbit Prerelease Case:
+    sealed:
+    - count: 15
+      name: The Hobbit Prerelease Pack
+      set: hob
+  The Hobbit Prerelease Pack:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Spindown die
+    pack:
+    - code: prerelease
+      set: hob
+    sealed:
+    - count: 6
+      name: The Hobbit Play Booster Pack
+      set: hob
+  The Hobbit Scene Box Case: []
+  The Hobbit Scene Box Crack the Plates:
+    card_count: 6
+    other:
+    - name: 6 borderless scene cards
+    sealed:
+    - count: 3
+      name: The Hobbit Play Booster Pack
+      set: hob
+  The Hobbit Scene Box Treasures of Smaug:
+    card_count: 6
+    other:
+    - name: 6 borderless scene cards
+    sealed:
+    - count: 3
+      name: The Hobbit Play Booster Pack
+      set: hob

--- a/data/products/HOB.yaml
+++ b/data/products/HOB.yaml
@@ -1,0 +1,110 @@
+code: hob
+products:
+  The Hobbit Bundle:
+    category: BUNDLE
+    identifiers:
+      tcgplayerProductId: '692966'
+    release_date: '2026-08-14'
+    subtype: DEFAULT
+  The Hobbit Bundle Case:
+    category: BUNDLE_CASE
+    identifiers:
+      tcgplayerProductId: '692967'
+    release_date: '2026-08-14'
+    subtype: DEFAULT
+  The Hobbit Collector Booster Box:
+    category: BOOSTER_BOX
+    identifiers:
+      tcgplayerProductId: '692963'
+    release_date: '2026-08-14'
+    subtype: COLLECTOR
+  The Hobbit Collector Booster Box Case:
+    category: BOOSTER_CASE
+    identifiers:
+      tcgplayerProductId: '692964'
+    release_date: '2026-08-14'
+    subtype: COLLECTOR
+  The Hobbit Collector Booster Box Master Case:
+    category: BOOSTER_CASE
+    identifiers:
+      tcgplayerProductId: '692965'
+    release_date: '2026-08-14'
+    subtype: COLLECTOR
+  The Hobbit Collector Booster Pack:
+    category: BOOSTER_PACK
+    identifiers:
+      tcgplayerProductId: '692962'
+    release_date: '2026-08-14'
+    subtype: COLLECTOR
+  The Hobbit Draft Night:
+    category: LIMITED
+    identifiers:
+      tcgplayerProductId: '692975'
+    release_date: '2026-08-14'
+    subtype: DRAFT_SET
+  The Hobbit Draft Night Case:
+    category: LIMITED_CASE
+    identifiers:
+      tcgplayerProductId: '692976'
+    release_date: '2026-08-14'
+    subtype: DRAFT_SET
+  The Hobbit Gift Bundle:
+    category: BUNDLE
+    identifiers:
+      tcgplayerProductId: '692971'
+    release_date: '2026-09-04'
+    subtype: GIFT_BUNDLE
+  The Hobbit Gift Bundle Case:
+    category: BUNDLE_CASE
+    identifiers:
+      tcgplayerProductId: '692972'
+    release_date: '2026-09-04'
+    subtype: GIFT_BUNDLE
+  The Hobbit Play Booster Box:
+    category: BOOSTER_BOX
+    identifiers:
+      tcgplayerProductId: '692960'
+    release_date: '2026-08-14'
+    subtype: PLAY
+  The Hobbit Play Booster Box Case:
+    category: BOOSTER_CASE
+    identifiers:
+      tcgplayerProductId: '692961'
+    release_date: '2026-08-14'
+    subtype: PLAY
+  The Hobbit Play Booster Pack:
+    category: BOOSTER_PACK
+    identifiers:
+      tcgplayerProductId: '692959'
+    release_date: '2026-08-14'
+    subtype: PLAY
+  The Hobbit Prerelease Case:
+    category: LIMITED_CASE
+    identifiers:
+      tcgplayerProductId: '692974'
+    release_date: '2026-08-07'
+    subtype: PRERELEASE
+  The Hobbit Prerelease Pack:
+    category: LIMITED
+    identifiers:
+      tcgplayerProductId: '692973'
+    release_date: '2026-08-14'
+    subtype: PRERELEASE
+  The Hobbit Scene Box Case:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '692970'
+    release_date: '2026-08-14'
+    subtype: OTHER
+  The Hobbit Scene Box Crack the Plates:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '692968'
+    release_date: '2026-08-14'
+    subtype: OTHER
+  The Hobbit Scene Box Treasures of Smaug:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '692969'
+    release_date: '2026-08-14'
+    subtype: OTHER


### PR DESCRIPTION
## What

Adds the 18 sealed products for **The Hobbit** (set code `HOB`, releasing 2026-08-14), which were missing from the repo:

- Play Booster: Pack / Box / Box Case
- Collector Booster: Pack / Box / Box Case / Box Master Case
- Bundle / Bundle Case
- Gift Bundle / Gift Bundle Case
- Scene Box: Crack the Plates / Treasures of Smaug / Scene Box Case
- Prerelease Pack / Prerelease Case
- Draft Night / Draft Night Case

## Data sources

- Set code + TCGPlayer group id (24683) from Scryfall
- Product IDs (692959–692976) and release dates from TCGPlayer (via the TCGCSV mirror, since the loader's TCGPlayer API auth isn't available locally)
- Categories/subtypes follow the **TMT** and **SPM** conventions for recent Universes Beyond sets (incl. the TCGPlayer "Display" → repo "Box" rename, and Play Booster Box = 30 packs)

## Notes

- The companion Commander set (`HOC`, group 24691) lists only singles on TCGPlayer — no sealed products — so no HOC files are added.
- The five Welcome Decks announced in press aren't listed on TCGPlayer yet, so they're not included.
- Only `tcgplayerProductId` is set; other marketplace IDs (Card Kingdom, Cardmarket, etc.) will be fuzzy-matched in by the daily `load_new_products.py` once those vendors list them.
- Contents with uncertain counts (Collector Booster Box Master Case, Scene Box Case, Draft Night, Draft Night Case) are left empty for now.
- `scripts/contents_validator.py` passes (exit 0) with no warnings for HOB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)