### PR TITLE
Populate Theros & Journey into Nyx Hero's Path prerelease kits

### DIFF
--- a/data/contents/JOU.yaml
+++ b/data/contents/JOU.yaml
@@ -108,10 +108,6 @@ products:
       set: jou
   Journey Into Nyx Prerelease Forged in Glory:
     card:
-    - foil: true
-      name: Dawnbringer Charioteers
-      number: "6\u2605"
-      set: pjou
     - foil: false
       name: Spear of the General
       number: 7a
@@ -134,10 +130,6 @@ products:
       set: ths
   Journey Into Nyx Prerelease Forged in Intellect:
     card:
-    - foil: true
-      name: Scourge of Fleets
-      number: "51\u2605"
-      set: pjou
     - foil: false
       name: Cloak of the Philosopher
       number: 7b
@@ -160,10 +152,6 @@ products:
       set: ths
   Journey Into Nyx Prerelease Forged in Pursuit:
     card:
-    - foil: true
-      name: Heroes' Bane
-      number: "126\u2605"
-      set: pjou
     - foil: false
       name: Bow of the Hunter
       number: 7e
@@ -186,10 +174,6 @@ products:
       set: ths
   Journey Into Nyx Prerelease Forged in Tyranny:
     card:
-    - foil: true
-      name: Doomwake Giant
-      number: "66\u2605"
-      set: pjou
     - foil: false
       name: Lash of the Tyrant
       number: 7c
@@ -212,10 +196,6 @@ products:
       set: ths
   Journey Into Nyx Prerelease Forged in War:
     card:
-    - foil: true
-      name: Spawn of Thraxes
-      number: "112\u2605"
-      set: pjou
     - foil: false
       name: Axe of the Warmonger
       number: 7d

--- a/data/contents/JOU.yaml
+++ b/data/contents/JOU.yaml
@@ -106,11 +106,136 @@ products:
     - count: 2
       name: Journey Into Nyx Booster Pack
       set: jou
-  Journey Into Nyx Prerelease Forged in Glory: []
-  Journey Into Nyx Prerelease Forged in Intellect: []
-  Journey Into Nyx Prerelease Forged in Pursuit: []
-  Journey Into Nyx Prerelease Forged in Tyranny: []
-  Journey Into Nyx Prerelease Forged in War: []
+  Journey Into Nyx Prerelease Forged in Glory:
+    card:
+    - foil: true
+      name: Dawnbringer Charioteers
+      number: "6\u2605"
+      set: pjou
+    - foil: false
+      name: Spear of the General
+      number: 7a
+      set: thp3
+    card_count: 15
+    pack:
+    - code: prerelease-glory
+      set: jou
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 2
+      name: Journey Into Nyx Booster Pack
+      set: jou
+    - count: 1
+      name: Born of the Gods Booster Pack
+      set: bng
+    - count: 2
+      name: Theros Booster Pack
+      set: ths
+  Journey Into Nyx Prerelease Forged in Intellect:
+    card:
+    - foil: true
+      name: Scourge of Fleets
+      number: "51\u2605"
+      set: pjou
+    - foil: false
+      name: Cloak of the Philosopher
+      number: 7b
+      set: thp3
+    card_count: 15
+    pack:
+    - code: prerelease-intellect
+      set: jou
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 2
+      name: Journey Into Nyx Booster Pack
+      set: jou
+    - count: 1
+      name: Born of the Gods Booster Pack
+      set: bng
+    - count: 2
+      name: Theros Booster Pack
+      set: ths
+  Journey Into Nyx Prerelease Forged in Pursuit:
+    card:
+    - foil: true
+      name: Heroes' Bane
+      number: "126\u2605"
+      set: pjou
+    - foil: false
+      name: Bow of the Hunter
+      number: 7e
+      set: thp3
+    card_count: 15
+    pack:
+    - code: prerelease-pursuit
+      set: jou
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 2
+      name: Journey Into Nyx Booster Pack
+      set: jou
+    - count: 1
+      name: Born of the Gods Booster Pack
+      set: bng
+    - count: 2
+      name: Theros Booster Pack
+      set: ths
+  Journey Into Nyx Prerelease Forged in Tyranny:
+    card:
+    - foil: true
+      name: Doomwake Giant
+      number: "66\u2605"
+      set: pjou
+    - foil: false
+      name: Lash of the Tyrant
+      number: 7c
+      set: thp3
+    card_count: 15
+    pack:
+    - code: prerelease-tyranny
+      set: jou
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 2
+      name: Journey Into Nyx Booster Pack
+      set: jou
+    - count: 1
+      name: Born of the Gods Booster Pack
+      set: bng
+    - count: 2
+      name: Theros Booster Pack
+      set: ths
+  Journey Into Nyx Prerelease Forged in War:
+    card:
+    - foil: true
+      name: Spawn of Thraxes
+      number: "112\u2605"
+      set: pjou
+    - foil: false
+      name: Axe of the Warmonger
+      number: 7d
+      set: thp3
+    card_count: 15
+    pack:
+    - code: prerelease-war
+      set: jou
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 2
+      name: Journey Into Nyx Booster Pack
+      set: jou
+    - count: 1
+      name: Born of the Gods Booster Pack
+      set: bng
+    - count: 2
+      name: Theros Booster Pack
+      set: ths
   Journey Into Nyx Prerelease Kit Set of 5:
     sealed:
     - count: 1

--- a/data/contents/THS.yaml
+++ b/data/contents/THS.yaml
@@ -143,10 +143,6 @@ products:
       set: ths
   Theros Prerelease Kit Path of Ambition:
     card:
-    - foil: true
-      name: Abhorrent Overlord
-      number: "75\u2605"
-      set: pths
     - foil: false
       name: The Avenger
       number: 1c
@@ -163,10 +159,6 @@ products:
       set: ths
   Theros Prerelease Kit Path of Battle:
     card:
-    - foil: true
-      name: Ember Swallower
-      number: "120\u2605"
-      set: pths
     - foil: false
       name: The Warrior
       number: 1d
@@ -183,10 +175,6 @@ products:
       set: ths
   Theros Prerelease Kit Path of Honor:
     card:
-    - foil: true
-      name: Celestial Archon
-      number: "3\u2605"
-      set: pths
     - foil: false
       name: The Protector
       number: 1a
@@ -203,10 +191,6 @@ products:
       set: ths
   Theros Prerelease Kit Path of Might:
     card:
-    - foil: true
-      name: Anthousa, Setessan Hero
-      number: "149\u2605"
-      set: pths
     - foil: false
       name: The Hunter
       number: 1e
@@ -223,10 +207,6 @@ products:
       set: ths
   Theros Prerelease Kit Path of Wisdom:
     card:
-    - foil: true
-      name: Shipbreaker Kraken
-      number: "63\u2605"
-      set: pths
     - foil: false
       name: The Philosopher
       number: 1b

--- a/data/contents/THS.yaml
+++ b/data/contents/THS.yaml
@@ -141,11 +141,106 @@ products:
     deck:
     - name: Theros Foil Redemption
       set: ths
-  Theros Prerelease Kit Path of Ambition: []
-  Theros Prerelease Kit Path of Battle: []
-  Theros Prerelease Kit Path of Honor: []
-  Theros Prerelease Kit Path of Might: []
-  Theros Prerelease Kit Path of Wisdom: []
+  Theros Prerelease Kit Path of Ambition:
+    card:
+    - foil: true
+      name: Abhorrent Overlord
+      number: "75\u2605"
+      set: pths
+    - foil: false
+      name: The Avenger
+      number: 1c
+      set: thp1
+    card_count: 15
+    pack:
+    - code: prerelease-ambition
+      set: ths
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 5
+      name: Theros Booster Pack
+      set: ths
+  Theros Prerelease Kit Path of Battle:
+    card:
+    - foil: true
+      name: Ember Swallower
+      number: "120\u2605"
+      set: pths
+    - foil: false
+      name: The Warrior
+      number: 1d
+      set: thp1
+    card_count: 15
+    pack:
+    - code: prerelease-battle
+      set: ths
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 5
+      name: Theros Booster Pack
+      set: ths
+  Theros Prerelease Kit Path of Honor:
+    card:
+    - foil: true
+      name: Celestial Archon
+      number: "3\u2605"
+      set: pths
+    - foil: false
+      name: The Protector
+      number: 1a
+      set: thp1
+    card_count: 15
+    pack:
+    - code: prerelease-honor
+      set: ths
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 5
+      name: Theros Booster Pack
+      set: ths
+  Theros Prerelease Kit Path of Might:
+    card:
+    - foil: true
+      name: Anthousa, Setessan Hero
+      number: "149\u2605"
+      set: pths
+    - foil: false
+      name: The Hunter
+      number: 1e
+      set: thp1
+    card_count: 15
+    pack:
+    - code: prerelease-might
+      set: ths
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 5
+      name: Theros Booster Pack
+      set: ths
+  Theros Prerelease Kit Path of Wisdom:
+    card:
+    - foil: true
+      name: Shipbreaker Kraken
+      number: "63\u2605"
+      set: pths
+    - foil: false
+      name: The Philosopher
+      number: 1b
+      set: thp1
+    card_count: 15
+    pack:
+    - code: prerelease-wisdom
+      set: ths
+    other:
+    - name: Spindown die
+    sealed:
+    - count: 5
+      name: Theros Booster Pack
+      set: ths
   Theros Prerelease Pack Set of 5:
     sealed:
     - count: 1


### PR DESCRIPTION
The ten Theros ("Path of X") and Journey into Nyx ("Forged in X") Hero's Path prerelease kits were empty `[]`. Populate each with its **foil promo + Hero's Path card + color-seeded prerelease pack + boosters + spindown**, mirroring the Born of the Gods kits.

- **THS** kits: 5 Theros boosters + `prerelease-<path>` seeded pack. Paths: Honor/Wisdom/Ambition/Battle/Might (W/U/B/R/G).
- **JOU** kits: 2 Journey into Nyx + 1 Born of the Gods + 2 Theros boosters + `prerelease-<path>` seeded pack. Paths: Glory/Intellect/Tyranny/War/Pursuit (W/U/B/R/G).

Path→color→promo→hero mappings verified against WotC's Theros / Journey into Nyx Prerelease Primers (e.g. Path of Honor → white → Celestial Archon + The Protector). Seeded packs added in taw/magic-search-engine#518. `card_count: 15` per kit; validator passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)