### PR TITLE
Populate prerelease pack cases and all missing Fat Packs

### DIFF
--- a/data/contents/BLB.yaml
+++ b/data/contents/BLB.yaml
@@ -74,7 +74,11 @@ products:
     - count: 6
       name: Bloomburrow Play Booster Pack
       set: blb
-  Bloomburrow Prerelease Pack Case: []
+  Bloomburrow Prerelease Pack Case:
+    sealed:
+    - count: 15
+      name: Bloomburrow Prerelease Pack
+      set: blb
   Bloomburrow Starter Kit:
     card_count: 120
     deck:

--- a/data/contents/DKA.yaml
+++ b/data/contents/DKA.yaml
@@ -41,7 +41,16 @@ products:
     - count: 1
       name: Dark Ascension Event Deck Spiraling Doom
       set: dka
-  Dark Ascension Fat Pack: []
+  Dark Ascension Fat Pack:
+    other:
+    - name: Dark Ascension Players Guide
+    - name: 70-card Basic Land Bundle
+    - name: Dark Ascension Spindown Life Counter
+    - name: Two 60-card Deck Boxes
+    sealed:
+    - count: 9
+      name: Dark Ascension Booster Pack
+      set: dka
   Dark Ascension Intro Pack Dark Sacrifice:
     card_count: 60
     deck:

--- a/data/contents/DKA.yaml
+++ b/data/contents/DKA.yaml
@@ -45,6 +45,7 @@ products:
     other:
     - name: Dark Ascension Players Guide
     - name: 70-card Basic Land Bundle
+    - name: 10 checklist cards
     - name: Dark Ascension Spindown Life Counter
     - name: Two 60-card Deck Boxes
     sealed:

--- a/data/contents/EMN.yaml
+++ b/data/contents/EMN.yaml
@@ -15,7 +15,16 @@ products:
     pack:
     - code: draft
       set: emn
-  Eldritch Moon Fat Pack: []
+  Eldritch Moon Fat Pack:
+    other:
+    - name: Eldritch Moon Player's Guide
+    - name: Eldritch Moon Card Box
+    - name: Eldritch Moon 80-card Basic Land Bundle
+    - name: Eldritch Moon Spindown
+    sealed:
+    - count: 9
+      name: Eldritch Moon Booster Pack
+      set: emn
   Eldritch Moon Intro Pack Dangerous Knowledge:
     card_count: 60
     deck:

--- a/data/contents/FRF.yaml
+++ b/data/contents/FRF.yaml
@@ -22,7 +22,17 @@ products:
       set: frf
     - name: Power
       set: frf
-  Fate Reforged Fat Pack: []
+  Fate Reforged Fat Pack:
+    other:
+    - name: Fate Reforged 80-card Basic Land Bundle
+    - name: Fate Reforged Special Edition Spindown
+    - name: Full Art Card Box
+    - name: Two Deck Boxes
+    - name: Player's Guide with Visual Encyclopedia
+    sealed:
+    - count: 9
+      name: Fate Reforged Booster Pack
+      set: frf
   Fate Reforged Intro Pack Cunning Plan:
     card_count: 60
     deck:

--- a/data/contents/ISD.yaml
+++ b/data/contents/ISD.yaml
@@ -42,6 +42,7 @@ products:
     other:
     - name: Innistrad Players Guide
     - name: 70-card Basic Land Bundle
+    - name: 10 checklist cards
     - name: Innistrad Spindown Life Counter
     - name: Two 60-card Deck Boxes
     sealed:

--- a/data/contents/JOU.yaml
+++ b/data/contents/JOU.yaml
@@ -26,7 +26,17 @@ products:
     deck:
     - name: Wrath of the Mortals
       set: jou
-  Journey Into Nyx Fat Pack: []
+  Journey Into Nyx Fat Pack:
+    other:
+    - name: Player's guide with encyclopedia
+    - name: Journey Into Nyx card box
+    - name: 80-card basic land pack
+    - name: Special edition spindown life counter
+    - name: Two deck boxes
+    sealed:
+    - count: 9
+      name: Journey Into Nyx Booster Pack
+      set: jou
   Journey Into Nyx Intro Pack Display:
     sealed:
     - count: 2

--- a/data/contents/KTK.yaml
+++ b/data/contents/KTK.yaml
@@ -20,7 +20,17 @@ products:
     deck:
     - name: Conquering Hordes
       set: ktk
-  Khans of Tarkir Fat Pack: []
+  Khans of Tarkir Fat Pack:
+    other:
+    - name: Khans of Tarkir 80-card Basic Land Bundle
+    - name: Khans of Tarkir Special Edition Spindown
+    - name: Full Art Card Box
+    - name: Two Deck Boxes
+    - name: Player's Guide with Visual Encyclopedia
+    sealed:
+    - count: 9
+      name: Khans of Tarkir Booster Pack
+      set: ktk
   Khans of Tarkir Holiday Gift Box:
     card:
     - foil: true

--- a/data/contents/LRW.yaml
+++ b/data/contents/LRW.yaml
@@ -15,7 +15,20 @@ products:
     pack:
     - code: draft
       set: lrw
-  Lorwyn Fat Pack: []
+  Lorwyn Fat Pack:
+    deck:
+    - name: Lorwyn Fat Pack Land Pack
+      set: lrw
+    other:
+    - name: 2 Card Storage Boxes
+    - name: Lorwyn Spindown
+    - name: One random Pro Tour Player Card
+    - name: The Lorwyn novel
+    - name: Six color-coded plastic card dividers
+    sealed:
+    - count: 6
+      name: Lorwyn Booster Pack
+      set: lrw
   Lorwyn MTGO Redemption:
     card_count: 301
     deck:

--- a/data/contents/M12.yaml
+++ b/data/contents/M12.yaml
@@ -41,7 +41,17 @@ products:
     - count: 1
       name: 2012 Core Set Event Deck Vampire Onslaught
       set: m12
-  2012 Core Set Fat Pack: []
+  2012 Core Set Fat Pack:
+    other:
+    - name: Magic 2012 Card Box
+    - name: Magic 2012 Player's Guide
+    - name: Learn-to-Play Insert
+    - name: 80-card basic land pack
+    - name: Magic 2012 Spindown Life Counter
+    sealed:
+    - count: 9
+      name: 2012 Core Set Booster Pack
+      set: m12
   2012 Core Set Intro Pack Blood and Fire:
     card_count: 60
     deck:

--- a/data/contents/M13.yaml
+++ b/data/contents/M13.yaml
@@ -42,7 +42,17 @@ products:
     - count: 1
       name: 2013 Core Set Event Deck Sweet Revenge
       set: m13
-  2013 Core Set Fat Pack: []
+  2013 Core Set Fat Pack:
+    other:
+    - name: Magic 2013 Player's Guide
+    - name: Magic 2013 Card Box
+    - name: 80-card basic land pack
+    - name: Special edition spindown life counter
+    - name: Two deck boxes
+    sealed:
+    - count: 9
+      name: 2013 Core Set Booster Pack
+      set: m13
   2013 Core Set Intro Pack Depths of Power Blue:
     card_count: 60
     deck:

--- a/data/contents/M14.yaml
+++ b/data/contents/M14.yaml
@@ -23,7 +23,17 @@ products:
     deck:
     - name: Rush of the Wild
       set: m14
-  2014 Core Set Fat Pack: []
+  2014 Core Set Fat Pack:
+    other:
+    - name: Magic 2014 Player's Guide
+    - name: Magic 2014 Card Box
+    - name: 80-card basic land pack
+    - name: Special edition spindown life counter
+    - name: Two deck boxes
+    sealed:
+    - count: 9
+      name: 2014 Core Set Booster Pack
+      set: m14
   2014 Core Set Intro Pack Bestial Strength:
     card_count: 60
     deck:

--- a/data/contents/MBS.yaml
+++ b/data/contents/MBS.yaml
@@ -58,7 +58,18 @@ products:
     - count: 6
       name: Mirrodin Besieged Faction Booster Box
       set: mbs
-  Mirrodin Besieged Fat Pack: []
+  Mirrodin Besieged Fat Pack:
+    other:
+    - name: 80 basic land cards
+    - name: Mirrodin Besieged spindown life counter
+    - name: player's guide
+    - name: learn-to-play insert
+    - name: card storage box
+    - name: two 60-card deck boxes
+    sealed:
+    - count: 9
+      name: Mirrodin Besieged Booster Pack
+      set: mbs
   Mirrodin Besieged Intro Pack Battle Cries:
     card_count: 60
     deck:

--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -30,7 +30,11 @@ products:
     - count: 6
       name: Marvel Super Heroes Play Booster Pack
       set: msh
-  Marvel Super Heroes Prerelease Pack Case: []
+  Marvel Super Heroes Prerelease Pack Case:
+    sealed:
+    - count: 15
+      name: Marvel Super Heroes Prerelease Pack
+      set: msh
   Marvel Super Heroes Scene Box Case: []
   Marvel Super Heroes Scene Box Heroes United: []
   Marvel Super Heroes Scene Box Villains Unleashed: []

--- a/data/contents/OGW.yaml
+++ b/data/contents/OGW.yaml
@@ -15,7 +15,16 @@ products:
     pack:
     - code: draft
       set: ogw
-  Oath of the Gatewatch Fat Pack: []
+  Oath of the Gatewatch Fat Pack:
+    other:
+    - name: Oath of the Gatewatch Player's Guide
+    - name: Oath of the Gatewatch Card Box
+    - name: Oath of the Gatewatch Basic Land Bundle
+    - name: Oath of the Gatewatch Premium Spindown
+    sealed:
+    - count: 9
+      name: Oath of the Gatewatch Booster Pack
+      set: ogw
   Oath of the Gatewatch Intro Pack Concerted Effort:
     card_count: 60
     deck:

--- a/data/contents/ORI.yaml
+++ b/data/contents/ORI.yaml
@@ -23,7 +23,16 @@ products:
     - name: Dangerous
       set: ori
   Magic Origins Deck Builders Toolkit: []
-  Magic Origins Fat Pack: []
+  Magic Origins Fat Pack:
+    other:
+    - name: Magic Origins Player's Guide and Visual Encyclopedia
+    - name: Magic Origins 80-card Land Bundle
+    - name: Special Edition Life Counter
+    - name: Two Deck Boxes
+    sealed:
+    - count: 9
+      name: Magic Origins Booster Pack
+      set: ori
   Magic Origins Intro Pack Assemble Victory:
     card_count: 60
     deck:

--- a/data/contents/RAV.yaml
+++ b/data/contents/RAV.yaml
@@ -25,7 +25,20 @@ products:
     deck:
     - name: 'Ravnica: City of Guilds Foil Redemption'
       set: rav
-  Ravnica Fat Pack: []
+  Ravnica Fat Pack:
+    deck:
+    - name: Ravnica Fat Pack Land Pack
+      set: rav
+    other:
+    - name: 2 Card Storage Boxes
+    - name: One random Pro Tour Player Card
+    - name: The Ravnica City of Guilds novel
+    - name: Six color-coded plastic card dividers
+    - name: Ravnica Life Counter
+    sealed:
+    - count: 6
+      name: Ravnica Booster Pack
+      set: rav
   Ravnica Theme Deck Charge of the Boros:
     card_count: 60
     deck:

--- a/data/contents/RTR.yaml
+++ b/data/contents/RTR.yaml
@@ -48,7 +48,17 @@ products:
     deck:
     - name: Wrack and Rage
       set: rtr
-  Return to Ravnica Fat Pack: []
+  Return to Ravnica Fat Pack:
+    other:
+    - name: Return to Ravnica themed card box
+    - name: Return to Ravnica player's guide
+    - name: Two deck boxes
+    - name: 80-card basic land pack
+    - name: Return to Ravnica spindown
+    sealed:
+    - count: 9
+      name: Return to Ravnica Booster Pack
+      set: rtr
   Return to Ravnica Holiday Gift Box:
     card:
     - foil: true

--- a/data/contents/SHM.yaml
+++ b/data/contents/SHM.yaml
@@ -15,7 +15,19 @@ products:
     pack:
     - code: draft
       set: shm
-  Shadowmoor Fat Pack: []
+  Shadowmoor Fat Pack:
+    deck:
+    - name: Shadowmoor Fat Pack Land Pack
+      set: shm
+    other:
+    - name: Shadowmoor Spindown
+    - name: Card storage box
+    - name: Shadowmoor Novel
+    - name: Random Pro Tour Player Card
+    sealed:
+    - count: 8
+      name: Shadowmoor Booster Pack
+      set: shm
   Shadowmoor MTGO Redemption:
     card_count: 301
     deck:

--- a/data/contents/SOI.yaml
+++ b/data/contents/SOI.yaml
@@ -16,7 +16,16 @@ products:
     - code: draft
       set: soi
   Shadows over Innistrad Deck Builders Toolkit: []
-  Shadows over Innistrad Fat Pack: []
+  Shadows over Innistrad Fat Pack:
+    other:
+    - name: Shadows over Innistrad Player's Guide
+    - name: Shadows over Innistrad Card Box
+    - name: Shadows over Innistrad 80-card Basic Land Bundle
+    - name: Shadows over Innistrad Spindown
+    sealed:
+    - count: 9
+      name: Shadows over Innistrad Booster Pack
+      set: soi
   Shadows over Innistrad Gift Box:
     card:
     - foil: true

--- a/data/contents/SOM.yaml
+++ b/data/contents/SOM.yaml
@@ -20,7 +20,17 @@ products:
     pack:
     - code: draft
       set: som
-  Scars of Mirrodin Fat Pack: []
+  Scars of Mirrodin Fat Pack:
+    other:
+    - name: 40 basic land cards
+    - name: Scars of Mirrodin spindown life counter
+    - name: player's guide
+    - name: card storage box
+    - name: two 60-card deck boxes
+    sealed:
+    - count: 8
+      name: Scars of Mirrodin Booster Pack
+      set: som
   Scars of Mirrodin Intro Pack Deadspread:
     card_count: 60
     deck:

--- a/data/contents/THB.yaml
+++ b/data/contents/THB.yaml
@@ -102,7 +102,11 @@ products:
     - count: 6
       name: Theros Beyond Death Draft Booster Pack
       set: thb
-  Theros Beyond Death Prerelease Pack Case: []
+  Theros Beyond Death Prerelease Pack Case:
+    sealed:
+    - count: 18
+      name: Theros Beyond Death Prerelease Pack
+      set: thb
   Theros Beyond Death Theme Booster Box:
     sealed:
     - count: 2

--- a/data/contents/THS.yaml
+++ b/data/contents/THS.yaml
@@ -21,7 +21,17 @@ products:
     deck:
     - name: Inspiring Heroics
       set: ths
-  Theros Fat Pack: []
+  Theros Fat Pack:
+    other:
+    - name: Player's guide with encyclopedia
+    - name: Theros card box
+    - name: 80-card basic land pack
+    - name: Special edition spindown life counter
+    - name: Two deck boxes
+    sealed:
+    - count: 9
+      name: Theros Booster Pack
+      set: ths
   Theros Holiday Gift Box:
     card:
     - foil: true

--- a/data/contents/TSP.yaml
+++ b/data/contents/TSP.yaml
@@ -15,7 +15,18 @@ products:
     pack:
     - code: draft
       set: tsp
-  Time Spiral Fat Pack: []
+  Time Spiral Fat Pack:
+    other:
+    - name: 2 card deck boxes
+    - name: Player's Guide
+    - name: 40 basic land cards
+    - name: Time Spiral Spindown Life Counter
+    - name: 1 Random Pro Tour player card
+    - name: Time Spiral novel
+    sealed:
+    - count: 6
+      name: Time Spiral Booster Pack
+      set: tsp
   Time Spiral Gift Box: []
   Time Spiral MTGO Redemption:
     card_count: 301


### PR DESCRIPTION
Two batches of contents fills:

**Prerelease pack cases** (THB/BLB/MSH): fill the empty case products with their pack counts.

**All 19 remaining empty Fat Packs** (RAV, TSP, LRW, SHM, SOM, MBS, M12, DKA, RTR, M13, THS, JOU, M14, KTK, FRF, ORI, OGW, SOI, EMN), following each era's populated block-mates and verified against retailer listings and the Bundle wiki page:

- 6 boosters + novel + Pro Tour player card through the Future Sight era
- 8 boosters with 40 lands for SHM and SOM
- 9 boosters with 80 lands from Mirrodin Besieged onward, with the exceptions the sources confirm: the Innistrad block swapped 10 lands for 10 checklist cards (70 lands, now listed on ISD/DKA), and Gatecrash reverted to 40
- RAV, LRW, and SHM reference the "Fat Pack Land Pack" decks now available in magic-preconstructed-decks-data, like their block-mates GPT, MOR, and EVE already do

The research notably confirmed two entries that looked wrong were correct all along: NPH really did have 9 boosters (the 8→9 switch happened at MBS, not ISD), and the GTC=40 / DGM=80 land split is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)