### PR TITLE
MSH: map Play/Collector/Jumpstart booster Pack/Box/Case contents

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -4,20 +4,56 @@ products:
   Marvel Super Heroes Beginner Box Case: []
   Marvel Super Heroes Bundle: []
   Marvel Super Heroes Bundle Case: []
-  Marvel Super Heroes Collector Booster Box: []
-  Marvel Super Heroes Collector Booster Box Case: []
+  Marvel Super Heroes Collector Booster Box:
+    sealed:
+    - count: 12
+      name: Marvel Super Heroes Collector Booster Pack
+      set: msh
+  Marvel Super Heroes Collector Booster Box Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Collector Booster Box
+      set: msh
   Marvel Super Heroes Collector Booster Box Master Case: []
-  Marvel Super Heroes Collector Booster Pack: []
+  Marvel Super Heroes Collector Booster Pack:
+    card_count: 15
+    pack:
+    - code: collector
+      set: msh
   Marvel Super Heroes Draft Night: []
   Marvel Super Heroes Draft Night Case: []
   Marvel Super Heroes Gift Bundle: []
   Marvel Super Heroes Gift Bundle Case: []
-  Marvel Super Heroes Jumpstart Booster Box: []
-  Marvel Super Heroes Jumpstart Booster Box Case: []
-  Marvel Super Heroes Jumpstart Booster Pack: []
-  Marvel Super Heroes Play Booster Box: []
-  Marvel Super Heroes Play Booster Box Case: []
-  Marvel Super Heroes Play Booster Pack: []
+  Marvel Super Heroes Jumpstart Booster Box:
+    sealed:
+    - count: 24
+      name: Marvel Super Heroes Jumpstart Booster Pack
+      set: msh
+  Marvel Super Heroes Jumpstart Booster Box Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Jumpstart Booster Box
+      set: msh
+  Marvel Super Heroes Jumpstart Booster Pack:
+    card_count: 20
+    pack:
+    - code: jumpstart
+      set: msh
+  Marvel Super Heroes Play Booster Box:
+    sealed:
+    - count: 30
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
+  Marvel Super Heroes Play Booster Box Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Play Booster Box
+      set: msh
+  Marvel Super Heroes Play Booster Pack:
+    card_count: 14
+    pack:
+    - code: play
+      set: msh
   Marvel Super Heroes Prerelease Pack:
     card_count: 1
     other:


### PR DESCRIPTION
Fills 9 empty `[]` entries for Marvel Super Heroes, wiring the booster chains to the existing `msh-play` / `msh-collector` / `msh-jumpstart` boosters in magic-search-engine.

| Pack (card_count) | Box | Box Case |
|---|---|---|
| Play — 14 (`code: play`) | 30 packs | 6 boxes |
| Collector — 15 (`code: collector`) | 12 packs | 6 boxes |
| Jumpstart — 20 (`code: jumpstart`) | 24 packs | 6 boxes |

Box pack counts from the WPN / retail listings (Play 30, Collector 12, Jumpstart 24); card counts match the boosters. Box cases are the standard 6 boxes.

**Left unmapped:** `Collector Booster Box Master Case` — its per-set count isn't documented (master-case sizes vary), so I left it `[]` rather than guess.

The MSH boosters already exist and MSH is released, so these validate immediately (no cross-repo dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)