### PR TITLE
SPM: link land packs to reusable Bundle Land Pack decks

### DIFF
--- a/data/contents/SPM.yaml
+++ b/data/contents/SPM.yaml
@@ -7,10 +7,13 @@ products:
       number: 285
       set: spm
     card_count: 1
+    deck:
+    - name: Marvel's Spider-Man Foil Bundle Land Pack
+      set: spm
+    - name: Marvel's Spider-Man Bundle Land Pack
+      set: spm
     other:
     - name: Marvels Spider Man Spindown
-    - name: Marvels Spider Man Foil Bundle Land Pack
-    - name: Marvels Spider Man Bundle Land Pack
     - name: Marvels Spider Man Card Storage Box
     sealed:
     - count: 9
@@ -43,8 +46,12 @@ products:
       number: 286
       set: spm
     card_count: 1
+    deck:
+    - name: Marvel's Spider-Man Foil Bundle Land Pack
+      set: spm
+    - name: Marvel's Spider-Man Bundle Land Pack
+      set: spm
     other:
-    - name: 30 Basic Land Pack
     - name: Marvels Spider Man Spindown
     - name: Marvels Spider Man Card Storage Box
     sealed:
@@ -188,9 +195,13 @@ products:
       number: 2025-23
       set: pmei
     card_count: 1
-    other:
-    - name: 15 traditional foil basic lands
-    - name: 30 regular basic lands
+    deck:
+    - name: Marvel's Spider-Man Foil Bundle Land Pack
+      set: spm
+    - name: Marvel's Spider-Man Bundle Land Pack
+      set: spm
+    - name: Marvel's Spider-Man Bundle Land Pack
+      set: spm
     sealed:
     - count: 6
       name: Marvels Spider Man Play Booster Pack


### PR DESCRIPTION
The Marvel's Spider-Man Bundle, Gift Bundle, and (Costco-exclusive) Web-Slingers Kit all build their basic-land content from the same reusable 15-card half packs (one foil, one non-foil, each 5 full-art spiderweb + 10 default-frame). This replaces the loose `other:` land lines with `deck:` pointers, assigning the packs per the collecting-page contents:

| Product | Foil pack | Non-foil pack | = |
|---|---|---|---|
| Bundle | 1 | 1 | 15 foil + 15 non-foil |
| Gift Bundle | 1 | 1 | 15 foil + 15 non-foil |
| Web-Slingers Kit | 1 | 2 | 15 foil + 30 non-foil |

Decks defined in taw/magic-preconstructed-decks#276.