### PR TITLE
Populate 2016-2018 prerelease packs (OGW/SOI/EMN/HOU/RIX)

### DIFF
--- a/data/contents/EMN.yaml
+++ b/data/contents/EMN.yaml
@@ -105,4 +105,17 @@ products:
     deck:
     - name: Eldritch Moon Foil Redemption
       set: emn
-  Eldritch Moon Prerelease Pack: []
+  Eldritch Moon Prerelease Pack:
+    card_count: 1
+    other:
+    - name: 1 Eldritch Moon Spindown
+    pack:
+    - code: prerelease
+      set: emn
+    sealed:
+    - count: 4
+      name: Eldritch Moon Booster Pack
+      set: emn
+    - count: 2
+      name: Shadows over Innistrad Booster Pack
+      set: soi

--- a/data/contents/HOU.yaml
+++ b/data/contents/HOU.yaml
@@ -53,5 +53,18 @@ products:
     - count: 1
       name: Hour of Devastation Planeswalker Deck Nissa
       set: hou
-  Hour of Devastation Prerelease Pack: []
+  Hour of Devastation Prerelease Pack:
+    card_count: 1
+    other:
+    - name: 1 Hour of Devastation Spindown
+    pack:
+    - code: prerelease
+      set: hou
+    sealed:
+    - count: 4
+      name: Hour of Devastation Booster Pack
+      set: hou
+    - count: 2
+      name: Amonkhet Booster Pack
+      set: akh
   Hour of Devastation Standard Showdown Booster: []

--- a/data/contents/OGW.yaml
+++ b/data/contents/OGW.yaml
@@ -16,7 +16,6 @@ products:
     - code: draft
       set: ogw
   Oath of the Gatewatch Fat Pack: []
-  Oath of the Gatewatch Hedron Prerelease Box: []
   Oath of the Gatewatch Intro Pack Concerted Effort:
     card_count: 60
     deck:
@@ -106,4 +105,17 @@ products:
     deck:
     - name: Oath of the Gatewatch Foil Redemption
       set: ogw
-  Oath of the Gatewatch Prerelease Pack: []
+  Oath of the Gatewatch Prerelease Pack:
+    card_count: 1
+    other:
+    - name: 1 Oath of the Gatewatch Spindown
+    pack:
+    - code: prerelease
+      set: ogw
+    sealed:
+    - count: 4
+      name: Oath of the Gatewatch Booster Pack
+      set: ogw
+    - count: 2
+      name: Battle for Zendikar Booster Pack
+      set: bfz

--- a/data/contents/RIX.yaml
+++ b/data/contents/RIX.yaml
@@ -60,5 +60,18 @@ products:
     - count: 1
       name: Rivals of Ixalan Planeswalker Deck Vraska
       set: rix
-  Rivals of Ixalan Prerelease Pack: []
+  Rivals of Ixalan Prerelease Pack:
+    card_count: 1
+    other:
+    - name: 1 Rivals of Ixalan Spindown
+    pack:
+    - code: prerelease
+      set: rix
+    sealed:
+    - count: 4
+      name: Rivals of Ixalan Booster Pack
+      set: rix
+    - count: 2
+      name: Ixalan Booster Pack
+      set: xln
   Rivals of Ixalan Standard Showdown Booster: []

--- a/data/contents/SOI.yaml
+++ b/data/contents/SOI.yaml
@@ -121,4 +121,14 @@ products:
     deck:
     - name: Shadows over Innistrad Foil Redemption
       set: soi
-  Shadows over Innistrad Prerelease Pack: []
+  Shadows over Innistrad Prerelease Pack:
+    card_count: 1
+    other:
+    - name: 1 Shadows over Innistrad Spindown
+    pack:
+    - code: prerelease
+      set: soi
+    sealed:
+    - count: 6
+      name: Shadows over Innistrad Booster Pack
+      set: soi

--- a/data/products/OGW.yaml
+++ b/data/products/OGW.yaml
@@ -49,11 +49,6 @@ products:
       tntId: '1084321'
     release_date: '2016-01-22'
     subtype: FAT_PACK
-  Oath of the Gatewatch Hedron Prerelease Box:
-    category: LIMITED
-    identifiers:
-      tcgplayerProductId: '111283'
-    subtype: PRERELEASE
   Oath of the Gatewatch Intro Pack Concerted Effort:
     category: DECK
     identifiers:
@@ -137,6 +132,7 @@ products:
       cardKingdomId: '205086'
       cardtraderId: '48382'
       mcmId: '287166'
+      tcgplayerProductId: '111283'
       tntId: '1096353'
     release_date: '2015-12-22'
     subtype: PRERELEASE


### PR DESCRIPTION
Wires the previously-empty **Prerelease Pack** products for five 2016-2018 sets to the stamped promo booster (`pack: prerelease`, `card_count: 1`) plus each set's boosters and a spindown — following the already-wired **Dominaria** template. These are all non-seeded, any-color stamped-promo prereleases, so the existing `<set>-prerelease.yaml` boosters need no changes (this is sealed-content only).

## Booster mixes (per the WotC prerelease primers)
| Set | Boosters |
|-----|----------|
| OGW | 4 Oath of the Gatewatch + 2 Battle for Zendikar |
| SOI | 6 Shadows over Innistrad |
| EMN | 4 Eldritch Moon + 2 Shadows over Innistrad |
| HOU | 4 Hour of Devastation + 2 Amonkhet |
| RIX | 4 Rivals of Ixalan + 2 Ixalan |

Also **drops the redundant "Oath of the Gatewatch Hedron Prerelease Box"** — a cosmetic box variant duplicating the Prerelease Pack — from both the contents and products, merging its `tcgplayerProductId` (`111283`) into the Prerelease Pack.

Dominaria (the sixth set requested) was already wired and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)