### PR TITLE
M15: map the five Prerelease Hunt kit contents

### DIFF
--- a/data/contents/M15.yaml
+++ b/data/contents/M15.yaml
@@ -195,11 +195,61 @@ products:
     deck:
     - name: Magic 2015 Foil Redemption
       set: m15
-  2015 Core Set Prerelease Hunt with Ambition: []
-  2015 Core Set Prerelease Hunt with Ferocity: []
-  2015 Core Set Prerelease Hunt with Guile: []
-  2015 Core Set Prerelease Hunt with Strength: []
-  2015 Core Set Prerelease Hunt with Valor: []
+  2015 Core Set Prerelease Hunt with Ambition:
+    card_count: 15
+    pack:
+    - code: prerelease-ambition
+      set: m15
+    sealed:
+    - count: 5
+      name: 2015 Core Set Booster Pack
+      set: m15
+    other:
+    - name: Spindown die
+  2015 Core Set Prerelease Hunt with Ferocity:
+    card_count: 15
+    pack:
+    - code: prerelease-ferocity
+      set: m15
+    sealed:
+    - count: 5
+      name: 2015 Core Set Booster Pack
+      set: m15
+    other:
+    - name: Spindown die
+  2015 Core Set Prerelease Hunt with Guile:
+    card_count: 15
+    pack:
+    - code: prerelease-guile
+      set: m15
+    sealed:
+    - count: 5
+      name: 2015 Core Set Booster Pack
+      set: m15
+    other:
+    - name: Spindown die
+  2015 Core Set Prerelease Hunt with Strength:
+    card_count: 15
+    pack:
+    - code: prerelease-strength
+      set: m15
+    sealed:
+    - count: 5
+      name: 2015 Core Set Booster Pack
+      set: m15
+    other:
+    - name: Spindown die
+  2015 Core Set Prerelease Hunt with Valor:
+    card_count: 15
+    pack:
+    - code: prerelease-valor
+      set: m15
+    sealed:
+    - count: 5
+      name: 2015 Core Set Booster Pack
+      set: m15
+    other:
+    - name: Spindown die
   2015 Core Set Prerelease Pack Set of 5:
     sealed:
     - count: 1


### PR DESCRIPTION
Fills the five empty `2015 Core Set Prerelease Hunt with …` entries (Ambition / Ferocity / Guile / Strength / Valor). Each kit = its color-seeded prerelease booster + 5 regular boosters + a spindown die, mirroring the Theros "Hero's Path" prerelease kits.

```yaml
2015 Core Set Prerelease Hunt with Ambition:
  card_count: 15
  pack:
  - code: prerelease-ambition
    set: m15
  sealed:
  - count: 5
    name: 2015 Core Set Booster Pack
    set: m15
  other:
  - name: Spindown die
```

**Dependency:** the `prerelease-<path>` booster codes are added in [taw/magic-search-engine#530](https://github.com/taw/magic-search-engine/pull/530). Until that merges and syncs, the booster-code validation for these won't resolve — land this after #530.

The "2015 Core Set Booster Pack" product and the "Prerelease Pack Set of 5" subset (which references these five) already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)