### PR TITLE
CLB: drop duplicate Commander Deck Display product

### DIFF
--- a/data/contents/CLB.yaml
+++ b/data/contents/CLB.yaml
@@ -48,20 +48,6 @@ products:
     pack:
     - code: collector-sample
       set: clb
-  Commander Legends Battle for Baldurs Gate Commander Deck Display:
-    sealed:
-    - count: 1
-      name: Commander Legends Battle for Baldurs Gate Commander Deck Draconic Dissent
-      set: clb
-    - count: 1
-      name: Commander Legends Battle for Baldurs Gate Commander Deck Exit from Exile
-      set: clb
-    - count: 1
-      name: Commander Legends Battle for Baldurs Gate Commander Deck Mind Flayarrrs
-      set: clb
-    - count: 1
-      name: Commander Legends Battle for Baldurs Gate Commander Deck Party Time
-      set: clb
   Commander Legends Battle for Baldurs Gate Commander Deck Draconic Dissent:
     card_count: 100
     deck:


### PR DESCRIPTION
Same duplicate pattern as the earlier SOS fix. `contents/CLB.yaml` had **two** entries with identical contents (1 each of the four commander decks):
- `Commander Legends Battle for Baldurs Gate Commander Deck Display`
- `Commander Legends Battle for Baldurs Gate Commander Decks Set of 4`

…but `products.yaml` only defines **Commander Decks Set of 4** (the one with the marketplace identifiers). So the *Display* entry was an orphan with no product definition, producing `Product name … Commander Deck Display not found in set clb` in status.txt. Nothing references it, so I dropped it; **Commander Decks Set of 4** remains as the single, product-backed entry.

Verified: no products↔contents orphans remain for CLB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)