### PR TITLE
MSH: map the Bundle and Draft Night contents

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -2,8 +2,29 @@ code: msh
 products:
   Marvel Super Heroes Beginner Box: []
   Marvel Super Heroes Beginner Box Case: []
-  Marvel Super Heroes Bundle: []
-  Marvel Super Heroes Bundle Case: []
+  Marvel Super Heroes Bundle:
+    card:
+    - foil: true
+      name: The Scarlet Witch
+      number: 431
+      set: msh
+    card_count: 1
+    deck:
+    - name: Marvel Super Heroes Bundle Land Pack
+      set: msh
+    other:
+    - name: Oversized Spindown life counter
+    - name: Card storage box
+    - name: 2 reference cards
+    sealed:
+    - count: 9
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
+  Marvel Super Heroes Bundle Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Bundle
+      set: msh
   Marvel Super Heroes Collector Booster Box:
     sealed:
     - count: 12
@@ -24,8 +45,22 @@ products:
     pack:
     - code: collector
       set: msh
-  Marvel Super Heroes Draft Night: []
-  Marvel Super Heroes Draft Night Case: []
+  Marvel Super Heroes Draft Night:
+    other:
+    - name: 90 basic lands
+    - name: 10 non-foil double-sided tokens
+    sealed:
+    - count: 12
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
+    - count: 1
+      name: Marvel Super Heroes Collector Booster Pack
+      set: msh
+  Marvel Super Heroes Draft Night Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Draft Night
+      set: msh
   Marvel Super Heroes Gift Bundle: []
   Marvel Super Heroes Gift Bundle Case: []
   Marvel Super Heroes Jumpstart Booster Box:


### PR DESCRIPTION
Fills four more MSH products.

**Bundle** (9 Play Boosters, 30 lands, foil promo, accessories):
```yaml
Marvel Super Heroes Bundle:
  card: [{foil: true, name: The Scarlet Witch, number: 431, set: msh}]
  card_count: 1
  deck: [{name: Marvel Super Heroes Bundle Land Pack, set: msh}]
  other: [Oversized Spindown, Card storage box, 2 reference cards]
  sealed: [{count: 9, name: Marvel Super Heroes Play Booster Pack, set: msh}]
```
The land pack is the existing `Marvel Super Heroes Bundle Land Pack` deck (15 foil + 15 nonfoil), and the promo is the traditional-foil **The Scarlet Witch** (msh 431). **Bundle Case = 6.**

**Draft Night** — 12 Play + 1 Collector + 90 basic lands + 10 double-sided tokens (mirrors the SOS Draft Night). **Draft Night Case = 6.**

Contents per the [buyer's guide](https://magic.wizards.com/en/news/feature/marvel-super-heroes-buyers-guide) / retail listings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)