### PR TITLE
SLD: fill in the 2021 bonus cards (7 products)

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -8822,9 +8822,20 @@ products:
     deck:
     - name: Teferi's Time Trouble
       set: sld
-    pack:
-    - code: jumpstart-lands
-      set: sld
+    variable:
+    - chance: 98
+      pack:
+      - code: jumpstart-lands
+        set: sld
+    - card:
+      - foil: true
+        name: Persistent Petitioners
+        number: 597
+        set: sld
+      chance: 2
+    variable_mode:
+      count: 1
+      weight: 100
   Secret Lair Drop Thalia Beyond the Helvault:
     card_count: 4
     deck:

--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -5883,15 +5883,17 @@ products:
     deck:
     - name: Purrfection
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: jumpstart-lands
+      set: sld
   Secret Lair Drop Purrfection Foil:
     card_count: 4
     deck:
     - name: Purrfection Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: jumpstart-lands
+      set: sld
   Secret Lair Drop Restless in Peace:
     card_count: 3
     deck:
@@ -8266,15 +8268,17 @@ products:
     deck:
     - name: 'Showcase: Strixhaven'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: jumpstart-lands
+      set: sld
   Secret Lair Drop Showcase Strixhaven Foil:
     card_count: 6
     deck:
     - name: 'Showcase: Strixhaven Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: jumpstart-lands
+      set: sld
   Secret Lair Drop Showcase The Lost Caverns of Ixalan:
     card_count: 5
     deck:
@@ -8400,15 +8404,17 @@ products:
     deck:
     - name: 'Special Guest: Jen Bartel'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: jumpstart-lands
+      set: sld
   Secret Lair Drop Special Guest Jen Bartel Foil:
     card_count: 4
     deck:
     - name: 'Special Guest: Jen Bartel Foil Edition'
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: jumpstart-lands
+      set: sld
   Secret Lair Drop Special Guest Junji Ito English:
     card_count: 4
     deck:
@@ -8816,8 +8822,9 @@ products:
     deck:
     - name: Teferi's Time Trouble
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: jumpstart-lands
+      set: sld
   Secret Lair Drop Thalia Beyond the Helvault:
     card_count: 4
     deck:


### PR DESCRIPTION
The last year of the "Bonus card unknown" sweep — the remaining 2021 unknowns (Showcase Strixhaven ×2, Purrfection ×2, Special Guest Jen Bartel ×2, Teferi's Time Trouble) all fall in the **Foil Jumpstart Lands** era (the bonus basics released Aug–Nov 2021), so they reference the `jumpstart-lands` pool.

**Depends on** taw/magic-search-engine#534 (the Foil Jumpstart Lands booster).

Flagged during review, left alone: the `blueprint-mk2` booster (SLD 691–695, June 2021) exists in taw's repo but is referenced by no product — the June 2021 wave products aren't identifiable from the local release dates; and Squire [59] (rd 2020-09-30) has no wiki/product association.

🤖 Generated with [Claude Code](https://claude.com/claude-code)