### PR TITLE
TMT/MSH: wire up the prerelease packs

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -18,7 +18,18 @@ products:
   Marvel Super Heroes Play Booster Box: []
   Marvel Super Heroes Play Booster Box Case: []
   Marvel Super Heroes Play Booster Pack: []
-  Marvel Super Heroes Prerelease Pack: []
+  Marvel Super Heroes Prerelease Pack:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Spindown die
+    pack:
+    - code: prerelease
+      set: msh
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
   Marvel Super Heroes Prerelease Pack Case: []
   Marvel Super Heroes Scene Box Case: []
   Marvel Super Heroes Scene Box Heroes United: []

--- a/data/contents/TMT.yaml
+++ b/data/contents/TMT.yaml
@@ -84,6 +84,9 @@ products:
     other:
     - name: Deck box
     - name: Spindown die
+    pack:
+    - code: prerelease
+      set: tmt
     sealed:
     - count: 6
       name: Teenage Mutant Ninja Turtles Play Booster Pack


### PR DESCRIPTION
Like ECL/SOS, TMT and MSH have no stamped prerelease promo; the promo is a base-set foil rare/mythic (booster defs in taw/magic-search-engine#515).

- **TMT**: add the missing `pack: [prerelease]` reference (the product already listed its 6 Play Boosters + accessories, just no promo).
- **MSH**: populate the previously-empty prerelease product — promo + 6 Play Boosters + deck box + spindown.

Validator passes.

**Note:** the MSH `Play Booster Pack` / `Collector Booster Pack` products are still empty `[]` (a pre-existing, broader MSH-population gap), so the 6 play-booster references here currently resolve to nothing until those are wired to their `play`/`collector` codes. Happy to do that in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)