### PR TITLE
Reference bundle/fat-pack land packs as decks (10 more sets)

### DIFF
--- a/data/contents/10E.yaml
+++ b/data/contents/10E.yaml
@@ -16,8 +16,10 @@ products:
     - code: draft
       set: 10e
   Tenth Edition Fat Pack:
+    deck:
+    - name: Tenth Edition Fat Pack Land Pack
+      set: 10e
     other:
-    - name: Tenth Edition 40-card Basic Land Bundle
     - name: Tenth Edition Special Life Counter
     - name: Pro-tour player highlight card
     sealed:

--- a/data/contents/9ED.yaml
+++ b/data/contents/9ED.yaml
@@ -47,8 +47,10 @@ products:
       set: 9ed
   Ninth Edition Fast Track Two Player Starter: []
   Ninth Edition Fat Pack:
+    deck:
+    - name: Ninth Edition Fat Pack Land Pack
+      set: 9ed
     other:
-    - name: Ninth Edition 40-card Basic Land Bundle
     - name: Ninth Edition Special Life Counter
     - name: Two Card Boxes
     - name: Promotional Oversized Card

--- a/data/contents/AFR.yaml
+++ b/data/contents/AFR.yaml
@@ -28,8 +28,10 @@ products:
       name: Treasure Chest
       number: 397
       set: afr
+    deck:
+    - name: Adventures in the Forgotten Realms Bundle Land Pack
+      set: afr
     other:
-    - name: Adventures in the Forgotten Realms 40-card Basic Land Bundle
     - name: Adventures in the Forgotten Realms Premium Spindown
     - name: 3 Oversized Dungeon Cards
     sealed:
@@ -82,8 +84,10 @@ products:
       name: Treasure Chest
       number: 397
       set: afr
+    deck:
+    - name: Adventures in the Forgotten Realms Bundle Land Pack
+      set: afr
     other:
-    - name: Adventures in the Forgotten Realms 40-card Basic Land Bundle
     - name: Adventures in the Forgotten Realms Premium Spindown
     - name: 3 Oversized Dungeon Cards
     sealed:

--- a/data/contents/CSP.yaml
+++ b/data/contents/CSP.yaml
@@ -16,13 +16,15 @@ products:
     - code: draft
       set: csp
   Coldsnap Fat Pack:
+    deck:
+    - name: Coldsnap Fat Pack Land Pack
+      set: csp
     other:
     - name: Two card boxes
     - name: Coldsnap player guide
     - name: 1 Pro Player card
     - name: 6 color dividers for the card boxes
     - name: 1 Spindown life counter
-    - name: 1 40 card Basic Land pack (all snow-covered!)
     - name: Jeff Grub's Ice Age novel The Gathering Dark
     sealed:
     - count: 6

--- a/data/contents/GPT.yaml
+++ b/data/contents/GPT.yaml
@@ -16,8 +16,10 @@ products:
     - code: draft
       set: gpt
   Guildpact Fat Pack:
+    deck:
+    - name: Ravnica Fat Pack Land Pack
+      set: rav
     other:
-    - name: 40 Basic Land Bundle
     - name: 2 Card Storage Boxes
     - name: One random Pro Tour Player Card
     - name: The Guildpact novel

--- a/data/contents/M10.yaml
+++ b/data/contents/M10.yaml
@@ -21,11 +21,13 @@ products:
     - code: draft
       set: m10
   2010 Core Set Fat Pack:
+    deck:
+    - name: Magic 2010 Fat Pack Land Pack
+      set: m10
     other:
     - name: Core Set 2010 Card Box
     - name: Magic 2010 Player's Guide
     - name: Learn-to-Play Insert
-    - name: Magic 2010 40-card Basic Land Bundle
     - name: Magic 2010 Spindown Life Counter
     sealed:
     - count: 8

--- a/data/contents/M11.yaml
+++ b/data/contents/M11.yaml
@@ -73,11 +73,13 @@ products:
       count: 4
       replacement: false
   2011 Core Set Fat Pack:
+    deck:
+    - name: Magic 2011 Fat Pack Land Pack
+      set: m11
     other:
     - name: Magic 2011 Card Box
     - name: Magic 2011 Player's Guide
     - name: Learn-to-Play Insert
-    - name: Magic 2011 40-card Basic Land Bundle
     - name: Magic 2011 Spindown Life Counter
     sealed:
     - count: 8

--- a/data/contents/M20.yaml
+++ b/data/contents/M20.yaml
@@ -21,8 +21,10 @@ products:
       name: Chandra's Regulator
       number: 131
       set: pm20
+    deck:
+    - name: Core Set 2020 Bundle Land Pack
+      set: m20
     other:
-    - name: Core Set 2020 40-card Basic Land Bundle
     - name: Core Set 2020 Spindown
     - name: Reusable Storage Box
     sealed:

--- a/data/contents/MOR.yaml
+++ b/data/contents/MOR.yaml
@@ -16,8 +16,10 @@ products:
     - code: draft
       set: mor
   Morningtide Fat Pack:
+    deck:
+    - name: Lorwyn Fat Pack Land Pack
+      set: lrw
     other:
-    - name: 40 Basic Land Bundle
     - name: 2 Card Storage Boxes
     - name: Morningtide Spindown
     - name: One random Pro Tour Player Card

--- a/data/contents/STX.yaml
+++ b/data/contents/STX.yaml
@@ -6,8 +6,10 @@ products:
       name: Archmage Emeritus
       number: 377
       set: stx
+    deck:
+    - name: Strixhaven Bundle Land Pack
+      set: stx
     other:
-    - name: Strixhaven 40-card Basic Land Bundle
     - name: Strixhaven Premium Spindown
     - name: Strixhaven Card Storage Box
     sealed:


### PR DESCRIPTION
Follow-up to the OTJ/MH3/MKM/EVE/ROE land-pack deck references. Replace the free-text `other:` land-pack entries with proper `deck:` references for ten more sets:

**Old fat packs (40 non-foil):** 10E, 9ED, M10, M11, CSP (snow), **GPT** (→ shared *Ravnica Fat Pack Land Pack*, since Guildpact printed no basics), **MOR** (→ shared *Lorwyn Fat Pack Land Pack*)

**2019+ bundles (20 non-foil + 20 foil):** M20, STX, AFR (both bundle products)

Validator passes. **Depends on** taw/magic-preconstructed-decks#261, which adds all these decks — merge that first so the references resolve.