### PR TITLE
MSH: map Collector Booster Box Master Case (24 boxes)

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -14,7 +14,11 @@ products:
     - count: 6
       name: Marvel Super Heroes Collector Booster Box
       set: msh
-  Marvel Super Heroes Collector Booster Box Master Case: []
+  Marvel Super Heroes Collector Booster Box Master Case:
+    sealed:
+    - count: 24
+      name: Marvel Super Heroes Collector Booster Box
+      set: msh
   Marvel Super Heroes Collector Booster Pack:
     card_count: 15
     pack:


### PR DESCRIPTION
Fills the last empty MSH booster-chain entry: the Collector Booster Box Master Case holds **24** Collector Booster Boxes.

```yaml
Marvel Super Heroes Collector Booster Box Master Case:
  sealed:
  - count: 24
    name: Marvel Super Heroes Collector Booster Box
    set: msh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)