### PR TITLE
Populate GRN/RNA/STX seeded + THB/M21/KHM/MH2 prerelease products

### DIFF
--- a/data/contents/GRN.yaml
+++ b/data/contents/GRN.yaml
@@ -120,11 +120,61 @@ products:
     - count: 1
       name: Guilds of Ravnica Planeswalker Deck Vraska
       set: grn
-  Guilds of Ravnica Prerelease Pack Boros: []
-  Guilds of Ravnica Prerelease Pack Dimir: []
-  Guilds of Ravnica Prerelease Pack Golgari: []
-  Guilds of Ravnica Prerelease Pack Izzet: []
-  Guilds of Ravnica Prerelease Pack Selesnya: []
+  Guilds of Ravnica Prerelease Pack Boros:
+    card_count: 15
+    other:
+    - name: Guilds of Ravnica Spindown
+    pack:
+    - code: prerelease-boros
+      set: grn
+    sealed:
+    - count: 5
+      name: Guilds of Ravnica Booster Pack
+      set: grn
+  Guilds of Ravnica Prerelease Pack Dimir:
+    card_count: 15
+    other:
+    - name: Guilds of Ravnica Spindown
+    pack:
+    - code: prerelease-dimir
+      set: grn
+    sealed:
+    - count: 5
+      name: Guilds of Ravnica Booster Pack
+      set: grn
+  Guilds of Ravnica Prerelease Pack Golgari:
+    card_count: 15
+    other:
+    - name: Guilds of Ravnica Spindown
+    pack:
+    - code: prerelease-golgari
+      set: grn
+    sealed:
+    - count: 5
+      name: Guilds of Ravnica Booster Pack
+      set: grn
+  Guilds of Ravnica Prerelease Pack Izzet:
+    card_count: 15
+    other:
+    - name: Guilds of Ravnica Spindown
+    pack:
+    - code: prerelease-izzet
+      set: grn
+    sealed:
+    - count: 5
+      name: Guilds of Ravnica Booster Pack
+      set: grn
+  Guilds of Ravnica Prerelease Pack Selesnya:
+    card_count: 15
+    other:
+    - name: Guilds of Ravnica Spindown
+    pack:
+    - code: prerelease-selesnya
+      set: grn
+    sealed:
+    - count: 5
+      name: Guilds of Ravnica Booster Pack
+      set: grn
   Guilds of Ravnica Prerelease Pack Set of 5:
     sealed:
     - count: 1

--- a/data/contents/KHM.yaml
+++ b/data/contents/KHM.yaml
@@ -61,7 +61,17 @@ products:
     deck:
     - name: Kaldheim Foil Redemption
       set: khm
-  Kaldheim Prerelease Pack: []
+  Kaldheim Prerelease Pack:
+    card_count: 1
+    other:
+    - name: Kaldheim Spindown
+    pack:
+    - code: prerelease
+      set: khm
+    sealed:
+    - count: 6
+      name: Kaldheim Draft Booster Pack
+      set: khm
   Kaldheim Set Booster Box:
     sealed:
     - count: 30

--- a/data/contents/M21.yaml
+++ b/data/contents/M21.yaml
@@ -157,7 +157,17 @@ products:
     - count: 1
       name: Core Set 2021 Planeswalker Deck Teferi
       set: m21
-  Core Set 2021 Prerelease Pack: []
+  Core Set 2021 Prerelease Pack:
+    card_count: 1
+    other:
+    - name: Core Set 2021 Spindown
+    pack:
+    - code: prerelease
+      set: m21
+    sealed:
+    - count: 6
+      name: Core Set 2021 Draft Booster Pack
+      set: m21
   Core Set 2021 Welcome Booster:
     card_count: 10
     deck:

--- a/data/contents/MH2.yaml
+++ b/data/contents/MH2.yaml
@@ -55,7 +55,19 @@ products:
     pack:
     - code: draft
       set: mh2
-  Modern Horizons 2 Prerelease Pack: []
+  Modern Horizons 2 Prerelease Pack:
+    card_count: 1
+    other:
+    - name: 5 Non-foil double-sided tokens
+    - name: Deck box
+    - name: Modern Horizons 2 Spindown
+    pack:
+    - code: prerelease
+      set: mh2
+    sealed:
+    - count: 6
+      name: Modern Horizons 2 Draft Booster Pack
+      set: mh2
   Modern Horizons 2 Set Booster Box:
     sealed:
     - count: 30

--- a/data/contents/RNA.yaml
+++ b/data/contents/RNA.yaml
@@ -133,10 +133,50 @@ products:
     - count: 1
       name: Ravnica Allegiance Planeswalker Deck Dovin
       set: rna
-  Ravnica Allegiance Prerelease Pack Azorius: []
-  Ravnica Allegiance Prerelease Pack Gruul: []
-  Ravnica Allegiance Prerelease Pack Orzhov: []
-  Ravnica Allegiance Prerelease Pack Rakdos: []
+  Ravnica Allegiance Prerelease Pack Azorius:
+    card_count: 15
+    other:
+    - name: Ravnica Allegiance Spindown
+    pack:
+    - code: prerelease-azorius
+      set: rna
+    sealed:
+    - count: 5
+      name: Ravnica Allegiance Booster Pack
+      set: rna
+  Ravnica Allegiance Prerelease Pack Gruul:
+    card_count: 15
+    other:
+    - name: Ravnica Allegiance Spindown
+    pack:
+    - code: prerelease-gruul
+      set: rna
+    sealed:
+    - count: 5
+      name: Ravnica Allegiance Booster Pack
+      set: rna
+  Ravnica Allegiance Prerelease Pack Orzhov:
+    card_count: 15
+    other:
+    - name: Ravnica Allegiance Spindown
+    pack:
+    - code: prerelease-orzhov
+      set: rna
+    sealed:
+    - count: 5
+      name: Ravnica Allegiance Booster Pack
+      set: rna
+  Ravnica Allegiance Prerelease Pack Rakdos:
+    card_count: 15
+    other:
+    - name: Ravnica Allegiance Spindown
+    pack:
+    - code: prerelease-rakdos
+      set: rna
+    sealed:
+    - count: 5
+      name: Ravnica Allegiance Booster Pack
+      set: rna
   Ravnica Allegiance Prerelease Pack Set of 5:
     sealed:
     - count: 1
@@ -154,7 +194,17 @@ products:
     - count: 1
       name: Ravnica Allegiance Prerelease Pack Simic
       set: rna
-  Ravnica Allegiance Prerelease Pack Simic: []
+  Ravnica Allegiance Prerelease Pack Simic:
+    card_count: 15
+    other:
+    - name: Ravnica Allegiance Spindown
+    pack:
+    - code: prerelease-simic
+      set: rna
+    sealed:
+    - count: 5
+      name: Ravnica Allegiance Booster Pack
+      set: rna
   Ravnica Allegiance Standard Showdown Booster: []
   Ravnica Allegiance Theme Booster Box:
     sealed:

--- a/data/contents/STX.yaml
+++ b/data/contents/STX.yaml
@@ -56,9 +56,39 @@ products:
     deck:
     - name: 'Strixhaven: School of Mages Foil Redemption'
       set: stx
-  Strixhaven School of Mages Prerelease Pack Lorehold: []
-  Strixhaven School of Mages Prerelease Pack Prismari: []
-  Strixhaven School of Mages Prerelease Pack Quandrix: []
+  Strixhaven School of Mages Prerelease Pack Lorehold:
+    card_count: 15
+    other:
+    - name: Strixhaven Spindown
+    pack:
+    - code: prerelease-lorehold
+      set: stx
+    sealed:
+    - count: 5
+      name: Strixhaven School of Mages Draft Booster Pack
+      set: stx
+  Strixhaven School of Mages Prerelease Pack Prismari:
+    card_count: 15
+    other:
+    - name: Strixhaven Spindown
+    pack:
+    - code: prerelease-prismari
+      set: stx
+    sealed:
+    - count: 5
+      name: Strixhaven School of Mages Draft Booster Pack
+      set: stx
+  Strixhaven School of Mages Prerelease Pack Quandrix:
+    card_count: 15
+    other:
+    - name: Strixhaven Spindown
+    pack:
+    - code: prerelease-quandrix
+      set: stx
+    sealed:
+    - count: 5
+      name: Strixhaven School of Mages Draft Booster Pack
+      set: stx
   Strixhaven School of Mages Prerelease Pack Set of 5:
     sealed:
     - count: 1
@@ -76,8 +106,28 @@ products:
     - count: 1
       name: Strixhaven School of Mages Prerelease Pack Witherbloom
       set: stx
-  Strixhaven School of Mages Prerelease Pack Silverquill: []
-  Strixhaven School of Mages Prerelease Pack Witherbloom: []
+  Strixhaven School of Mages Prerelease Pack Silverquill:
+    card_count: 15
+    other:
+    - name: Strixhaven Spindown
+    pack:
+    - code: prerelease-silverquill
+      set: stx
+    sealed:
+    - count: 5
+      name: Strixhaven School of Mages Draft Booster Pack
+      set: stx
+  Strixhaven School of Mages Prerelease Pack Witherbloom:
+    card_count: 15
+    other:
+    - name: Strixhaven Spindown
+    pack:
+    - code: prerelease-witherbloom
+      set: stx
+    sealed:
+    - count: 5
+      name: Strixhaven School of Mages Draft Booster Pack
+      set: stx
   Strixhaven School of Mages Set Booster Box:
     sealed:
     - count: 30

--- a/data/contents/THB.yaml
+++ b/data/contents/THB.yaml
@@ -91,7 +91,17 @@ products:
     - count: 1
       name: Theros Beyond Death Planeswalker Deck Ashiok
       set: thb
-  Theros Beyond Death Prerelease Pack: []
+  Theros Beyond Death Prerelease Pack:
+    card_count: 1
+    other:
+    - name: Theros Beyond Death Spindown
+    pack:
+    - code: prerelease
+      set: thb
+    sealed:
+    - count: 6
+      name: Theros Beyond Death Draft Booster Pack
+      set: thb
   Theros Beyond Death Prerelease Pack Case: []
   Theros Beyond Death Theme Booster Box:
     sealed:


### PR DESCRIPTION
## Seeded guild/college kits
Each Prerelease Pack = the seeded faction booster (`pack: prerelease-<faction>`) + 5 set boosters + a spindown:
- **GRN**: Boros / Dimir / Golgari / Izzet / Selesnya
- **RNA**: Azorius / Gruul / Orzhov / Rakdos / Simic
- **STX**: Lorehold / Prismari / Quandrix / Silverquill / Witherbloom (College Booster is 15 cards incl. the folded any-color promo)

## Non-seeded stamped-promo packs
`pack: prerelease` (`card_count: 1`) + boosters + spindown, following the Dominaria template:
- **THB**: 6 Draft Boosters
- **M21**: 6 Draft Boosters
- **KHM**: 6 Draft Boosters
- **MH2**: 6 Draft Boosters + 5 double-sided tokens + deck box

Booster collation for the seeded sets comes from taw/magic-search-engine#524. Booster counts per the WotC prerelease primers / WPN product overviews.

> Skipped (no prerelease): Battlebond, Modern Horizons 1, and Commander Legends had no stamped-promo prerelease packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)