### PR TITLE
DMU, SNC, BRO: link bundle land packs to decks

### DIFF
--- a/data/contents/BRO.yaml
+++ b/data/contents/BRO.yaml
@@ -19,8 +19,10 @@ products:
       name: Queen Kayla bin-Kroog
       number: 379
       set: bro
-    other:
+    deck:
     - name: The Brothers' War Bundle Land Pack
+      set: bro
+    other:
     - name: The Brothers' War Spindown Die
     sealed:
     - count: 8
@@ -72,8 +74,10 @@ products:
       name: Queen Kayla bin-Kroog
       number: 379
       set: bro
+    deck:
+    - name: The Brothers' War Bundle Land Pack
+      set: bro
     other:
-    - name: The Brothers' War Gift Bundle Land Pack
     - name: Foil Mythic Rare Transformers Card
     - name: The Brothers' War Spindown Die
     sealed:

--- a/data/contents/DMU.yaml
+++ b/data/contents/DMU.yaml
@@ -11,8 +11,10 @@ products:
       name: Herd Migration
       number: 429
       set: dmu
-    other:
+    deck:
     - name: Dominaria United Bundle Land Pack
+      set: dmu
+    other:
     - name: Dominaria United Spindown
     sealed:
     - count: 8

--- a/data/contents/SNC.yaml
+++ b/data/contents/SNC.yaml
@@ -27,8 +27,10 @@ products:
       name: Mysterious Limousine
       number: 462
       set: snc
-    other:
+    deck:
     - name: Streets of New Capenna Bundle Land Pack
+      set: snc
+    other:
     - name: Streets of New Capenna Spindown
     sealed:
     - count: 8


### PR DESCRIPTION
Each set's Bundle listed its land pack as a loose `other:` component with no card list behind it. This replaces them with `deck:` pointers to the 40-card bundle land packs (20 traditional foil + 20 non-foil).

The Brothers' War **Bundle** and **Gift Bundle** contain identical lands, so both point to the single `The Brothers' War Bundle Land Pack`.

Decklists added in taw/magic-preconstructed-decks#279.