### PR TITLE
Reference Bundle Land Packs as decks (OTJ, MH3, MKM, EVE, ROE)

### DIFF
--- a/data/contents/EVE.yaml
+++ b/data/contents/EVE.yaml
@@ -17,8 +17,8 @@ products:
       set: eve
   Eventide Fat Pack:
     deck:
-    - name: Eventide Fat Pack Land Pack
-      set: eve
+    - name: Shadowmoor Fat Pack Land Pack
+      set: shm
     other:
     - name: Eventide Spindown
     - name: Card storage box

--- a/data/contents/EVE.yaml
+++ b/data/contents/EVE.yaml
@@ -16,9 +16,11 @@ products:
     - code: draft
       set: eve
   Eventide Fat Pack:
+    deck:
+    - name: Eventide Fat Pack Land Pack
+      set: eve
     other:
     - name: Eventide Spindown
-    - name: 40 basic land bundle
     - name: Card storage box
     - name: Eventide Novel
     - name: Random Pro Tour Player Card

--- a/data/contents/MH3.yaml
+++ b/data/contents/MH3.yaml
@@ -6,10 +6,12 @@ products:
       name: Powerbalance
       number: 495
       set: mh3
+    deck:
+    - name: Modern Horizons 3 Bundle Land Pack
+      set: mh3
     other:
     - name: Card storage box
     - name: Modern Horizons 3 spindown
-    - name: 30 card basic land bundle
     sealed:
     - count: 9
       name: Modern Horizons 3 Play Booster Pack
@@ -45,10 +47,12 @@ products:
       name: Powerbalance
       number: 495
       set: mh3
+    deck:
+    - name: Modern Horizons 3 Bundle Land Pack
+      set: mh3
     other:
     - name: Card storage box
     - name: Modern Horizons 3 spindown
-    - name: 30 card basic land bundle
     sealed:
     - count: 9
       name: Modern Horizons 3 Play Booster Pack

--- a/data/contents/MKM.yaml
+++ b/data/contents/MKM.yaml
@@ -6,11 +6,13 @@ products:
       name: Axebane Ferox
       number: 428
       set: mkm
+    deck:
+    - name: Murders at Karlov Manor Bundle Land Pack
+      set: mkm
     other:
     - name: Card Storage Box
     - name: Murders at Karlov Manor Spindown
     - name: 2 Reference Cards
-    - name: 30 card basic land pack
     sealed:
     - count: 9
       name: Murders at Karlov Manor Play Booster Pack

--- a/data/contents/OTJ.yaml
+++ b/data/contents/OTJ.yaml
@@ -6,8 +6,10 @@ products:
       name: The Key to the Vault
       number: 373
       set: otj
+    deck:
+    - name: Outlaws of Thunder Junction Bundle Land Pack
+      set: otj
     other:
-    - name: 30 card basic land bundle
     - name: Outlaws of Thunder Junction Spindown
     sealed:
     - count: 9

--- a/data/contents/ROE.yaml
+++ b/data/contents/ROE.yaml
@@ -21,13 +21,15 @@ products:
     - code: draft
       set: roe
   Rise of the Eldrazi Fat Pack:
+    deck:
+    - name: Rise of the Eldrazi Fat Pack Land Pack
+      set: roe
     other:
     - name: Card box with panoramic art
     - name: The Rise of the Eldrazi Palyer's Guide
     - name: A learn-to-play insert
     - name: A sample chapter from In the Teeth of Akoum
     - name: An exclusive Rise of the Eldrazi Spindown Life Counter
-    - name: 40 card basic land pack
     sealed:
     - count: 8
       name: Rise of the Eldrazi Booster Pack


### PR DESCRIPTION
Replace free-text `other:` land-pack entries with proper `deck:` references, matching how other sets model their bundle land packs:

- **OTJ** — Outlaws of Thunder Junction Bundle Land Pack
- **MH3** — Modern Horizons 3 Bundle Land Pack (Bundle + Gift Bundle)
- **MKM** — Murders at Karlov Manor Bundle Land Pack
- **EVE** — the Eventide fat pack reused the Shadowmoor land pack, so it references the shared **Shadowmoor Fat Pack Land Pack** deck (set `shm`)
- **ROE** — Rise of the Eldrazi Fat Pack Land Pack

Validator passes. **Depends on** taw/magic-preconstructed-decks#261, which adds these decks — merge that first so the references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)