### PR TITLE
SLD: wire the 2026 Handsome Humans bonus pools (16 products)

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -3015,15 +3015,17 @@ products:
     deck:
     - name: Cats of Chaos
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-jun
+      set: sld
   Secret Lair Drop Cats of Chaos Foil:
     card_count: 5
     deck:
     - name: Cats of Chaos Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-jun
+      set: sld
   Secret Lair Drop City Styles:
     card_count: 5
     deck:
@@ -4755,15 +4757,17 @@ products:
     deck:
     - name: Inked
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop Inked Foil:
     card_count: 5
     deck:
     - name: Inked Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop International Womens Day 2020:
     card_count: 5
     deck:
@@ -5150,16 +5154,18 @@ products:
     - name: "Mah\u014D Gakuin Seishun Hakusho \u2014 \u9B54\u6CD5\u5B66\u9662\u9752\
         \u6625\u767D\u66F8"
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   "Secret Lair Drop Mah\u014D Gakuin Seishun Hakusho \u2014 \u9B54\u6CD5\u5B66\u9662\u9752\u6625\u767D\u66F8 Foil":
     card_count: 5
     deck:
     - name: "Mah\u014D Gakuin Seishun Hakusho \u2014 \u9B54\u6CD5\u5B66\u9662\u9752\
         \u6625\u767D\u66F8 Foil Edition"
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop Marvels Deadpool I Fixed It (Youre Welcome):
     card_count: 5
     deck:
@@ -5469,15 +5475,17 @@ products:
     deck:
     - name: Notebook Genius
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop Notebook Genius Foil:
     card_count: 4
     deck:
     - name: Notebook Genius Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop Now on VHS:
     card_count: 4
     deck:
@@ -5541,15 +5549,17 @@ products:
     deck:
     - name: Omens of Chaos
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop Omens of Chaos Foil:
     card_count: 5
     deck:
     - name: Omens of Chaos Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop Ornithological Studies:
     card_count: 5
     deck:
@@ -8912,15 +8922,17 @@ products:
     deck:
     - name: The Eyes Have It
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop The Eyes Have It Foil:
     card_count: 5
     deck:
     - name: The Eyes Have It Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-may
+      set: sld
   Secret Lair Drop The Fairest Drop of All Foil:
     card_count: 4
     deck:
@@ -9366,15 +9378,17 @@ products:
     deck:
     - name: Toby's Journey by Gary Baseman
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-jun
+      set: sld
   Secret Lair Drop Tobys Journey by Gary Baseman Foil:
     card_count: 5
     deck:
     - name: Toby's Journey by Gary Baseman Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-jun
+      set: sld
   Secret Lair Drop Tome of the Astral Sorceress:
     card_count: 4
     deck:
@@ -9691,15 +9705,17 @@ products:
     deck:
     - name: Witch's Familiar
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-jun
+      set: sld
   Secret Lair Drop Witchs Familiar Foil:
     card_count: 5
     deck:
     - name: Witch's Familiar Foil Edition
       set: sld
-    other:
-    - name: Bonus card unknown
+    pack:
+    - code: handsome-humans-jun
+      set: sld
   Secret Lair Drop Wizards of the Street:
     card_count: 4
     deck:


### PR DESCRIPTION
Resolves "Bonus card unknown" for 16 of the remaining 2026 SLD products — the drops without a drop-exclusive bonus, which come with a random foil retro-frame Human (Scryfall's "Handsome Humans" group). Like the 2025 Zippy Zombies, each wave has its own pool, referenced via top-level `pack:` from taw/magic-search-engine#536:

| Pool | Products |
|---|---|
| `handsome-humans-may` | Mahō Gakuin, Notebook Genius, Omens of Chaos, The Eyes Have It (May 12 wave) + Inked (May 29) — ×2 finishes each |
| `handsome-humans-jun` | Cats of Chaos, Toby's Journey by Gary Baseman, Witch's Familiar (June "Cats" wave) — ×2 finishes each |

**Prints Charming ×2 (February 2026) stays unknown** — it predates both Human waves and needs separate evidence.

**Depends on** taw/magic-search-engine#536 for the booster codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
