### PR TITLE
GTC: map Booster Battle Pack Display contents

### DIFF
--- a/data/contents/GTC.yaml
+++ b/data/contents/GTC.yaml
@@ -24,7 +24,11 @@ products:
     variable_mode:
       count: 2
       replacement: false
-  Gatecrash Booster Battle Pack Display: []
+  Gatecrash Booster Battle Pack Display:
+    sealed:
+    - count: 12
+      name: Gatecrash Booster Battle Pack
+      set: gtc
   Gatecrash Booster Box:
     sealed:
     - count: 36


### PR DESCRIPTION
The Gatecrash Booster Battle Pack is already mapped (2 boosters + 2 guild battle decks); its Display was empty. Wire it as a display of **12** Booster Battle Packs (per retail listings).

```yaml
Gatecrash Booster Battle Pack Display:
  sealed:
  - count: 12
    name: Gatecrash Booster Battle Pack
    set: gtc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)