### PR TITLE
Drop non-existent prerelease-promo pack references (ECL, SOS)

### DIFF
--- a/data/contents/ECL.yaml
+++ b/data/contents/ECL.yaml
@@ -109,10 +109,6 @@ products:
     - code: play
       set: ecl
   Lorwyn Eclipsed Prerelease Pack:
-    card_count: 1
     other:
     - name: Deck box
     - name: Spindown die
-    pack:
-    - code: prerelease
-      set: ecl

--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -118,37 +118,25 @@ products:
     - code: play
       set: sos
   Secrets of Strixhaven Prerelease Pack Lorehold:
-    card_count: 1
     other:
     - name: Deck box
     - name: Spindown die
-    pack:
-    - code: prerelease-lorehold
-      set: sos
     sealed:
     - count: 5
       name: Secrets of Strixhaven Play Booster Pack
       set: sos
   Secrets of Strixhaven Prerelease Pack Prismari:
-    card_count: 1
     other:
     - name: Deck box
     - name: Spindown die
-    pack:
-    - code: prerelease-prismari
-      set: sos
     sealed:
     - count: 5
       name: Secrets of Strixhaven Play Booster Pack
       set: sos
   Secrets of Strixhaven Prerelease Pack Quandrix:
-    card_count: 1
     other:
     - name: Deck box
     - name: Spindown die
-    pack:
-    - code: prerelease-quandrix
-      set: sos
     sealed:
     - count: 5
       name: Secrets of Strixhaven Play Booster Pack
@@ -171,25 +159,17 @@ products:
       name: Secrets of Strixhaven Prerelease Pack Prismari
       set: sos
   Secrets of Strixhaven Prerelease Pack Silverquill:
-    card_count: 1
     other:
     - name: Deck box
     - name: Spindown die
-    pack:
-    - code: prerelease-silverquill
-      set: sos
     sealed:
     - count: 5
       name: Secrets of Strixhaven Play Booster Pack
       set: sos
   Secrets of Strixhaven Prerelease Pack Witherbloom:
-    card_count: 1
     other:
     - name: Deck box
     - name: Spindown die
-    pack:
-    - code: prerelease-witherbloom
-      set: sos
     sealed:
     - count: 5
       name: Secrets of Strixhaven Play Booster Pack


### PR DESCRIPTION
From Lorwyn Eclipsed onward, sets no longer include dedicated prerelease promo cards, so the `pack: [prerelease-*]` references on these prerelease packs point to promos that don't exist (unresolved pack code). Remove them, along with the `card_count: 1` that counted only that promo:

- **ECL**: Lorwyn Eclipsed Prerelease Pack
- **SOS**: the five college prerelease packs (Lorehold / Prismari / Quandrix / Silverquill / Witherbloom)

The SOS packs keep their 5 Play Boosters; the ECL pack keeps its deck box + spindown. Validator passes.

*Note:* the ECL Prerelease Pack has no boosters listed at all (it was only ever modeled as the promo) — that's a pre-existing data gap, separate from this reference cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)