### PR TITLE
RTR, THS, KTK, SOI, BFZ: link gift box land packs to decks

### DIFF
--- a/data/contents/BFZ.yaml
+++ b/data/contents/BFZ.yaml
@@ -36,11 +36,13 @@ products:
       name: Scythe Leopard
       number: 188
       set: pbfz
+    deck:
+    - name: Battle for Zendikar Gift Box Land Pack
+      set: bfz
     other:
     - name: Battle for Zendikar Storage Box
     - name: Illustrated Storage Dividers
     - name: Stickers for Customizing the Dividers
-    - name: Battle for Zendikar 20-card Basic Land Pack
     sealed:
     - count: 5
       name: Battle for Zendikar Booster Pack

--- a/data/contents/KTK.yaml
+++ b/data/contents/KTK.yaml
@@ -38,8 +38,10 @@ products:
       number: 204
       set: pktk
     card_count: 1
+    deck:
+    - name: Khans of Tarkir Holiday Gift Box Land Pack
+      set: ktk
     other:
-    - name: Land Pack
     - name: Dividers
     - name: Stickers
     sealed:

--- a/data/contents/RTR.yaml
+++ b/data/contents/RTR.yaml
@@ -66,8 +66,10 @@ products:
       number: 158
       set: prtr
     card_count: 1
+    deck:
+    - name: Return to Ravnica Holiday Gift Box Land Pack
+      set: rtr
     other:
-    - name: Land Pack
     - name: Dividers
     - name: Stickers
     sealed:

--- a/data/contents/SOI.yaml
+++ b/data/contents/SOI.yaml
@@ -33,8 +33,10 @@ products:
       number: 175
       set: psoi
     card_count: 1
+    deck:
+    - name: Shadows over Innistrad Gift Box Land Pack
+      set: soi
     other:
-    - name: Land Pack
     - name: Dividers
     - name: Stickers
     sealed:

--- a/data/contents/THS.yaml
+++ b/data/contents/THS.yaml
@@ -43,8 +43,10 @@ products:
       number: 160
       set: pths
     card_count: 1
+    deck:
+    - name: Theros Holiday Gift Box Land Pack
+      set: ths
     other:
-    - name: Land Pack
     - name: Dividers
     - name: Stickers
     sealed:


### PR DESCRIPTION
Each Holiday/Gift Box listed its 20-card basic land pack as a loose `other:` component (`Land Pack`, or for BFZ `Battle for Zendikar 20-card Basic Land Pack`) with no card list behind it. This replaces them with `deck:` pointers to per-set gift box land packs (20 non-foil basics each).

BFZ's pack uses the set's full-art lands; the other four are default-frame `[SET:*]` round-robins.

Decklists added in taw/magic-preconstructed-decks#280.