### PR TITLE
ELD, IKO, M21, MH2: link bundle land packs to decks

### DIFF
--- a/data/contents/ELD.yaml
+++ b/data/contents/ELD.yaml
@@ -62,9 +62,10 @@ products:
       name: Piper of the Swarm
       number: 392
       set: eld
+    deck:
+    - name: Throne of Eldraine Bundle Land Pack
+      set: eld
     other:
-    - name: 20 foil basic lands
-    - name: 20 nonfoil basic lands
     - name: Throne of Eldraine oversized spindown
     - name: Reusable card storage box
     sealed:
@@ -136,9 +137,10 @@ products:
       name: Piper of the Swarm
       number: 392
       set: eld
+    deck:
+    - name: Throne of Eldraine Bundle Land Pack
+      set: eld
     other:
-    - name: 20 foil basic lands
-    - name: 20 nonfoil basic lands
     - name: Throne of Eldraine oversized spindown
     - name: Reusable card storage box
     sealed:

--- a/data/contents/IKO.yaml
+++ b/data/contents/IKO.yaml
@@ -11,9 +11,10 @@ products:
       name: Colossification
       number: 364
       set: iko
+    deck:
+    - name: 'Ikoria: Lair of Behemoths Bundle Land Pack'
+      set: iko
     other:
-    - name: 20 foil basic lands
-    - name: 20 nonfoil basic lands
     - name: Ikoria oversized spindown
     - name: Reusable card storage box
     sealed:

--- a/data/contents/M21.yaml
+++ b/data/contents/M21.yaml
@@ -29,9 +29,10 @@ products:
       name: Pack Leader
       number: 392
       set: m21
+    deck:
+    - name: Core Set 2021 Bundle Land Pack
+      set: m21
     other:
-    - name: Core Set 2021 20-card Basic Land Bundle Non-Foil
-    - name: Core Set 2021 20-card Basic Land Bundle Foil
     - name: Core Set 2021 Spindown
     - name: Reusable Storage Box
     sealed:

--- a/data/contents/MH2.yaml
+++ b/data/contents/MH2.yaml
@@ -11,9 +11,10 @@ products:
       name: Yusri, Fortune's Flame
       number: 492
       set: mh2
+    deck:
+    - name: Modern Horizons 2 Bundle Land Pack
+      set: mh2
     other:
-    - name: Modern Horizons 2 20-card Basic Land Bundle Non-Foil
-    - name: Modern Horizons 2 20-card Basic Land Bundle Foil
     - name: Modern Horizons 2 Spindown
     - name: Reusable Storage Box
     sealed:


### PR DESCRIPTION
Each Bundle described its 40 basic lands (20 traditional foil + 20 non-foil) as loose `other:` lines with no card list behind them. This replaces them with `deck:` pointers to per-set bundle land packs.

Throne of Eldraine's **Bundle** and **Gift Bundle** contain the same lands, so both point to the single `Throne of Eldraine Bundle Land Pack`.

Decklists added in taw/magic-preconstructed-decks#282.