### PR TITLE
Represent Bundle promos as fixed cards, not bundle-promo packs

### DIFF
--- a/data/contents/ECL.yaml
+++ b/data/contents/ECL.yaml
@@ -47,9 +47,6 @@ products:
     - name: 2 Reference cards
     - name: 1 Spindown die
     - name: 1 Card-storage box
-    pack:
-    - code: bundle-promo
-      set: ecl
     sealed:
     - count: 9
       name: Lorwyn Eclipsed Play Booster Pack

--- a/data/contents/EOE.yaml
+++ b/data/contents/EOE.yaml
@@ -14,9 +14,6 @@ products:
     - name: 5 Foil Full-art Basic Lands
     - name: Edge of Eternities Spindown
     - name: Edge of Eternities Card Storage Box
-    pack:
-    - code: bundle-promo
-      set: eoe
     sealed:
     - count: 9
       name: Edge of Eternities Play Booster Pack

--- a/data/contents/LCI.yaml
+++ b/data/contents/LCI.yaml
@@ -13,9 +13,6 @@ products:
     other:
     - name: Lost Caverns of Ixalan Spindown
     - name: Card storage box
-    pack:
-    - code: bundle-promo
-      set: lci
     sealed:
     - count: 8
       name: The Lost Caverns of Ixalan Set Booster Pack
@@ -84,9 +81,6 @@ products:
     other:
     - name: Lost Caverns of Ixalan Spindown
     - name: Card storage box
-    pack:
-    - code: gift-bundle-promo
-      set: lci
     sealed:
     - count: 8
       name: The Lost Caverns of Ixalan Set Booster Pack

--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -31,13 +31,15 @@ products:
     - name: 1 Strategy insert
     - name: 1 Deck box
   Secrets of Strixhaven Bundle:
+    card:
+    - foil: true
+      name: Wisdom of Ages
+      number: 368
+      set: sos
     card_count: 1
     other:
     - name: 1 Spindown die
     - name: 1 Card-storage box
-    pack:
-    - code: bundle-promo
-      set: sos
     sealed:
     - count: 9
       name: Secrets of Strixhaven Play Booster Pack

--- a/data/contents/SPM.yaml
+++ b/data/contents/SPM.yaml
@@ -47,9 +47,6 @@ products:
     - name: 30 Basic Land Pack
     - name: Marvels Spider Man Spindown
     - name: Marvels Spider Man Card Storage Box
-    pack:
-    - code: bundle-promo
-      set: spm
     sealed:
     - count: 9
       name: Marvels Spider Man Play Booster Pack

--- a/data/contents/TMT.yaml
+++ b/data/contents/TMT.yaml
@@ -12,9 +12,6 @@ products:
     - name: Spindown die
     - name: Card-storage box
     - name: 40 card land Pack
-    pack:
-    - code: bundle-promo
-      set: tmt
     sealed:
     - count: 9
       name: Teenage Mutant Ninja Turtles Play Booster Pack


### PR DESCRIPTION
Several bundle products referenced a `bundle-promo` / `gift-bundle-promo` pack code whose only content is a single foil promo card. A single fixed card is better represented directly as a `card` entry than as a booster, so drop the pack reference and list the card:

| Set | Product(s) | Promo card |
|-----|-----------|-----------|
| ECL | Bundle | Kinbinding (ecl/407, foil) — already listed |
| EOE | Bundle | Emissary Escort (eoe/399, foil) — already listed |
| SPM | Gift Bundle | Gwenom, Remorseless (spm/286, foil) — already listed |
| TMT | Bundle | Shark Shredder, Killer Clone (tmt/320, foil) — already listed |
| SOS | Bundle | **added** Wisdom of Ages (sos/368, foil) |
| LCI | Bundle + Gift Bundle | Hit the Mother Lode (lci/404, foil) — already listed |

For the products that already listed the card, this just removes the redundant `pack:` reference; SOS gets the card added. Each product's `card_count` is unchanged. `scripts/contents_validator.py` passes.

**Not changed:** the Final Fantasy bundles keep their `bundle-promo` pack — that promo is genuinely *2 random* foil legendary creatures, which a fixed card list can't represent. The Hobbit bundles are left as-is (set data not yet available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)