### PR TITLE
Merge the M12 toolkit into M13 (no distinct 2012 toolkit)

### DIFF
--- a/data/contents/M12.yaml
+++ b/data/contents/M12.yaml
@@ -22,7 +22,6 @@ products:
     pack:
     - code: draft
       set: m12
-  2012 Core Set Deck Builders Toolkit: []
   2012 Core Set Event Deck Illusionary Might:
     card_count: 75
     deck:

--- a/data/products/M12.yaml
+++ b/data/products/M12.yaml
@@ -53,13 +53,6 @@ products:
       tcgplayerProductId: '46956'
       tntId: '319979'
     subtype: DRAFT
-  2012 Core Set Deck Builders Toolkit:
-    category: KIT
-    identifiers:
-      cardtraderId: '47789'
-      mcmId: '261010'
-      tcgplayerProductId: '92504'
-    subtype: DECK_BUILDERS_TOOLKIT
   2012 Core Set Event Deck Illusionary Might:
     category: DECK
     identifiers:

--- a/data/products/M13.yaml
+++ b/data/products/M13.yaml
@@ -61,6 +61,8 @@ products:
     identifiers:
       abuId: '1100362'
       cardKingdomId: '199663'
+      cardtraderId: '47789'
+      mcmId: '261010'
       scgId: SLD-MTG-INT-M13TOOLKIT-EN
       tcgplayerProductId: '245962'
       tntId: '385248'


### PR DESCRIPTION
There is no distinct Magic 2012 Deck Builder's Toolkit — per [mtg.wiki](https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit) it "was synchronized with Magic 2013" and shares its contents. So this:

- removes the empty `2012 Core Set Deck Builders Toolkit` product (`data/products/M12.yaml`) and its contents placeholder (`data/contents/M12.yaml`), and
- merges its marketplace identifiers (`cardtraderId: 47789`, `mcmId: 261010`) into the `2013 Core Set Deck Builders Toolkit` product.

The M12 `tcgplayerProductId 92504` conflicts with M13's `245962`; since identifiers are single-value, M13's is kept — flag if you'd rather use the M12 one.

Independent of the new toolkit-content definitions (separate PR), so this can merge on its own.