### PR TITLE
TDM: link Bundle land pack to a deck

### DIFF
--- a/data/contents/TDM.yaml
+++ b/data/contents/TDM.yaml
@@ -6,12 +6,11 @@ products:
       name: Temur Battlecrier
       number: 425
       set: tdm
+    deck:
+    - name: 'Tarkir: Dragonstorm Bundle Land Pack'
+      set: tdm
     other:
-    - name: 15 Foil Basic Land Pack
-    - name: 15 Non-Foil Basic Land Pack
     - name: Tarkir Dragonstorm Spindown
-    - name: Tarkir Dragonstorm Foil Bundle Land Pack
-    - name: Tarkir Dragonstorm Bundle Land Pack
     sealed:
     - count: 9
       name: Tarkir Dragonstorm Play Booster Pack


### PR DESCRIPTION
The Tarkir: Dragonstorm Bundle listed its land pack as **four** redundant `other:` lines (`15 Foil Basic Land Pack` + `15 Non-Foil Basic Land Pack` *and* `Tarkir Dragonstorm Foil Bundle Land Pack` + `Tarkir Dragonstorm Bundle Land Pack` — two naming schemes for the same two physical packs).

Consolidated into a single `deck:` pointer to `Tarkir: Dragonstorm Bundle Land Pack` (combined 30-card, 15 foil + 15 non-foil), matching how other sets model their bundle land packs.

Decklist added in taw/magic-preconstructed-decks#273.