### PR TITLE
Fill empty prerelease pack case products (THB/BLB/MSH)

### DIFF
--- a/data/contents/BLB.yaml
+++ b/data/contents/BLB.yaml
@@ -74,7 +74,11 @@ products:
     - count: 6
       name: Bloomburrow Play Booster Pack
       set: blb
-  Bloomburrow Prerelease Pack Case: []
+  Bloomburrow Prerelease Pack Case:
+    sealed:
+    - count: 15
+      name: Bloomburrow Prerelease Pack
+      set: blb
   Bloomburrow Starter Kit:
     card_count: 120
     deck:

--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -30,7 +30,11 @@ products:
     - count: 6
       name: Marvel Super Heroes Play Booster Pack
       set: msh
-  Marvel Super Heroes Prerelease Pack Case: []
+  Marvel Super Heroes Prerelease Pack Case:
+    sealed:
+    - count: 15
+      name: Marvel Super Heroes Prerelease Pack
+      set: msh
   Marvel Super Heroes Scene Box Case: []
   Marvel Super Heroes Scene Box Heroes United: []
   Marvel Super Heroes Scene Box Villains Unleashed: []

--- a/data/contents/THB.yaml
+++ b/data/contents/THB.yaml
@@ -102,7 +102,11 @@ products:
     - count: 6
       name: Theros Beyond Death Draft Booster Pack
       set: thb
-  Theros Beyond Death Prerelease Pack Case: []
+  Theros Beyond Death Prerelease Pack Case:
+    sealed:
+    - count: 18
+      name: Theros Beyond Death Prerelease Pack
+      set: thb
   Theros Beyond Death Theme Booster Box:
     sealed:
     - count: 2


### PR DESCRIPTION
Fills the three empty `Prerelease Pack Case` products with their pack counts. Case size varies by era — **18** packs in the 2020-2021 era (matching the existing ZNR/AFR cases), **15** in 2024+ (matching DSK/FIN/SPM):

| Set | Packs per case |
|-----|----------------|
| Theros Beyond Death | 18 |
| Bloomburrow | 15 |
| Marvel Super Heroes | 15 |

Follow-up to #460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)