### PR TITLE
SLD: fill in the 2025 bonus cards (TLA Superdrop + Zippy Zombies, 50 products)

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -1804,8 +1804,9 @@ products:
     deck:
     - name: A Devastation of Dragons
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Absolute Annihilation:
     card_count: 4
     deck:
@@ -1867,29 +1868,33 @@ products:
     deck:
     - name: Adventures of the Little Witch
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Adventures of the Little Witch Rainbow Foil:
     card_count: 4
     deck:
     - name: Adventures of the Little Witch Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Aether Drifters:
     card_count: 5
     deck:
     - name: Aether Drifters
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Aether Drifters Foil:
     card_count: 5
     deck:
     - name: Aether Drifters Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Alien Auroras:
     card_count: 5
     deck:
@@ -1947,15 +1952,17 @@ products:
     deck:
     - name: Arcade Racers
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Arcade Racers Rainbow Foil:
     card_count: 5
     deck:
     - name: Arcade Racers Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Artist Series Alayna Danner:
     card:
     - name: Seraph Sanctuary
@@ -3167,15 +3174,17 @@ products:
     deck:
     - name: 'City Styles 2: Dressed to Kill'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop City Styles 2 Dressed to Kill Rainbow Foil:
     card_count: 5
     deck:
     - name: 'City Styles 2: Dressed to Kill Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop City Styles Foil:
     card_count: 5
     deck:
@@ -3799,22 +3808,25 @@ products:
     deck:
     - name: EVERYTHING IS ON FIRE
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop EVERYTHING IS ON FIRE Rainbow Foil:
     card_count: 5
     deck:
     - name: EVERYTHING IS ON FIRE Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop EVERYTHING IS ON FIRE Raised Foil:
     card_count: 5
     deck:
     - name: EVERYTHING IS ON FIRE Raised Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop Eldraine Wonderland:
     card_count: 5
     deck:
@@ -4248,15 +4260,17 @@ products:
     deck:
     - name: 'Featuring: Jay Howell'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop Featuring Jay Howell Rainbow Foil:
     card_count: 5
     deck:
     - name: 'Featuring: Jay Howell Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop Featuring Julie Bell:
     card_count: 5
     deck:
@@ -4314,29 +4328,33 @@ products:
     deck:
     - name: 'Featuring: Luke Pearson'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Featuring Luke Pearson Rainbow Foil:
     card_count: 4
     deck:
     - name: 'Featuring: Luke Pearson Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Featuring Mitsuhiro Arita:
     card_count: 4
     deck:
     - name: 'Featuring: Mitsuhiro Arita'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Featuring Mitsuhiro Arita Rainbow Foil:
     card_count: 4
     deck:
     - name: 'Featuring: Mitsuhiro Arita Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Featuring Not a Wolf:
     card:
     - name: Immerwolf
@@ -4560,15 +4578,17 @@ products:
     deck:
     - name: Garden Buds
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Garden Buds Rainbow Foil:
     card_count: 5
     deck:
     - name: Garden Buds Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Garfield As Intended:
     card:
     - name: Clone
@@ -5212,15 +5232,17 @@ products:
     deck:
     - name: Lorwyn Lightboxes
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Lorwyn Lightboxes Rainbow Foil:
     card_count: 5
     deck:
     - name: Lorwyn Lightboxes Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-feb
+      set: sld
   Secret Lair Drop Magic The Baseballing:
     card_count: 5
     deck:
@@ -5636,16 +5658,18 @@ products:
     deck:
     - name: "Oishii! Tokens \u30AA\u30A4\u30B7\u30A4\uFF01 \u30C8\u30FC\u30AF\u30F3"
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Oishii Tokens Rainbow Foil:
     card_count: 0
     deck:
     - name: "Oishii! Tokens \u30AA\u30A4\u30B7\u30A4\uFF01 \u30C8\u30FC\u30AF\u30F3\
         \ Foil Edition"
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Omens of Chaos:
     card_count: 5
     deck:
@@ -5804,15 +5828,17 @@ products:
     deck:
     - name: Pick 'em & Stick 'em
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Pick Em and Stick Em Rainbow Foil:
     card_count: 9
     deck:
     - name: Pick 'em & Stick 'em Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Pictures of the Floating World:
     card_count: 5
     deck:
@@ -6094,15 +6120,17 @@ products:
     deck:
     - name: 'Secret Lair High: Class of ''87'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Secret Lair High Class of 87 Rainbow Foil:
     card_count: 4
     deck:
     - name: 'Secret Lair High: Class of ''87 Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Secret Lair Promo Cryptic Command:
     card:
     - foil: true
@@ -8460,15 +8488,17 @@ products:
     deck:
     - name: Slay the Day
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop So Salty:
     card_count: 5
     deck:
     - name: So Salty
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Special Guest Fiona Staples:
     card_count: 5
     deck:
@@ -8984,15 +9014,17 @@ products:
     deck:
     - name: 'The Art of Frank Frazetta: The Second Exhibition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-jun
+      set: sld
   Secret Lair Drop The Art of Frank Frazetta The Second Exhibition Rainbow Foil:
     card_count: 5
     deck:
     - name: 'The Art of Frank Frazetta: The Second Exhibition Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-jun
+      set: sld
   Secret Lair Drop The Beauty of the Beasts:
     card_count: 5
     deck:
@@ -9429,15 +9461,17 @@ products:
     deck:
     - name: They Grow Up So Fast
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop They Grow Up So Fast Rainbow Foil:
     card_count: 5
     deck:
     - name: They Grow Up So Fast Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Through the Wormhole:
     card:
     - name: Solemn Simulacrum
@@ -9511,15 +9545,17 @@ products:
     deck:
     - name: Tragic Romance
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Tragic Romance Rainbow Foil:
     card_count: 4
     deck:
     - name: Tragic Romance Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-mar
+      set: sld
   Secret Lair Drop Transformers One Shall Stand One Shall Fall:
     card:
     - name: Command Tower
@@ -9732,8 +9768,9 @@ products:
     deck:
     - name: Viva Las Rakdos
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop We Hope You Like Squirrels:
     card_count: 5
     deck:
@@ -9876,22 +9913,25 @@ products:
     deck:
     - name: vroooOOOMMMMMM!
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop vroooOOOMMMMMM! Rainbow Foil:
     card_count: 5
     deck:
     - name: vroooOOOMMMMMM! Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   Secret Lair Drop vroooOOOMMMMMM! Raised Foil:
     card_count: 5
     deck:
     - name: vroooOOOMMMMMM! Raised Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: zippy-zombies-may
+      set: sld
   "Secret Lair Drop \u201Cexplosion sounds\u201D":
     card_count: 5
     deck:

--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -2654,71 +2654,181 @@ products:
     deck:
     - name: 'Avatar: The Last Airbender: A Lot to Learn'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender A Lot to Learn Foil:
     card_count: 4
     deck:
     - name: 'Avatar: The Last Airbender: A Lot to Learn Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender Everything Changed:
     card_count: 4
     deck:
     - name: 'Avatar: The Last Airbender: Everything Changed'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender Everything Changed Foil:
     card_count: 4
     deck:
     - name: 'Avatar: The Last Airbender: Everything Changed Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender My Cabbages!:
     card_count: 5
     deck:
     - name: 'Avatar: The Last Airbender: My Cabbages!'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender My Cabbages! Foil:
     card_count: 5
     deck:
     - name: 'Avatar: The Last Airbender: My Cabbages! Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender One with the Elements:
     card_count: 6
     deck:
     - name: 'Avatar: The Last Airbender: One with the Elements'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender One with the Elements Foil:
     card_count: 6
     deck:
     - name: 'Avatar: The Last Airbender: One with the Elements Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender The Ember Island Players:
     card_count: 5
     deck:
     - name: 'Avatar: The Last Airbender: The Ember Island Players'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Avatar The Last Airbender The Ember Island Players Foil:
     card_count: 5
     deck:
     - name: 'Avatar: The Last Airbender: The Ember Island Players Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Fellwar Stone
+        number: 7062
+        set: sld
+    - card:
+      - foil: true
+        name: Command Tower
+        number: 7063
+        set: sld
+    variable_mode:
+      count: 1
   Secret Lair Drop Back in My Day!:
     card:
     - name: Utopia Sprawl


### PR DESCRIPTION
Resolves "Bonus card unknown" for all 50 remaining 2025 SLD products, in two commits:

## Avatar: The Last Airbender Superdrop (10 products)
Each drop came with one of two foil bonus cards — **Fellwar Stone [7062]** or **Command Tower [7063]** — at equal odds (Scryfall groups them as "Avatar: The Last Airbender: Bonus Cards"; the wiki lists them as superdrop-wide). Both cards are foil-only, so the bonus is foil in the non-foil editions too.

## Zippy Zombies (40 products)
The Feb–Jun 2025 drops came with a random foil retro-frame Zombie from a per-wave pool (Scryfall's "Zippy Zombies" group, 29 cards). Wired via top-level `pack:` refs (stainedglass-era convention) to the per-wave boosters from taw/magic-search-engine#531:

| Wave | Products | Booster |
|---|---|---|
| February (incl. Devastation of Dragons Rainbow Foil) | 13 | `zippy-zombies-feb` (14 zombies) |
| March/April | 16 | `zippy-zombies-mar` (5) |
| May | 9 | `zippy-zombies-may` (5) |
| June (Frazetta) | 2 | `zippy-zombies-jun` (5) |

Wave membership from mtgjson per-card release dates; drop rates in the boosters are price-estimated (each wave has a clear chase: Wilhelt, Varina, Mikaeus, Rot Hulk).

**Depends on** taw/magic-search-engine#531 for the booster codes to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)