### PR TITLE
BLB: map Bloomburrow Value Booster contents

### DIFF
--- a/data/contents/BLB.yaml
+++ b/data/contents/BLB.yaml
@@ -131,4 +131,8 @@ products:
     - count: 1
       name: Bloomburrow Tin Skunk
       set: blb
-  Bloomburrow Value Booster: []
+  Bloomburrow Value Booster:
+    card_count: 7
+    pack:
+    - code: value
+      set: blb


### PR DESCRIPTION
The Bloomburrow Value Booster product has empty contents (`Bloomburrow Value Booster: []`), listed in `status.txt` as `blb - Bloomburrow Value Booster missing contents`. This maps it to the new booster.

```yaml
Bloomburrow Value Booster:
  card_count: 7
  pack:
  - code: value
    set: blb
```

**Dependency:** the `value` booster code is added in [taw/magic-search-engine#528](https://github.com/taw/magic-search-engine/pull/528). Until that merges and the daily booster sync runs, the booster-code validation for this entry won't resolve — so this should land after #528.

Structure matches the existing `Bloomburrow Play Booster` pack entry; the matching product definition already exists in `data/products/BLB.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)