### PR TITLE
SOS: de-duplicate the Theme Decks Set of 2 product

### DIFF
--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -3,7 +3,7 @@ products:
   Secrets of Strixhaven 60-Card Theme Deck Display:
     sealed:
     - count: 4
-      name: Secrets of Strixhaven 60-Card Theme Deck Set of 2
+      name: Secrets of Strixhaven Theme Decks Set of 2
       set: sos
   Secrets of Strixhaven 60-Card Theme Deck Display Case:
     sealed:
@@ -30,14 +30,6 @@ products:
     - name: 1 Double-sided reference card
     - name: 1 Strategy insert
     - name: 1 Deck box
-  Secrets of Strixhaven 60-Card Theme Deck Set of 2:
-    sealed:
-    - count: 1
-      name: Secrets of Strixhaven 60-Card Theme Deck Eerie
-      set: sos
-    - count: 1
-      name: Secrets of Strixhaven 60-Card Theme Deck Lifegain
-      set: sos
   Secrets of Strixhaven Bundle:
     card:
     - foil: true


### PR DESCRIPTION
Found during a self-review of the recent contents work.

Commit `7810f74b` introduced a duplicate: it added a `Secrets of Strixhaven 60-Card Theme Deck Set of 2` contents entry (identical to the existing `Secrets of Strixhaven Theme Decks Set of 2`, which is the one defined in `products.yaml` with the marketplace identifiers) and pointed the Theme Deck **Display** at that orphan name.

Result: the Display referenced a product with no `products.yaml` definition — the two `Product name … 60-Card Theme Deck Set of 2 not found in set sos` errors in `status.txt`.

Fix:
- point the Display's `sealed` at the real `Secrets of Strixhaven Theme Decks Set of 2`
- delete the orphan duplicate contents entry

Verified: no products↔contents orphans remain for SOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)