### PR TITLE
MSH: map the Beginner Box and Beginner Box Case

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -1,7 +1,39 @@
 code: msh
 products:
-  Marvel Super Heroes Beginner Box: []
-  Marvel Super Heroes Beginner Box Case: []
+  Marvel Super Heroes Beginner Box:
+    card_count: 200
+    deck:
+    - name: Beginner Box - Heroes
+      set: msh
+    - name: Beginner Box - Captain America Tutorial
+      set: msh
+    - name: Beginner Box - Artifacts
+      set: msh
+    - name: Beginner Box - Card Draw
+      set: msh
+    - name: Beginner Box - HYDRA
+      set: msh
+    - name: Beginner Box - Villains
+      set: msh
+    - name: Beginner Box - Iron Man Tutorial
+      set: msh
+    - name: Beginner Box - Young Avengers
+      set: msh
+    - name: Beginner Box - Counters
+      set: msh
+    - name: Beginner Box - Ramp
+      set: msh
+    other:
+    - name: 5 double-sided tokens
+    - name: 2 Gameboard playmats
+    - name: 2 How to Play guides
+    - name: Reference guide booklet
+    - name: 2 Spindown life counters
+  Marvel Super Heroes Beginner Box Case:
+    sealed:
+    - count: 3
+      name: Marvel Super Heroes Beginner Box
+      set: msh
   Marvel Super Heroes Bundle: []
   Marvel Super Heroes Bundle Case: []
   Marvel Super Heroes Collector Booster Box:


### PR DESCRIPTION
The final MSH product. Beginner Box = the **10 themed Jumpstart half-decks (200 cards)** + accessories, mirroring the FDN/TLA Beginner Box model:

```yaml
Marvel Super Heroes Beginner Box:
  card_count: 200
  deck:
  - {name: Beginner Box - Heroes, set: msh}
  - {name: Beginner Box - Captain America Tutorial, set: msh}
  - ... (Artifacts, Card Draw, HYDRA, Villains, Iron Man Tutorial, Young Avengers, Counters, Ramp)
  other: [5 double-sided tokens, 2 Gameboard playmats, 2 How to Play guides, Reference guide booklet, 2 Spindown life counters]
```

Beginner Box Case = **3**.

**Depends on [taw/magic-preconstructed-decks#269](https://github.com/taw/magic-preconstructed-decks/pull/269)** (adds the 10 decklists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)