### PR TITLE
BNG kits: prerelease promo comes from the seeded pack, not a fixed card

### DIFF
--- a/data/contents/BNG.yaml
+++ b/data/contents/BNG.yaml
@@ -128,10 +128,6 @@ products:
       set: bng
   Born of the Gods Prerelease Kit Destined To Conquer:
     card:
-    - foil: true
-      name: Forgestoker Dragon
-      number: "98\u2605"
-      set: pbng
     - foil: false
       name: The Warmonger
       number: 4d
@@ -149,10 +145,6 @@ products:
       set: ths
   Born of the Gods Prerelease Kit Destined To Dominate:
     card:
-    - foil: true
-      name: Eater of Hope
-      number: "66\u2605"
-      set: pbng
     - foil: false
       name: The Tyrant
       number: 4c
@@ -170,10 +162,6 @@ products:
       set: ths
   Born of the Gods Prerelease Kit Destined To Lead:
     card:
-    - foil: true
-      name: Silent Sentinel
-      number: "26\u2605"
-      set: pbng
     - foil: false
       name: The General
       number: 4a
@@ -191,10 +179,6 @@ products:
       set: ths
   Born of the Gods Prerelease Kit Destined To Outwit:
     card:
-    - foil: true
-      name: Arbiter of the Ideal
-      number: "31\u2605"
-      set: pbng
     - foil: false
       name: The Savant
       number: 4b
@@ -212,10 +196,6 @@ products:
       set: ths
   Born of the Gods Prerelease Kit Destined To Thrive:
     card:
-    - foil: true
-      name: Nessian Wilds Ravager
-      number: "129\u2605"
-      set: pbng
     - foil: false
       name: The Provider
       number: 4e


### PR DESCRIPTION
The `bng-prerelease-<path>` booster (taw/magic-search-engine#517) now models the full 15-card seeded booster, **including the guaranteed stamped foil prerelease promo as a slot**. So the fixed promo `card:` on each "Destined to" kit is now redundant (it would double-count against the pack). Remove it, keeping only the oversized Hero's Path card. `card_count` stays 15 (the seeded booster's 15 cards, promo included).

Validator passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)