### PR TITLE
MSH: map the Gift Bundle contents

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -26,8 +26,31 @@ products:
       set: msh
   Marvel Super Heroes Draft Night: []
   Marvel Super Heroes Draft Night Case: []
-  Marvel Super Heroes Gift Bundle: []
-  Marvel Super Heroes Gift Bundle Case: []
+  Marvel Super Heroes Gift Bundle:
+    card:
+    - foil: true
+      name: Daredevil, Man Without Fear
+      number: 432
+      set: msh
+    card_count: 1
+    deck:
+    - name: Marvel Super Heroes Bundle Land Pack
+      set: msh
+    other:
+    - name: Spindown life counter
+    - name: Foil card storage box
+    sealed:
+    - count: 9
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
+    - count: 1
+      name: Marvel Super Heroes Collector Booster Pack
+      set: msh
+  Marvel Super Heroes Gift Bundle Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Gift Bundle
+      set: msh
   Marvel Super Heroes Jumpstart Booster Box:
     sealed:
     - count: 24


### PR DESCRIPTION
The Gift Bundle (Gift Edition) = the regular Bundle **plus 1 Collector Booster**, with the **Daredevil, Man Without Fear** (#432) alt-art promo instead of Scarlet Witch, and a foil storage box:

- 9 Play Boosters + 1 Collector Booster
- `Marvel Super Heroes Bundle Land Pack` deck (15 foil + 15 nonfoil)
- foil Daredevil, Man Without Fear (msh 432)
- spindown + foil card storage box

Gift Bundle Case = 6. Contents per the [Gift-vs-Regular breakdown](https://cardgamebase.com/marvel-super-heroes-bundle-contents-gift-vs-regular/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)