### PR TITLE
Add M13 and M14 Deck Builder's Toolkit contents

### DIFF
--- a/data/contents/M13.yaml
+++ b/data/contents/M13.yaml
@@ -22,7 +22,65 @@ products:
     pack:
     - code: draft
       set: m13
-  2013 Core Set Deck Builders Toolkit: []
+  2013 Core Set Deck Builders Toolkit:
+    card_count: 225
+    deck:
+    - name: Fixed Content
+      set: m13
+    other:
+    - name: Magic 2013 Deck Builder's Guide
+    - name: Magic "Learn to Play" Guide
+    - name: Full-art Reusable Storage Box
+    sealed:
+    - count: 1
+      name: 2013 Core Set Booster Pack
+      set: m13
+    - count: 1
+      name: Innistrad Booster Pack
+      set: isd
+    - count: 1
+      name: Dark Ascension Booster Pack
+      set: dka
+    - count: 1
+      name: Avacyn Restored Booster Pack
+      set: avr
+    variable:
+    - deck:
+      - name: Blue Black Evasion
+        set: m13
+    - deck:
+      - name: Humans
+        set: m13
+    - deck:
+      - name: Library Depletion
+        set: m13
+    - deck:
+      - name: Tokens
+        set: m13
+    - deck:
+      - name: Midrange Green
+        set: m13
+    - deck:
+      - name: Exalted
+        set: m13
+    - deck:
+      - name: Spirits
+        set: m13
+    - deck:
+      - name: Angels
+        set: m13
+    - deck:
+      - name: Vampires
+        set: m13
+    - deck:
+      - name: Zombies
+        set: m13
+    - deck:
+      - name: Red Burn
+        set: m13
+    variable_mode:
+      count: 4
+      replacement: false
   2013 Core Set Event Deck Display:
     sealed:
     - count: 3

--- a/data/contents/M14.yaml
+++ b/data/contents/M14.yaml
@@ -17,7 +17,65 @@ products:
     pack:
     - code: draft
       set: m14
-  2014 Core Set Deck Builders Toolkit: []
+  2014 Core Set Deck Builders Toolkit:
+    card_count: 225
+    deck:
+    - name: Fixed Content
+      set: m14
+    other:
+    - name: Magic 2014 Deck Builder's Guide
+    - name: Magic "Learn to Play" Guide
+    - name: Full-art Reusable Storage Box
+    sealed:
+    - count: 1
+      name: 2014 Core Set Booster Pack
+      set: m14
+    - count: 1
+      name: 2013 Core Set Booster Pack
+      set: m13
+    - count: 1
+      name: Return to Ravnica Booster Pack
+      set: rtr
+    - count: 1
+      name: Gatecrash Booster Pack
+      set: gtc
+    variable:
+    - deck:
+      - name: Life Gain
+        set: m14
+    - deck:
+      - name: Counterburn
+        set: m14
+    - deck:
+      - name: Slivers
+        set: m14
+    - deck:
+      - name: Sacrifice
+        set: m14
+    - deck:
+      - name: Library Depletion
+        set: m14
+    - deck:
+      - name: Red-Green Aggression
+        set: m14
+    - deck:
+      - name: Skies
+        set: m14
+    - deck:
+      - name: Tokens
+        set: m14
+    - deck:
+      - name: Red-White Swarm
+        set: m14
+    - deck:
+      - name: Mana Ramp
+        set: m14
+    - deck:
+      - name: Black Control
+        set: m14
+    variable_mode:
+      count: 4
+      replacement: false
   2014 Core Set Event Deck Rush of the Wild:
     card_count: 75
     deck:


### PR DESCRIPTION
Fills the empty M13 and M14 `Deck Builders Toolkit` placeholders from `status.txt` (semi-random era).

Each is: a `Fixed Content` deck (85 fixed + 100 basics), four booster packs, and the **11 themed "strategy" groups** as `variable` with `variable_mode: {count: 4, replacement: false}` — the box shipped a random **4 distinct groups of 11** (matches the KLD/M15 toolkit convention and the wiki's "4 of 11 strategies").
- **M14** boosters: Magic 2014 + Magic 2013 + Return to Ravnica + Gatecrash
- **M13** boosters: Magic 2013 + Innistrad + Dark Ascension + Avacyn Restored

> **Dependency:** the referenced decklists are in taw/magic-preconstructed-decks#277 and must reach `decks_v2.json` before this validates.

(The M12→M13 toolkit merge that was previously bundled here is now split into #494.)