### PR TITLE
TLA: link Bundle land pack to a deck

### DIFF
--- a/data/contents/TLA.yaml
+++ b/data/contents/TLA.yaml
@@ -42,10 +42,11 @@ products:
       number: 394
       set: tla
     card_count: 1
+    deck:
+    - name: 'Avatar: The Last Airbender Bundle Land Pack'
+      set: tla
     other:
     - name: Avatar The Last Airbender Spindown
-    - name: Avatar The Last Airbender Foil Bundle Land Pack
-    - name: Avatar The Last Airbender Bundle Land Pack
     - name: Avatar The Last Airbender Card Storage Box
     sealed:
     - count: 9
@@ -74,11 +75,11 @@ products:
   Avatar The Last Airbender Commanders Bundle:
     card_count: 13
     deck:
+    - name: 'Avatar: The Last Airbender Bundle Land Pack'
+      set: tla
     - name: Commander's Bundle
       set: tla
     other:
-    - name: 15 Traditional Foil Land cards
-    - name: 15 Land cards
     - name: Click Wheel life counter
     - name: Card storage box
     sealed:


### PR DESCRIPTION
The Avatar: The Last Airbender Bundle listed its land pack as two loose `other:` components:

```yaml
    other:
    - name: Avatar The Last Airbender Foil Bundle Land Pack
    - name: Avatar The Last Airbender Bundle Land Pack
```

Replaces both with a single `deck:` pointer to the combined 30-card `Avatar The Last Airbender Bundle Land Pack` (15 foil + 15 non-foil), matching how other sets model their bundle land packs (one deck carrying both finishes).

The decklist is added in taw/magic-preconstructed-decks#272.