### PR TITLE
MH3 + ORI: populate the prerelease products

### DIFF
--- a/data/contents/MH3.yaml
+++ b/data/contents/MH3.yaml
@@ -80,4 +80,15 @@ products:
     pack:
     - code: play
       set: mh3
-  Modern Horizons 3 Prerelease Pack: []
+  Modern Horizons 3 Prerelease Pack:
+    card_count: 1
+    other:
+    - name: Deck box
+    - name: Modern Horizons 3 spindown
+    pack:
+    - code: prerelease
+      set: mh3
+    sealed:
+    - count: 6
+      name: Modern Horizons 3 Play Booster Pack
+      set: mh3

--- a/data/contents/ORI.yaml
+++ b/data/contents/ORI.yaml
@@ -114,11 +114,51 @@ products:
     deck:
     - name: Magic Origins Foil Redemption
       set: ori
-  Magic Origins Prerelease Kit Chandra: []
-  Magic Origins Prerelease Kit Gideon: []
-  Magic Origins Prerelease Kit Jace: []
-  Magic Origins Prerelease Kit Liliana: []
-  Magic Origins Prerelease Kit Nissa: []
+  Magic Origins Prerelease Kit Chandra:
+    card_count: 7
+    pack:
+    - code: prerelease-chandra
+      set: ori
+    sealed:
+    - count: 6
+      name: Magic Origins Booster Pack
+      set: ori
+  Magic Origins Prerelease Kit Gideon:
+    card_count: 7
+    pack:
+    - code: prerelease-gideon
+      set: ori
+    sealed:
+    - count: 6
+      name: Magic Origins Booster Pack
+      set: ori
+  Magic Origins Prerelease Kit Jace:
+    card_count: 7
+    pack:
+    - code: prerelease-jace
+      set: ori
+    sealed:
+    - count: 6
+      name: Magic Origins Booster Pack
+      set: ori
+  Magic Origins Prerelease Kit Liliana:
+    card_count: 7
+    pack:
+    - code: prerelease-liliana
+      set: ori
+    sealed:
+    - count: 6
+      name: Magic Origins Booster Pack
+      set: ori
+  Magic Origins Prerelease Kit Nissa:
+    card_count: 7
+    pack:
+    - code: prerelease-nissa
+      set: ori
+    sealed:
+    - count: 6
+      name: Magic Origins Booster Pack
+      set: ori
   Magic Origins Prerelease Kit Set of 5:
     sealed:
     - count: 1


### PR DESCRIPTION
## Modern Horizons 3
Wires the previously-empty **Prerelease Pack** to the stamped promo booster (`pack: prerelease`, `card_count: 1`) plus 6 Play Boosters + a deck box + a spindown — the standard modern prerelease convention (OTJ/DSK/BLB). Contents per the [WotC prerelease primer](https://magic.wizards.com/en/news/feature/modern-horizons-3-prerelease-primer).

## Magic Origins
Wires the five previously-empty planeswalker-seeded **Prerelease Kits** (Gideon/Jace/Liliana/Chandra/Nissa) to their seeded booster codes (`prerelease-<pw>`) plus 6 Magic Origins boosters. The 7-card seeded booster folds the color-stamped promo (`card_count: 7`), as in the DTK-era kits. Kit contents (6 boosters + 1 seeded booster) per community/WotC listings.

Booster collation for the Origins seeded packs comes from taw/magic-search-engine#523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)