### PR TITLE
KTK + FRF: populate the five clan-seeded prerelease kits

### DIFF
--- a/data/contents/FRF.yaml
+++ b/data/contents/FRF.yaml
@@ -112,9 +112,42 @@ products:
     deck:
     - name: Fate Reforged Foil Redemption
       set: frf
-  Fate Reforged Prerelease Kit Abzan Battle with Endurance: []
-  Fate Reforged Prerelease Kit Jeskai Battle with Cunning: []
-  Fate Reforged Prerelease Kit Mardu Battle with Speed: []
+  Fate Reforged Prerelease Kit Abzan Battle with Endurance:
+    card_count: 16
+    pack:
+    - code: prerelease-abzan
+      set: frf
+    sealed:
+    - count: 4
+      name: Fate Reforged Booster Pack
+      set: frf
+    - count: 1
+      name: Khans of Tarkir Booster Pack
+      set: ktk
+  Fate Reforged Prerelease Kit Jeskai Battle with Cunning:
+    card_count: 16
+    pack:
+    - code: prerelease-jeskai
+      set: frf
+    sealed:
+    - count: 4
+      name: Fate Reforged Booster Pack
+      set: frf
+    - count: 1
+      name: Khans of Tarkir Booster Pack
+      set: ktk
+  Fate Reforged Prerelease Kit Mardu Battle with Speed:
+    card_count: 16
+    pack:
+    - code: prerelease-mardu
+      set: frf
+    sealed:
+    - count: 4
+      name: Fate Reforged Booster Pack
+      set: frf
+    - count: 1
+      name: Khans of Tarkir Booster Pack
+      set: ktk
   Fate Reforged Prerelease Kit Set of 5:
     sealed:
     - count: 1
@@ -132,8 +165,30 @@ products:
     - count: 1
       name: Fate Reforged Prerelease Kit Temur Battle with Savagery
       set: frf
-  Fate Reforged Prerelease Kit Sultai Battle with Ruthlessness: []
-  Fate Reforged Prerelease Kit Temur Battle with Savagery: []
+  Fate Reforged Prerelease Kit Sultai Battle with Ruthlessness:
+    card_count: 16
+    pack:
+    - code: prerelease-sultai
+      set: frf
+    sealed:
+    - count: 4
+      name: Fate Reforged Booster Pack
+      set: frf
+    - count: 1
+      name: Khans of Tarkir Booster Pack
+      set: ktk
+  Fate Reforged Prerelease Kit Temur Battle with Savagery:
+    card_count: 16
+    pack:
+    - code: prerelease-temur
+      set: frf
+    sealed:
+    - count: 4
+      name: Fate Reforged Booster Pack
+      set: frf
+    - count: 1
+      name: Khans of Tarkir Booster Pack
+      set: ktk
   Ugins Fate Event Booster Pack:
     pack:
     - code: fate

--- a/data/contents/KTK.yaml
+++ b/data/contents/KTK.yaml
@@ -125,9 +125,33 @@ products:
     deck:
     - name: Khans of Tarkir Foil Redemption
       set: ktk
-  Khans of Tarkir Prerelease Kit Abzan Battle with Endurance: []
-  Khans of Tarkir Prerelease Kit Jeskai Battle with Cunning: []
-  Khans of Tarkir Prerelease Kit Mardu Battle with Speed: []
+  Khans of Tarkir Prerelease Kit Abzan Battle with Endurance:
+    card_count: 16
+    pack:
+    - code: prerelease-abzan
+      set: ktk
+    sealed:
+    - count: 5
+      name: Khans of Tarkir Booster Pack
+      set: ktk
+  Khans of Tarkir Prerelease Kit Jeskai Battle with Cunning:
+    card_count: 16
+    pack:
+    - code: prerelease-jeskai
+      set: ktk
+    sealed:
+    - count: 5
+      name: Khans of Tarkir Booster Pack
+      set: ktk
+  Khans of Tarkir Prerelease Kit Mardu Battle with Speed:
+    card_count: 16
+    pack:
+    - code: prerelease-mardu
+      set: ktk
+    sealed:
+    - count: 5
+      name: Khans of Tarkir Booster Pack
+      set: ktk
   Khans of Tarkir Prerelease Kit Set of 5:
     sealed:
     - count: 1
@@ -145,5 +169,21 @@ products:
     - count: 1
       name: Khans of Tarkir Prerelease Kit Temur Battle with Savagery
       set: ktk
-  Khans of Tarkir Prerelease Kit Sultai Battle with Ruthlessness: []
-  Khans of Tarkir Prerelease Kit Temur Battle with Savagery: []
+  Khans of Tarkir Prerelease Kit Sultai Battle with Ruthlessness:
+    card_count: 16
+    pack:
+    - code: prerelease-sultai
+      set: ktk
+    sealed:
+    - count: 5
+      name: Khans of Tarkir Booster Pack
+      set: ktk
+  Khans of Tarkir Prerelease Kit Temur Battle with Savagery:
+    card_count: 16
+    pack:
+    - code: prerelease-temur
+      set: ktk
+    sealed:
+    - count: 5
+      name: Khans of Tarkir Booster Pack
+      set: ktk


### PR DESCRIPTION
Fills in the previously-empty **Khans of Tarkir** and **Fate Reforged** clan "Battle with …" Prerelease Kits, matching the already-populated **Dragons of Tarkir** kits.

## What this adds (per set, five clans: Abzan/Jeskai/Mardu/Sultai/Temur)
- **Prerelease Kit \<clan\> Battle with …** → the seeded Clan Booster (`pack: prerelease-<clan>`, `card_count: 16` incl. the folded clan-colored stamped promo) plus the kit's boosters:
  - **KTK**: 5 Khans of Tarkir boosters
  - **FRF**: 4 Fate Reforged + 1 Khans of Tarkir booster

Kit booster counts are per the WotC/retailer prerelease listings. Modeling mirrors the existing DTK prerelease kits.

Booster collation comes from taw/magic-search-engine#521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)