### PR TITLE
Add Magic Origins and Shadows over Innistrad Deck Builder's Toolkit contents

### DIFF
--- a/data/contents/ORI.yaml
+++ b/data/contents/ORI.yaml
@@ -22,7 +22,65 @@ products:
       set: ori
     - name: Dangerous
       set: ori
-  Magic Origins Deck Builders Toolkit: []
+  Magic Origins Deck Builders Toolkit:
+    card_count: 225
+    deck:
+    - name: Fixed Content
+      set: ori
+    other:
+    - name: Magic Origins Deck Builder's Guide
+    - name: Magic "Learn to Play" Guide
+    - name: Full-art Reusable Storage Box
+    sealed:
+    - count: 1
+      name: Journey Into Nyx Booster Pack
+      set: jou
+    - count: 1
+      name: Fate Reforged Booster Pack
+      set: frf
+    - count: 1
+      name: Dragons of Tarkir Booster Pack
+      set: dtk
+    - count: 1
+      name: Magic Origins Booster Pack
+      set: ori
+    variable:
+    - deck:
+      - name: White Black Warriors
+        set: ori
+    - deck:
+      - name: White Black Auras
+        set: ori
+    - deck:
+      - name: White Blue Prowess
+        set: ori
+    - deck:
+      - name: Blue Red Artifacts
+        set: ori
+    - deck:
+      - name: Blue Red Counterburn
+        set: ori
+    - deck:
+      - name: Green Red Beatdown
+        set: ori
+    - deck:
+      - name: Red Burn
+        set: ori
+    - deck:
+      - name: Black Green Toughness
+        set: ori
+    - deck:
+      - name: White Green Aggro
+        set: ori
+    - deck:
+      - name: Blue Black Exploit
+        set: ori
+    - deck:
+      - name: Blue Green Secret Plans Morph
+        set: ori
+    variable_mode:
+      count: 4
+      replacement: false
   Magic Origins Fat Pack:
     other:
     - name: Magic Origins Player's Guide and Visual Encyclopedia

--- a/data/contents/SOI.yaml
+++ b/data/contents/SOI.yaml
@@ -15,7 +15,59 @@ products:
     pack:
     - code: draft
       set: soi
-  Shadows over Innistrad Deck Builders Toolkit: []
+  Shadows over Innistrad Deck Builders Toolkit:
+    card_count: 225
+    deck:
+    - name: Fixed Content
+      set: soi
+    other:
+    - name: Shadows over Innistrad Deck Builder's Guide
+    - name: Magic "Learn to Play" Guide
+    - name: Full-art Reusable Storage Box
+    sealed:
+    - count: 2
+      name: Shadows over Innistrad Booster Pack
+      set: soi
+    - count: 2
+      name: Battle for Zendikar Booster Pack
+      set: bfz
+    variable:
+    - deck:
+      - name: White and Colorless Equipment
+        set: soi
+    - deck:
+      - name: White and Blue Fliers Control
+        set: soi
+    - deck:
+      - name: White and Black Life gain
+        set: soi
+    - deck:
+      - name: White and Green counters
+        set: soi
+    - deck:
+      - name: Blue and Black Control
+        set: soi
+    - deck:
+      - name: Blue and Red Instants and Sorceries
+        set: soi
+    - deck:
+      - name: Blue and Green Creature control
+        set: soi
+    - deck:
+      - name: Black and Red Attrition
+        set: soi
+    - deck:
+      - name: Black and Green Graveyard
+        set: soi
+    - deck:
+      - name: Red and Colorless RampLandfall
+        set: soi
+    - deck:
+      - name: Red and Green Landfall
+        set: soi
+    variable_mode:
+      count: 4
+      replacement: false
   Shadows over Innistrad Fat Pack:
     other:
     - name: Shadows over Innistrad Player's Guide


### PR DESCRIPTION
Fills the `[]` contents placeholders for the **Magic Origins** and **Shadows over Innistrad** Deck Builder's Toolkits (semi-random era, same shape as the M13/M14 toolkits).

Each entry:
- `deck`: **Fixed Content** (85 fixed cards + 100 basics)
- `variable`: the **11 themed strategy groups** of 10, with `variable_mode: {count: 4, replacement: false}` (box shipped a random 4 of 11)
- `card_count: 225` = 185 Fixed Content + 4×10 drawn (matches M13/M14/M15)
- `other`: deck builder's guide, learn-to-play guide, storage box
- `sealed` (per mtg.wiki):
  - **ORI**: 1 each Journey Into Nyx, Fate Reforged, Dragons of Tarkir, Magic Origins
  - **SOI**: 2× Shadows over Innistrad + 2× Battle for Zendikar

**Depends on** taw/magic-preconstructed-decks#278, which adds the referenced `Fixed Content` and strategy-group decklists. Every `variable` deck name was cross-checked against the decklist filenames.