### PR TITLE
Populate welcome decks, deluxe kits, bundles, and the pizza/scene cases

### DIFF
--- a/data/contents/BLC.yaml
+++ b/data/contents/BLC.yaml
@@ -66,7 +66,79 @@ products:
     - count: 1
       name: Bloomburrow Collector Booster Sample Pack
       set: blb
-  Bloomburrow Deluxe Commander Kit Animated Army: []
-  Bloomburrow Deluxe Commander Kit Family Matters: []
-  Bloomburrow Deluxe Commander Kit Peace Offering: []
-  Bloomburrow Deluxe Commander Kit Squirreled Away: []
+  Bloomburrow Deluxe Commander Kit Animated Army:
+    other:
+    - name: Exclusive foil promo card
+    sealed:
+    - count: 1
+      name: Bloomburrow Commander Deck Animated Army
+      set: blc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: Edge of Eternities Play Booster Pack
+      set: eoe
+    - count: 1
+      name: Foundations Play Booster Pack
+      set: fdn
+    - count: 1
+      name: Aetherdrift Play Booster Pack
+      set: dft
+  Bloomburrow Deluxe Commander Kit Family Matters:
+    other:
+    - name: Exclusive foil promo card
+    sealed:
+    - count: 1
+      name: Bloomburrow Commander Deck Family Matters
+      set: blc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: Edge of Eternities Play Booster Pack
+      set: eoe
+    - count: 1
+      name: Foundations Play Booster Pack
+      set: fdn
+    - count: 1
+      name: Aetherdrift Play Booster Pack
+      set: dft
+  Bloomburrow Deluxe Commander Kit Peace Offering:
+    other:
+    - name: Exclusive foil promo card
+    sealed:
+    - count: 1
+      name: Bloomburrow Commander Deck Peace Offering
+      set: blc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: Edge of Eternities Play Booster Pack
+      set: eoe
+    - count: 1
+      name: Foundations Play Booster Pack
+      set: fdn
+    - count: 1
+      name: Aetherdrift Play Booster Pack
+      set: dft
+  Bloomburrow Deluxe Commander Kit Squirreled Away:
+    other:
+    - name: Exclusive foil promo card
+    sealed:
+    - count: 1
+      name: Bloomburrow Commander Deck Squirreled Away
+      set: blc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: Edge of Eternities Play Booster Pack
+      set: eoe
+    - count: 1
+      name: Foundations Play Booster Pack
+      set: fdn
+    - count: 1
+      name: Aetherdrift Play Booster Pack
+      set: dft

--- a/data/contents/HOU.yaml
+++ b/data/contents/HOU.yaml
@@ -15,7 +15,17 @@ products:
     pack:
     - code: draft
       set: hou
-  Hour of Devastation Bundle: []
+  Hour of Devastation Bundle:
+    other:
+    - name: Hour of Devastation 80-card Basic Land Bundle
+    - name: 25 Double-sided Tokens
+    - name: Hour of Devastation Reusable Card Storage Box
+    - name: Hour of Devastation Bundle Spindown
+    - name: Hour of Devastation Players Guide
+    sealed:
+    - count: 10
+      name: Hour of Devastation Booster Pack
+      set: hou
   Hour of Devastation MTGO Redemption:
     card_count: 199
     deck:

--- a/data/contents/RIX.yaml
+++ b/data/contents/RIX.yaml
@@ -15,7 +15,18 @@ products:
     pack:
     - code: draft
       set: rix
-  Rivals of Ixalan Bundle: []
+  Rivals of Ixalan Bundle:
+    other:
+    - name: 1 Card box
+    - name: "1 Player\u2019s Guide with visual encyclopedia for Rivals of Ixalan"
+    - name: 80 Basic land cards
+    - name: 1 Magic learn-to-play guide
+    - name: 1 Spindown life counter
+    - name: 2 Deck boxes
+    sealed:
+    - count: 10
+      name: Rivals of Ixalan Booster Pack
+      set: rix
   Rivals of Ixalan MTGO Redemption:
     card_count: 196
     deck:

--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -228,9 +228,45 @@ products:
     deck:
     - name: White Deck
       set: sos
-  Welcome Deck 2026 Black Deck: {}
-  Welcome Deck 2026 Blue Deck: {}
-  Welcome Deck 2026 Green Deck: {}
-  Welcome Deck 2026 Red Deck: {}
-  Welcome Deck 2026 Set of 5: {}
-  Welcome Deck 2026 White Deck: {}
+  Welcome Deck 2026 Black Deck:
+    card_count: 40
+    deck:
+    - name: Black Deck
+      set: sos
+  Welcome Deck 2026 Blue Deck:
+    card_count: 40
+    deck:
+    - name: Blue Deck
+      set: sos
+  Welcome Deck 2026 Green Deck:
+    card_count: 40
+    deck:
+    - name: Green Deck
+      set: sos
+  Welcome Deck 2026 Red Deck:
+    card_count: 40
+    deck:
+    - name: Red Deck
+      set: sos
+  Welcome Deck 2026 Set of 5:
+    sealed:
+    - count: 1
+      name: Welcome Deck 2026 Black Deck
+      set: sos
+    - count: 1
+      name: Welcome Deck 2026 Blue Deck
+      set: sos
+    - count: 1
+      name: Welcome Deck 2026 Green Deck
+      set: sos
+    - count: 1
+      name: Welcome Deck 2026 Red Deck
+      set: sos
+    - count: 1
+      name: Welcome Deck 2026 White Deck
+      set: sos
+  Welcome Deck 2026 White Deck:
+    card_count: 40
+    deck:
+    - name: White Deck
+      set: sos

--- a/data/contents/SPM.yaml
+++ b/data/contents/SPM.yaml
@@ -103,7 +103,11 @@ products:
     - count: 3
       name: Marvels Spider Man Play Booster Pack
       set: spm
-  Marvels Spider Man Scene Box Case: []
+  Marvels Spider Man Scene Box Case:
+    sealed:
+    - count: 4
+      name: Marvels Spider Man Scene Box
+      set: spm
   Marvels Spider Man Welcome Deck Black:
     deck:
     - name: Black Deck

--- a/data/contents/TMT.yaml
+++ b/data/contents/TMT.yaml
@@ -62,8 +62,24 @@ products:
     deck:
     - name: Enemy Deck
       set: tmt
-  Teenage Mutant Ninja Turtles Pizza Bundle: []
-  Teenage Mutant Ninja Turtles Pizza Bundle Case: []
+  Teenage Mutant Ninja Turtles Pizza Bundle:
+    other:
+    - name: 5 traditional foil full-art pizza basic land cards
+    - name: 25 non-foil full-art pizza basic land cards
+    - name: 2 of 6 pizza-themed promo cards
+    - name: Oversized Pizza Bundle Spindown life counter
+    sealed:
+    - count: 9
+      name: Teenage Mutant Ninja Turtles Play Booster Pack
+      set: tmt
+    - count: 1
+      name: Teenage Mutant Ninja Turtles Collector Booster Pack
+      set: tmt
+  Teenage Mutant Ninja Turtles Pizza Bundle Case:
+    sealed:
+    - count: 6
+      name: Teenage Mutant Ninja Turtles Pizza Bundle
+      set: tmt
   Teenage Mutant Ninja Turtles Play Booster Box:
     sealed:
     - count: 30


### PR DESCRIPTION
Fills 15 empty product-contents entries:

**Deck/booster references (taw-resolved):**
- **SOS Welcome Deck 2026** — five mono-color decks (40 cards each, referencing their taw decklists) plus the Set of 5.
- **BLC Bloomburrow Deluxe Commander Kits** ×4 — each bundles its commander deck with one Bloomburrow, Edge of Eternities, Foundations, and Aetherdrift Play Booster, plus an exclusive foil promo.

**Bundles (verified against retailer listings):**
- **Hour of Devastation** and **Rivals of Ixalan** Bundles — standard 10-booster bundles following their Amonkhet/Ixalan block-mates (HOU ships 25 double-sided tokens).

**Multipacks / specialty:**
- **Marvel's Spider-Man Scene Box Case** — holds 4 Scene Boxes.
- **TMNT Pizza Bundle** — 9 Play Boosters + a Collector Booster, with the full-art pizza basic lands (5 foil + 25 non-foil), 2-of-6 promo cards, and oversized Spindown; the **Pizza Bundle Case** holds 6, matching the regular Bundle Case.

All deck and sealed references validated to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)