### PR TITLE
Connect the Theros-block Challenge Decks

### DIFF
--- a/data/contents/BNG.yaml
+++ b/data/contents/BNG.yaml
@@ -1,6 +1,10 @@
 code: bng
 products:
-  Battle the Horde Challenge Deck: []
+  Battle the Horde Challenge Deck:
+    card_count: 60
+    deck:
+    - name: Battle the Horde
+      set: tbth
   Born of the Gods Booster Box:
     sealed:
     - count: 36

--- a/data/contents/JOU.yaml
+++ b/data/contents/JOU.yaml
@@ -1,6 +1,10 @@
 code: jou
 products:
-  Defeat a God Challenge Deck: []
+  Defeat a God Challenge Deck:
+    card_count: 60
+    deck:
+    - name: Defeat a God
+      set: tdag
   Journey Into Nyx Booster Box:
     sealed:
     - count: 36

--- a/data/contents/THS.yaml
+++ b/data/contents/THS.yaml
@@ -15,7 +15,11 @@ products:
     pack:
     - code: draft
       set: ths
-  Theros Challenge Deck Face the Hydra: []
+  Theros Challenge Deck Face the Hydra:
+    card_count: 60
+    deck:
+    - name: Face the Hydra
+      set: tfth
   Theros Event Deck Inspiring Heroics:
     card_count: 75
     deck:

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -27,6 +27,9 @@ skip_types = [
     "Shandalar",
     # skip artificial decks
     "Bundle Land Pack",
+    # referenced manually from contents; the products already exist under
+    # names that don't follow this script's naming convention
+    "Challenge Deck",
     # skip randomized decks
     "Clash Pack",
     "Sample Deck",


### PR DESCRIPTION
Fill the three empty Challenge Deck products (Face the Hydra / Battle the Horde / Defeat a God) with deck references to their tfth/tbth/tdag sets.

The decks themselves are added upstream in taw/magic-preconstructed-decks#265 (60-card decklists per the MTG Wiki, cross-checked against the mtgjson TFTH/TBTH/TDAG sets), so this should merge after that lands and decks_v2.json regenerates.

import_new_decks.py skips the new "Challenge Deck" type since these products already exist here under names that don't follow the import's naming convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)