### PR TITLE
Add Marvel Super Heroes Draft Night contents

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -66,8 +66,24 @@ products:
     pack:
     - code: collector
       set: msh
-  Marvel Super Heroes Draft Night: []
-  Marvel Super Heroes Draft Night Case: []
+  Marvel Super Heroes Draft Night:
+    deck:
+    - name: Marvel Super Heroes Draft Night Land Pack
+      set: msh
+    other:
+    - name: 1 Draft insert
+    sealed:
+    - count: 12
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
+    - count: 1
+      name: Marvel Super Heroes Collector Booster Pack
+      set: msh
+  Marvel Super Heroes Draft Night Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Draft Night
+      set: msh
   Marvel Super Heroes Gift Bundle:
     card:
     - foil: true


### PR DESCRIPTION
Fills the `[]` contents placeholders for the two **Marvel Super Heroes Draft Night** products (the last Draft Night missing contents apart from The Hobbit).

Draft Night is the standardized WPN Pick-Two draft kit, modeled the same way as the Lorwyn Eclipsed / Secrets of Strixhaven / Teenage Mutant Ninja Turtles entries:

- **Draft Night** — `other`: 90 non-foil basic lands + 1 draft insert; `sealed`: 12× Play Booster + 1× Collector Booster (the packed-in winner's prize).
- **Draft Night Case** — 6× Draft Night.

The `10 double-sided tokens` line from the generic kit description is **omitted**: the Marvel Super Heroes token set (`tmsh`) contains 21 tokens, none double-faced — matching how SOS and TMT (which also lack DFC tokens) drop that line. All referenced booster products exist in `data/products/MSH.yaml`.