### PR TITLE
MBS: map Mirran/Phyrexian faction booster contents

### DIFF
--- a/data/contents/MBS.yaml
+++ b/data/contents/MBS.yaml
@@ -130,8 +130,16 @@ products:
     deck:
     - name: Mirrodin Besieged Foil Redemption
       set: mbs
-  Mirrodin Besieged Mirran Faction Booster Pack: []
-  Mirrodin Besieged Phyrexian Faction Booster Pack: []
+  Mirrodin Besieged Mirran Faction Booster Pack:
+    card_count: 15
+    pack:
+    - code: mirran
+      set: mbs
+  Mirrodin Besieged Phyrexian Faction Booster Pack:
+    card_count: 15
+    pack:
+    - code: phyrexian
+      set: mbs
   Mirrodin Besieged Six Card Booster Pack:
     card_count: 6
     pack:


### PR DESCRIPTION
The two Mirrodin Besieged faction booster packs currently have empty contents (`Mirrodin Besieged Mirran Faction Booster Pack: []` / `Phyrexian ...: []`), showing as gaps in `status.txt`. This maps them to the new faction boosters.

```yaml
Mirrodin Besieged Mirran Faction Booster Pack:
  card_count: 15
  pack:
  - code: mirran
    set: mbs
Mirrodin Besieged Phyrexian Faction Booster Pack:
  card_count: 15
  pack:
  - code: phyrexian
    set: mbs
```

**Dependency:** the `mirran`/`phyrexian` booster codes are added in [taw/magic-search-engine#526](https://github.com/taw/magic-search-engine/pull/526). Until that merges and the daily booster sync runs, the booster-code validation for these two entries won't resolve — so this should land after #526.

Structure matches the existing `Mirrodin Besieged Booster Pack` entry (`code: draft`). Matching product definitions already exist in `data/products/MBS.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)