### PR TITLE
SOS: college prerelease packs are 15-card seeded packs

### DIFF
--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -118,7 +118,7 @@ products:
     - code: play
       set: sos
   Secrets of Strixhaven Prerelease Pack Lorehold:
-    card_count: 1
+    card_count: 15
     other:
     - name: Deck box
     - name: Spindown die
@@ -130,7 +130,7 @@ products:
       name: Secrets of Strixhaven Play Booster Pack
       set: sos
   Secrets of Strixhaven Prerelease Pack Prismari:
-    card_count: 1
+    card_count: 15
     other:
     - name: Deck box
     - name: Spindown die
@@ -142,7 +142,7 @@ products:
       name: Secrets of Strixhaven Play Booster Pack
       set: sos
   Secrets of Strixhaven Prerelease Pack Quandrix:
-    card_count: 1
+    card_count: 15
     other:
     - name: Deck box
     - name: Spindown die
@@ -171,7 +171,7 @@ products:
       name: Secrets of Strixhaven Prerelease Pack Prismari
       set: sos
   Secrets of Strixhaven Prerelease Pack Silverquill:
-    card_count: 1
+    card_count: 15
     other:
     - name: Deck box
     - name: Spindown die
@@ -183,7 +183,7 @@ products:
       name: Secrets of Strixhaven Play Booster Pack
       set: sos
   Secrets of Strixhaven Prerelease Pack Witherbloom:
-    card_count: 1
+    card_count: 15
     other:
     - name: Deck box
     - name: Spindown die


### PR DESCRIPTION
The Secrets of Strixhaven college prerelease packs (`prerelease-<college>`) are a 14-card non-foil pile seeded to the college's colors **plus** a foil base-set promo = **15 cards**, modeled by the `sos-prerelease-<college>` boosters in taw/magic-search-engine#513. Update `card_count` from 1 → 15 for all five colleges (Lorehold / Prismari / Quandrix / Silverquill / Witherbloom).

The ECL prerelease promo stays `card_count: 1` (just the foil rare/mythic). Validator passes.

**Depends on** taw/magic-search-engine#513 (adds the booster definitions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)