### PR TITLE
WHO: merge Commander Deck Display into Commander Decks Set of 4

### DIFF
--- a/data/contents/WHO.yaml
+++ b/data/contents/WHO.yaml
@@ -34,20 +34,6 @@ products:
     - count: 1
       name: Doctor Who Collector Booster Sample Pack
       set: who
-  Doctor Who Commander Deck Display:
-    sealed:
-    - count: 1
-      name: Doctor Who Commander Deck Blast From the Past
-      set: who
-    - count: 1
-      name: Doctor Who Commander Deck Masters of Evil
-      set: who
-    - count: 1
-      name: Doctor Who Commander Deck Paradox Power
-      set: who
-    - count: 1
-      name: Doctor Who Commander Deck Timey Wimey
-      set: who
   Doctor Who Commander Deck Masters of Evil:
     card_count: 110
     deck:

--- a/data/products/WHO.yaml
+++ b/data/products/WHO.yaml
@@ -54,12 +54,6 @@ products:
       tntId: '1789040'
     release_date: '2023-10-13'
     subtype: COMMANDER
-  Doctor Who Commander Deck Display:
-    category: DECK_BOX
-    identifiers:
-      tcgplayerProductId: '496074'
-    release_date: '2023-10-13'
-    subtype: COMMANDER
   Doctor Who Commander Deck Masters of Evil:
     category: DECK
     identifiers:
@@ -111,6 +105,7 @@ products:
       hareruyaId: '139412'
       mcmId: '711973'
       scgId: SLD-MTG-MLT-WHO-EN-SET4
+      tcgplayerProductId: '496074'
       tntId: '1789041'
     release_date: '2023-10-13'
     subtype: COMMANDER


### PR DESCRIPTION
`Doctor Who Commander Deck Display` and `Doctor Who Commander Decks Set of 4` describe the same product — the four Doctor Who Commander decks — with **identical contents**, but their vendor identifiers were split across the two entries:

- `Commander Deck Display` (DECK_BOX): only `tcgplayerProductId: 496074`
- `Commander Decks Set of 4` (SUBSET): `cardKingdomId`, `cardtraderId`, `csiId`, `hareruyaId`, `mcmId`, `scgId`, `tntId`

This folds the TCGplayer id into `Commander Decks Set of 4` (which now carries all eight ids) and removes the duplicate `Commander Deck Display` from both `products/WHO.yaml` and `contents/WHO.yaml`. No other product referenced the Display entry.