### PR TITLE
Fix invalid BRAWL_DECK subtype in ELD (unbreaks CI)

### DIFF
--- a/data/products/ELD.yaml
+++ b/data/products/ELD.yaml
@@ -42,7 +42,7 @@ products:
       tcgplayerProductId: '194909'
       tntId: '1604223'
     release_date: '2019-10-04'
-    subtype: BRAWL_DECK
+    subtype: BRAWL
   Throne of Eldraine Brawl Deck Wild Bounty:
     category: DECK
     identifiers:

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -58,6 +58,7 @@ category_fixups = {
 
 subtype_fixups = {
     "BOX_SET": "OTHER",
+    "BRAWL_DECK": "BRAWL",
     "COMMANDER_DECK": "COMMANDER",
     "THEME_DECK": "THEME",
     "WELCOME_DECK": "WELCOME",


### PR DESCRIPTION
## Problem

`contents_validator.py` (the `validate contents` workflow) is currently **failing on `main`**, which blocks CI on every open PR:

```
Product Throne of Eldraine Brawl Deck Savage Hunger uses an invalid subtype: BRAWL_DECK
```

A "Pull new daily content" commit (`670f54ca`) imported "Throne of Eldraine Brawl Deck Savage Hunger" with subtype `BRAWL_DECK`, which isn't in the validator's allow-list. The set's other five Brawl decks all use the valid `BRAWL` subtype.

Root cause: `import_new_decks.py` derives the subtype from upstream as `deck["type"].upper().replace(" ", "_")`, so an upstream type of "Brawl Deck" produced `BRAWL_DECK`.

## Fix

- Correct the `ELD.yaml` entry: `BRAWL_DECK` → `BRAWL`
- Add `"BRAWL_DECK": "BRAWL"` to the `subtype_fixups` map in `import_new_decks.py` so future daily pulls don't reintroduce it (mirrors the existing `THEME_DECK` → `THEME` fixup)

`scripts/contents_validator.py` passes (exit 0) after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)