### PR TITLE
NEO, LTR, MOM, ONE, WOE, SOS: link bundle land packs to decks

### DIFF
--- a/data/contents/LTR.yaml
+++ b/data/contents/LTR.yaml
@@ -28,8 +28,10 @@ products:
       name: The One Ring
       number: 451
       set: ltr
+    deck:
+    - name: 'The Lord of the Rings: Tales of Middle-earth Bundle Land Pack'
+      set: ltr
     other:
-    - name: Tales of Middle Earth 40-card Land Bundle
     - name: Tales of Middle Earth Premium Spindown
     sealed:
     - count: 8
@@ -99,8 +101,10 @@ products:
       name: The One Ring
       number: 451
       set: ltr
+    deck:
+    - name: 'The Lord of the Rings: Tales of Middle-earth Bundle Land Pack'
+      set: ltr
     other:
-    - name: Tales of Middle Earth 40-card Land Bundle
     - name: Tales of Middle Earth Gift Bundle Spindown
     sealed:
     - count: 8

--- a/data/contents/MOM.yaml
+++ b/data/contents/MOM.yaml
@@ -6,8 +6,10 @@ products:
       name: Ghalta and Mavren
       number: 386
       set: mom
+    deck:
+    - name: 'March of the Machine Bundle Land Pack'
+      set: mom
     other:
-    - name: March of the Machine Land Bundle
     - name: March of the Machine 20-sided die
     sealed:
     - count: 8

--- a/data/contents/NEO.yaml
+++ b/data/contents/NEO.yaml
@@ -11,8 +11,10 @@ products:
       name: Invoke Despair
       number: 506
       set: neo
+    deck:
+    - name: 'Kamigawa: Neon Dynasty Bundle Land Pack'
+      set: neo
     other:
-    - name: Kamigawa Neon Dynasty Land Bundle
     - name: Kamigawa Neon Dynasty Spindown
     sealed:
     - count: 8

--- a/data/contents/ONE.yaml
+++ b/data/contents/ONE.yaml
@@ -6,8 +6,10 @@ products:
       name: Karumonix, the Rat King
       number: 282
       set: one
+    deck:
+    - name: 'Phyrexia: All Will Be One Bundle Land Pack'
+      set: one
     other:
-    - name: Phyrexia All Will Be One Bundle Land Pack
     - name: Phyrexia All Will Be One Spindown
     sealed:
     - count: 8

--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -37,6 +37,9 @@ products:
       number: 368
       set: sos
     card_count: 1
+    deck:
+    - name: 'Secrets of Strixhaven Bundle Land Pack'
+      set: sos
     other:
     - name: 1 Spindown die
     - name: 1 Card-storage box

--- a/data/contents/WOE.yaml
+++ b/data/contents/WOE.yaml
@@ -16,8 +16,10 @@ products:
       name: Lich-Knights' Conquest
       number: 380
       set: woe
+    deck:
+    - name: 'Wilds of Eldraine Bundle Land Pack'
+      set: woe
     other:
-    - name: 40 basic lands (20 Traditional Foil + 20 nonfoil)
     - name: Spindown life counter
     - name: card storage box
     - name: 2 reference cards


### PR DESCRIPTION
Points each set's Bundle basic-land component at a `deck:` (default-frame basics — the sets' full-art lands are booster-exclusive, confirmed per set).

- **LTR** Bundle and Gift Bundle share the same lands → both point to one deck.
- Only the standard bundles are linked; the **ONE Compleat Bundle** and **SOS Codex Bundle** have distinct land packs and are left untouched.

Decklists added in taw/magic-preconstructed-decks#284.