### PR TITLE
Add Deck Builder's Toolkit contents for THB and RNA

### DIFF
--- a/data/contents/RNA.yaml
+++ b/data/contents/RNA.yaml
@@ -43,7 +43,24 @@ products:
     pack:
     - code: collector
       set: rna
-  Ravnica Allegiance Deck Builders Toolkit: []
+  Ravnica Allegiance Deck Builders Toolkit:
+    card_count: 225
+    deck:
+    - name: Deck Builder's Toolkit
+      set: rna
+    sealed:
+    - count: 1
+      name: Ravnica Allegiance Booster Pack
+      set: rna
+    - count: 1
+      name: Guilds of Ravnica Booster Pack
+      set: grn
+    - count: 1
+      name: Core Set 2019 Booster Pack
+      set: m19
+    - count: 1
+      name: Dominaria Booster Pack
+      set: dom
   Ravnica Allegiance MTGO Redemption:
     card_count: 259
     deck:

--- a/data/contents/THB.yaml
+++ b/data/contents/THB.yaml
@@ -31,7 +31,24 @@ products:
     pack:
     - code: collector
       set: thb
-  Theros Beyond Death Deck Builders Toolkit: []
+  Theros Beyond Death Deck Builders Toolkit:
+    card_count: 225
+    deck:
+    - name: Deck Builder's Toolkit
+      set: thb
+    sealed:
+    - count: 1
+      name: Theros Beyond Death Draft Booster Pack
+      set: thb
+    - count: 1
+      name: Throne of Eldraine Draft Booster Pack
+      set: eld
+    - count: 1
+      name: Core Set 2020 Booster Pack
+      set: m20
+    - count: 1
+      name: War of the Spark Booster Pack
+      set: war
   Theros Beyond Death Draft Booster Box:
     sealed:
     - count: 36


### PR DESCRIPTION
Fills the empty placeholders for the **Theros Beyond Death** and **Ravnica Allegiance** Deck Builders Toolkits (both flagged as missing contents in `status.txt`).

Each is the all-fixed-era format (matching the M19/M20 toolkits): `card_count: 225`, a `Deck Builder's Toolkit` deck reference, and the four booster packs:
- **THB:** Theros Beyond Death (draft) + Throne of Eldraine (draft) + Core Set 2020 + War of the Spark
- **RNA:** Ravnica Allegiance + Guilds of Ravnica + Core Set 2019 + Dominaria

> **Dependency:** the referenced `Deck Builder's Toolkit` decklists are added in taw/magic-preconstructed-decks#274. This PR's validation will only pass once those decks reach the built `decks_v2.json`, so it should merge after that lands.