### PR TITLE
Set Marvel Super Heroes Gift Bundle release date to 2026-07-17

### DIFF
--- a/data/products/MSH.yaml
+++ b/data/products/MSH.yaml
@@ -89,6 +89,7 @@ products:
       miniaturemarketId: 019c06a2745570b4a0c96b085e33b38f
       scgId: SLD-MTG-BUN-MSHGIFT-EN
       tcgplayerProductId: '675617'
+    release_date: '2026-07-17'
     subtype: GIFT_BUNDLE
   Marvel Super Heroes Gift Bundle Case:
     category: BUNDLE_CASE


### PR DESCRIPTION
The Marvel Super Heroes Gift Bundle (`SLD-MTG-BUN-MSHGIFT-EN`, tcgplayer `675617`) releases on **2026-07-17**, separately from the main set's 2026-06-26 release. This adds a per-product `release_date` override in `data/products/MSH.yaml` so it isn't treated as released on the set's date.

Source: [WPN — Marvel Super Heroes Dates & Details](https://wpn.wizards.com/en/news/marvel-super-heroes-dates-and-details)

🤖 Generated with [Claude Code](https://claude.com/claude-code)