### PR TITLE
Fill KLD Holiday Buy-a-Box contents + PRM Behold New Phyrexia release date

### DIFF
--- a/data/contents/KLD.yaml
+++ b/data/contents/KLD.yaml
@@ -97,7 +97,11 @@ products:
     - count: 5
       name: Kaladesh Booster Pack
       set: kld
-  Kaladesh Holiday Buy a Box Promo Pack: []
+  Kaladesh Holiday Buy a Box Promo Pack:
+    card_count: 3
+    pack:
+    - code: buyabox
+      set: kld
   Kaladesh MTGO Redemption:
     card_count: 264
     deck:

--- a/data/products/PRM.yaml
+++ b/data/products/PRM.yaml
@@ -4,4 +4,5 @@ products:
     category: BOX_SET
     identifiers:
       cardtraderId: '270614'
+    release_date: '2023-02-18'
     subtype: SECRET_LAIR


### PR DESCRIPTION
Two small documented gaps from status.txt:

- **KLD Holiday Buy a Box Promo Pack** — was `[]`; map it to the `kld-buyabox` booster (3 cards: 1 foil of any rarity + 2 non-foil rares/mythics). **Depends on [taw/magic-search-engine#527](https://github.com/taw/magic-search-engine/pull/527)** (adds the `buyabox` code); booster-code validation resolves once that merges and syncs.
- **Behold New Phyrexia Limited Edition Set** (PRM) — add `release_date: '2023-02-18'` (Feb 18, 2023), clearing the "missing required release date" status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)