### PR TITLE
XLN, RIX, DOM, WAR, M19, KLD: link bundle/gift box land packs to decks

### DIFF
--- a/data/contents/DOM.yaml
+++ b/data/contents/DOM.yaml
@@ -17,10 +17,12 @@ products:
     - code: draft
       set: dom
   Dominaria Bundle:
+    deck:
+    - name: Dominaria Bundle Land Pack
+      set: dom
     other:
     - name: 1 card box
     - name: "1 player\u2019s guide"
-    - name: 80-card land pack
     - name: 1 learn-to-play insert
     - name: "1 Spindown\u2122 life counter"
     - name: 1 Menu booklet

--- a/data/contents/KLD.yaml
+++ b/data/contents/KLD.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: kld
   Kaladesh Bundle:
+    deck:
+    - name: Kaladesh Bundle Land Pack
+      set: kld
     other:
     - name: Card Storage Box
     - name: Player's Guide and Visual Encyclopaedia
-    - name: Kaladesh 80-card Basic Land Bundle
     - name: Magic Learn-to-Play Guide
     - name: Kaladesh Bundle Spindown
     sealed:
@@ -88,8 +90,10 @@ products:
       name: Chief of the Foundry
       number: 200
       set: pkld
+    deck:
+    - name: Kaladesh Gift Box Land Pack
+      set: kld
     other:
-    - name: Kaladesh 20-card Basic Land Bundle
     - name: Card Storage Box
     - name: Six Illustrated Plastic Dividers
     - name: Kaladesh Sticker Sheet

--- a/data/contents/M19.yaml
+++ b/data/contents/M19.yaml
@@ -16,8 +16,10 @@ products:
     - code: draft
       set: m19
   Core Set 2019 Bundle:
+    deck:
+    - name: Core Set 2019 Bundle Land Pack
+      set: m19
     other:
-    - name: Basic Land Pack
     - name: Reusable Card Storage Box
     - name: Player's Guide
     - name: Core Set 2019 Spindown Life Counter

--- a/data/contents/RIX.yaml
+++ b/data/contents/RIX.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: rix
   Rivals of Ixalan Bundle:
+    deck:
+    - name: Rivals of Ixalan Bundle Land Pack
+      set: rix
     other:
     - name: 1 Card box
     - name: "1 Player\u2019s Guide with visual encyclopedia for Rivals of Ixalan"
-    - name: 80 Basic land cards
     - name: 1 Magic learn-to-play guide
     - name: 1 Spindown life counter
     - name: 2 Deck boxes

--- a/data/contents/WAR.yaml
+++ b/data/contents/WAR.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: war
   War of the Spark Bundle:
+    deck:
+    - name: War of the Spark Bundle Land Pack
+      set: war
     other:
     - name: 1 card box
     - name: "1 player\u2019s guide"
-    - name: 80-card land pack
     - name: 1 learn-to-play insert
     - name: 1 Spindown life counter
     sealed:

--- a/data/contents/XLN.yaml
+++ b/data/contents/XLN.yaml
@@ -46,10 +46,12 @@ products:
     - code: draft
       set: xln
   Ixalan Bundle:
+    deck:
+    - name: Ixalan Bundle Land Pack
+      set: xln
     other:
     - name: 1 Card box
     - name: "1 Player\u2019s Guide with visual encyclopedia for Ixalan"
-    - name: 80 Basic land cards
     - name: 1 Magic learn-to-play guide
     - name: 1 Spindown life counter
     - name: 2 Deck boxes


### PR DESCRIPTION
Each product described its basic land pack as a loose `other:` line — an 80-card pack for the pre-2019 bundles (Ixalan, Rivals of Ixalan, Dominaria, War of the Spark, Core Set 2019, Kaladesh) and a 20-card pack for the Kaladesh Gift Box. This replaces them with `deck:` pointers to per-set land packs.

Decklists added in taw/magic-preconstructed-decks#283.