### PR TITLE
TDM: populate the five clan-seeded prerelease products

### DIFF
--- a/data/contents/TDM.yaml
+++ b/data/contents/TDM.yaml
@@ -61,14 +61,120 @@ products:
     pack:
     - code: play
       set: tdm
-  Tarkir Dragonstorm Prerelease Booster Abzan: []
-  Tarkir Dragonstorm Prerelease Booster Jeskai: []
-  Tarkir Dragonstorm Prerelease Booster Mardu: []
-  Tarkir Dragonstorm Prerelease Booster Sultai: []
-  Tarkir Dragonstorm Prerelease Booster Temur: []
-  Tarkir Dragonstorm Prerelease Pack Abzan: []
-  Tarkir Dragonstorm Prerelease Pack Jeskai: []
-  Tarkir Dragonstorm Prerelease Pack Mardu: []
-  Tarkir Dragonstorm Prerelease Pack Sultai: []
-  Tarkir Dragonstorm Prerelease Pack Temur: []
-  Tarkir Dragonstorm Prerelease Packs Set of 5: []
+  Tarkir Dragonstorm Prerelease Booster Abzan:
+    card_count: 14
+    pack:
+    - code: prerelease-abzan
+      set: tdm
+  Tarkir Dragonstorm Prerelease Booster Jeskai:
+    card_count: 14
+    pack:
+    - code: prerelease-jeskai
+      set: tdm
+  Tarkir Dragonstorm Prerelease Booster Mardu:
+    card_count: 14
+    pack:
+    - code: prerelease-mardu
+      set: tdm
+  Tarkir Dragonstorm Prerelease Booster Sultai:
+    card_count: 14
+    pack:
+    - code: prerelease-sultai
+      set: tdm
+  Tarkir Dragonstorm Prerelease Booster Temur:
+    card_count: 14
+    pack:
+    - code: prerelease-temur
+      set: tdm
+  Tarkir Dragonstorm Prerelease Pack Abzan:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Tarkir Dragonstorm Spindown
+    pack:
+    - code: prerelease
+      set: tdm
+    sealed:
+    - count: 5
+      name: Tarkir Dragonstorm Play Booster Pack
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Booster Abzan
+      set: tdm
+  Tarkir Dragonstorm Prerelease Pack Jeskai:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Tarkir Dragonstorm Spindown
+    pack:
+    - code: prerelease
+      set: tdm
+    sealed:
+    - count: 5
+      name: Tarkir Dragonstorm Play Booster Pack
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Booster Jeskai
+      set: tdm
+  Tarkir Dragonstorm Prerelease Pack Mardu:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Tarkir Dragonstorm Spindown
+    pack:
+    - code: prerelease
+      set: tdm
+    sealed:
+    - count: 5
+      name: Tarkir Dragonstorm Play Booster Pack
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Booster Mardu
+      set: tdm
+  Tarkir Dragonstorm Prerelease Pack Sultai:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Tarkir Dragonstorm Spindown
+    pack:
+    - code: prerelease
+      set: tdm
+    sealed:
+    - count: 5
+      name: Tarkir Dragonstorm Play Booster Pack
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Booster Sultai
+      set: tdm
+  Tarkir Dragonstorm Prerelease Pack Temur:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Tarkir Dragonstorm Spindown
+    pack:
+    - code: prerelease
+      set: tdm
+    sealed:
+    - count: 5
+      name: Tarkir Dragonstorm Play Booster Pack
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Booster Temur
+      set: tdm
+  Tarkir Dragonstorm Prerelease Packs Set of 5:
+    sealed:
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Pack Abzan
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Pack Jeskai
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Pack Mardu
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Pack Sultai
+      set: tdm
+    - count: 1
+      name: Tarkir Dragonstorm Prerelease Pack Temur
+      set: tdm


### PR DESCRIPTION
Fills in the previously-empty **Tarkir: Dragonstorm** prerelease products.

Each prerelease pack ships with one of five clan-seeded Clan Boosters (Abzan/Jeskai/Mardu/Sultai/Temur), themed to a 3-color wedge per the [official WotC prerelease guide](https://magic.wizards.com/en/news/feature/tarkir-dragonstorm-prerelease-guide).

## What this adds
- **Prerelease Booster \<clan\>** → the 14-card seeded Clan Booster, wired to booster code `prerelease-<clan>` (`card_count: 14`).
- **Prerelease Pack \<clan\>** → the full kit: 5 Play Boosters + the seeded Clan Booster + the loose foil stamped promo (`pack: prerelease`, `card_count: 1`) + a deck box + a spindown.
- **Prerelease Packs Set of 5** → one of each Pack.

Mirrors the OTJ/DSK/BLB prerelease-pack convention (promo via a pack ref) and the TLA seeded-prerelease modeling. The stamped promo is a separate loose card per the WotC guide, so it is not folded into the seeded booster.

Booster collation comes from taw/magic-search-engine#520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)