### PR TITLE
MSH: map the Scene Boxes and Scene Box Case

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -75,9 +75,38 @@ products:
     - count: 15
       name: Marvel Super Heroes Prerelease Pack
       set: msh
-  Marvel Super Heroes Scene Box Case: []
-  Marvel Super Heroes Scene Box Heroes United: []
-  Marvel Super Heroes Scene Box Villains Unleashed: []
+  Marvel Super Heroes Scene Box Case:
+    sealed:
+    - count: 2
+      name: Marvel Super Heroes Scene Box Heroes United
+      set: msh
+    - count: 2
+      name: Marvel Super Heroes Scene Box Villains Unleashed
+      set: msh
+  Marvel Super Heroes Scene Box Heroes United:
+    card_count: 6
+    deck:
+    - name: Heroes United
+      set: msh
+    other:
+    - name: 6 Art-Only Scene Cards
+    - name: Marvel Super Heroes Display Easel
+    sealed:
+    - count: 3
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
+  Marvel Super Heroes Scene Box Villains Unleashed:
+    card_count: 6
+    deck:
+    - name: Villains Unleashed
+      set: msh
+    other:
+    - name: 6 Art-Only Scene Cards
+    - name: Marvel Super Heroes Display Easel
+    sealed:
+    - count: 3
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
   Marvel Super Heroes Welcome Deck Black: {}
   Marvel Super Heroes Welcome Deck Blue: {}
   Marvel Super Heroes Welcome Deck Green: {}


### PR DESCRIPTION
Fills the three empty MSH Scene Box products.

Each **Scene Box** = a 6-card foil borderless scene deck + 6 art-only cards + display easel + **3 Play Boosters** (per Amazon/retail listings), mirroring the FIN scene-box model:

```yaml
Marvel Super Heroes Scene Box Heroes United:
  card_count: 6
  deck:
  - name: Heroes United
    set: msh
  other:
  - name: 6 Art-Only Scene Cards
  - name: Marvel Super Heroes Display Easel
  sealed:
  - count: 3
    name: Marvel Super Heroes Play Booster Pack
    set: msh
```

The **Scene Box Case** holds **4 boxes — two of each type** (2× Heroes United + 2× Villains Unleashed).

**Depends on [taw/magic-preconstructed-decks#268](https://github.com/taw/magic-preconstructed-decks/pull/268)** (adds the two scene decklists, msc 501-512).

🤖 Generated with [Claude Code](https://claude.com/claude-code)