### PR TITLE
SLD: fill in the 2023 bonus cards (44 products)

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -4540,15 +4540,17 @@ products:
     deck:
     - name: Gift Wrapped
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Gift Wrapped Rainbow Foil:
     card_count: 5
     deck:
     - name: Gift Wrapped Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Goblin and Squabblin:
     card_count: 5
     deck:
@@ -5088,15 +5090,17 @@ products:
     deck:
     - name: Lilest Walkers
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Lilest Walkers Rainbow Foil:
     card_count: 5
     deck:
     - name: Lilest Walkers Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Lorwyn Lightboxes:
     card_count: 5
     deck:
@@ -5116,15 +5120,17 @@ products:
     deck:
     - name: 'Magic: The Baseballing'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: baseball-signed
+      set: sld
   Secret Lair Drop Magic The Baseballing Foil:
     card_count: 5
     deck:
     - name: 'Magic: The Baseballing Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: baseball-signed
+      set: sld
   Secret Lair Drop MagicCon The Gathering:
     card_count: 4
     deck:
@@ -5264,15 +5270,17 @@ products:
     deck:
     - name: Meditations on Nature
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Meditations on Nature Foil:
     card_count: 5
     deck:
     - name: Meditations on Nature Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Mirrodinsanity:
     card:
     - name: Darksteel Citadel
@@ -5441,15 +5449,17 @@ products:
     deck:
     - name: Mycosynthwave
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Mycosynthwave Rainbow Foil:
     card_count: 3
     deck:
     - name: Mycosynthwave Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Nature is Adorable:
     card_count: 4
     deck:
@@ -5606,15 +5616,17 @@ products:
     deck:
     - name: Paradise Frost
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Paradise Frost Rainbow Foil:
     card_count: 5
     deck:
     - name: Paradise Frost Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: elusive-elves-early
+      set: sld
   Secret Lair Drop Party Hard Shred Harder:
     card:
     - foil: true

--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -2743,15 +2743,17 @@ products:
     deck:
     - name: Bad to the Bones
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Bad to the Bones Foil:
     card_count: 5
     deck:
     - name: Bad to the Bones Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Bitterblossom Dreams:
     card_count: 6
     deck:
@@ -3099,15 +3101,17 @@ products:
     deck:
     - name: Cool Ocean Breeze
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Cool Ocean Breeze Foil:
     card_count: 4
     deck:
     - name: Cool Ocean Breeze Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Crocodile Jacksons Monstrous Menagerie:
     card:
     - name: Lurking Crocodile
@@ -3429,15 +3433,17 @@ products:
     deck:
     - name: Death Is Temporary, Metal Is Forever
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Death Is Temporary Metal Is Forever Foil:
     card_count: 5
     deck:
     - name: Death Is Temporary, Metal Is Forever Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Deceptive Divination:
     card_count: 5
     deck:
@@ -3486,15 +3492,75 @@ products:
     deck:
     - name: Draw Your Hand
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Draw Your Hand Foil:
     card_count: 4
     deck:
     - name: Draw Your Hand Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Dreaming Darkly:
     card_count: 4
     deck:
@@ -4058,15 +4124,17 @@ products:
     deck:
     - name: 'Featuring: Gary Baseman'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Featuring Gary Baseman Foil:
     card_count: 5
     deck:
     - name: 'Featuring: Gary Baseman Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Featuring Imiri Sakabashira:
     card_count: 4
     deck:
@@ -4556,15 +4624,17 @@ products:
     deck:
     - name: Goblin & Squabblin'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Goblin and Squabblin Foil:
     card_count: 5
     deck:
     - name: Goblin & Squabblin' Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Goblingram:
     card:
     - name: Thrun, the Last Troll
@@ -5014,16 +5084,18 @@ products:
     deck:
     - name: Keep Partying Hard, Shred Harder Than You Previously Thought Possible
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Keep Partying Hard Shred Harder Than You Previously Thought Possible Foil:
     card_count: 4
     deck:
     - name: Keep Partying Hard, Shred Harder Than You Previously Thought Possible
         Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop LOOK AT THE KITTIES:
     card_count: 4
     deck:
@@ -5036,8 +5108,9 @@ products:
     deck:
     - name: Legendary Flyers (Not That Kind)
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Lil Giri Saves the Day Foil:
     card:
     - foil: true
@@ -5120,17 +5193,35 @@ products:
     deck:
     - name: 'Magic: The Baseballing'
       set: sld
-    pack:
-    - code: baseball-signed
-      set: sld
+    variable:
+    - chance: 1
+      pack:
+      - code: baseball-signed
+        set: sld
+    - chance: 99
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Magic The Baseballing Foil:
     card_count: 5
     deck:
     - name: 'Magic: The Baseballing Foil Edition'
       set: sld
-    pack:
-    - code: baseball-signed
-      set: sld
+    variable:
+    - chance: 1
+      pack:
+      - code: baseball-signed
+        set: sld
+    - chance: 99
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop MagicCon The Gathering:
     card_count: 4
     deck:
@@ -5352,8 +5443,9 @@ products:
     deck:
     - name: More Borderless Planeswalkers
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Mothers Day 2021:
     card_count: 4
     deck:
@@ -5465,15 +5557,17 @@ products:
     deck:
     - name: Nature Is Adorable
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Nature is Adorable Foil:
     card_count: 4
     deck:
     - name: Nature Is Adorable Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Notebook Genius:
     card_count: 4
     deck:
@@ -5493,15 +5587,17 @@ products:
     deck:
     - name: Now on VHS!
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Now on VHS Foil:
     card_count: 4
     deck:
     - name: Now on VHS! Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop OMG KITTIES:
     card:
     - foil: true
@@ -5642,15 +5738,75 @@ products:
     deck:
     - name: Phyrexian Faves
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Phyrexian Faves Foil:
     card_count: 5
     deck:
     - name: Phyrexian Faves Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Phyrexian Praetors Compleat Edition:
     card_count: 5
     deck:
@@ -8042,8 +8198,38 @@ products:
     deck:
     - name: 'Showcase: All Will Be One Step-and-Compleat Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Showcase Bloomburrow:
     card_count: 5
     deck:
@@ -8156,22 +8342,25 @@ products:
     deck:
     - name: 'Showcase: March of the Machine Vol. 1'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Showcase March of the Machine Vol 2:
     card_count: 5
     deck:
     - name: 'Showcase: March of the Machine Vol. 2'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Showcase March of the Machine Vol 3:
     card_count: 5
     deck:
     - name: 'Showcase: March of the Machine Vol. 3'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop Showcase Midnight Hunt:
     card_count: 10
     deck:
@@ -8762,15 +8951,75 @@ products:
     deck:
     - name: Ssssssnakessssss
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Ssssssnakessssss Foil:
     card_count: 5
     deck:
     - name: Ssssssnakessssss Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Tales of the Time Stoppers:
     card_count: 4
     deck:
@@ -8853,15 +9102,75 @@ products:
     deck:
     - name: The '90s Binder Experience
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop The 90s Binder Experience Foil:
     card_count: 5
     deck:
     - name: The '90s Binder Experience Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    variable:
+    - card:
+      - foil: true
+        name: Plague Sliver
+        number: 633Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Toxin Sliver
+        number: 635Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Virulent Sliver
+        number: 659Φ
+        set: sld
+      chance: 1
+    - card:
+      - foil: true
+        name: Shadowborn Apostle
+        number: 681Φ
+        set: sld
+      chance: 1
+    - chance: 96
+      pack:
+      - code: surprise-slivers
+        set: sld
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop The Art of Frank Frazetta:
     card:
     - name: Lightning Strike
@@ -9143,15 +9452,17 @@ products:
     deck:
     - name: The Stars Gaze Back
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop The Stars Gaze Back Foil:
     card_count: 4
     deck:
     - name: The Stars Gaze Back Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: surprise-slivers
+      set: sld
   Secret Lair Drop The Strange Sands Forest:
     card_count: 10
     deck:


### PR DESCRIPTION
Resolves "Bonus card unknown" for all 44 remaining 2023 SLD products, in two commits.

## Late-2023 → Elf pool (10 products)
The extended-art Elf era began October 2023, so Lil'est Walkers, Meditations on Nature, Gift Wrapped, Mycosynthwave, and Paradise Frost (×2 finishes each) reference `elusive-elves-early` (from taw/magic-search-engine#532).

## Sliver era (34 products)
The 2022–2023 drops came with a random foil extended-art Sliver (Scryfall's "Surprise Slivers" group), via the `surprise-slivers` booster from taw/magic-search-engine#533:

- **23 products** (Mar–Sep 2023 waves) reference the pool directly
- **9 April 2023 (All Will Be One / Phyrexian) products** additionally carry the four **Phyrexian-language variants** (Plague/Toxin/Virulent Sliver + Shadowborn Apostle, suffix `Φ`, all released with that wave) as 1% chases each
- **Magic: The Baseballing ×2**: the signed reversible baseball-card pack (`baseball-signed`, which existed in taw's repo but was never referenced) is the **1% chase**, with the sliver pool as the regular bonus

Deliberately not covered (not drop bonuses / handled separately later): Shadowborn Apostles & Persistent Petitioners (per-product chases), MagicCon attendee promos (713–717), Jace #8001, SCTLR Counterspell, The Locust God [903].

**Depends on** taw/magic-search-engine#532 and #533 for the booster codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)