### PR TITLE
ZEN, AKH, HOU, ACR, FDN, DFT, DSK, EOE, ECL, WWK: link full-art land packs

### DIFF
--- a/data/contents/ACR.yaml
+++ b/data/contents/ACR.yaml
@@ -22,8 +22,10 @@ products:
       number: 306
       set: acr
     card_count: 1
+    deck:
+    - name: "Assassin's Creed Bundle Land Pack"
+      set: acr
     other:
-    - name: 40 card land Pack
     - name: Assassin's Creed spindown
     sealed:
     - count: 9

--- a/data/contents/AKH.yaml
+++ b/data/contents/AKH.yaml
@@ -41,8 +41,10 @@ products:
     - code: draft
       set: akh
   Amonkhet Bundle:
+    deck:
+    - name: "Amonkhet Bundle Land Pack"
+      set: akh
     other:
-    - name: Amonkhet 80-card Basic Land Bundle
     - name: 20 Double-sided Tokens
     - name: Amonkhet Reusable Card Storage Box
     - name: Amonkhet Bundle Spindown

--- a/data/contents/DFT.yaml
+++ b/data/contents/DFT.yaml
@@ -11,8 +11,10 @@ products:
       name: Lumbering Worldwagon
       number: 422
       set: dft
+    deck:
+    - name: "Aetherdrift Bundle Land Pack"
+      set: dft
     other:
-    - name: 40 Basic Lands Bundle
     - name: 2 Reference Cards
     - name: 1 Spindown Die
     - name: Aetherdrift Card Storage Box

--- a/data/contents/DSK.yaml
+++ b/data/contents/DSK.yaml
@@ -6,8 +6,10 @@ products:
       name: Grievous Wound
       number: 416
       set: dsk
+    deck:
+    - name: "Duskmourn: House of Horror Bundle Land Pack"
+      set: dsk
     other:
-    - name: 30 basic lands
     - name: Duskmourn Spindown
     - name: Deck Box
     sealed:

--- a/data/contents/ECL.yaml
+++ b/data/contents/ECL.yaml
@@ -43,6 +43,9 @@ products:
       number: 407
       set: ecl
     card_count: 1
+    deck:
+    - name: "Lorwyn Eclipsed Bundle Land Pack"
+      set: ecl
     other:
     - name: 2 Reference cards
     - name: 1 Spindown die

--- a/data/contents/EOE.yaml
+++ b/data/contents/EOE.yaml
@@ -7,11 +7,10 @@ products:
       number: 399
       set: eoe
     card_count: 1
+    deck:
+    - name: "Edge of Eternities Bundle Land Pack"
+      set: eoe
     other:
-    - name: 10 Nonfoil Basic Lands
-    - name: 10 Foil Basic Lands
-    - name: 5 Nonfoil Full-art Basic Lands
-    - name: 5 Foil Full-art Basic Lands
     - name: Edge of Eternities Spindown
     - name: Edge of Eternities Card Storage Box
     sealed:

--- a/data/contents/FDN.yaml
+++ b/data/contents/FDN.yaml
@@ -40,8 +40,10 @@ products:
       name: Phyrexian Arena
       number: 728
       set: fdn
+    deck:
+    - name: "Foundations Bundle Land Pack"
+      set: fdn
     other:
-    - name: 40 basic land pack
     - name: Oversize spindown life counter
     - name: Deck box
     sealed:

--- a/data/contents/HOU.yaml
+++ b/data/contents/HOU.yaml
@@ -16,8 +16,10 @@ products:
     - code: draft
       set: hou
   Hour of Devastation Bundle:
+    deck:
+    - name: "Hour of Devastation Bundle Land Pack"
+      set: hou
     other:
-    - name: Hour of Devastation 80-card Basic Land Bundle
     - name: 25 Double-sided Tokens
     - name: Hour of Devastation Reusable Card Storage Box
     - name: Hour of Devastation Bundle Spindown

--- a/data/contents/WWK.yaml
+++ b/data/contents/WWK.yaml
@@ -16,13 +16,15 @@ products:
     - code: draft
       set: wwk
   Worldwake Fat Pack:
+    deck:
+    - name: "Zendikar Fat Pack Land Pack"
+      set: zen
     other:
     - name: One card box with panoramic art
     - name: The Worldwake Player's Guide
     - name: A learn-to-play insert
     - name: An excerpt from In the Teeth of Akoum
     - name: An exclusive Worldwake Spindown Life Counter
-    - name: 40 Zendikar extended art basic lands
     sealed:
     - count: 8
       name: Worldwake Booster Pack

--- a/data/contents/ZEN.yaml
+++ b/data/contents/ZEN.yaml
@@ -21,10 +21,12 @@ products:
     - code: draft
       set: zen
   Zendikar Fat Pack:
+    deck:
+    - name: "Zendikar Fat Pack Land Pack"
+      set: zen
     other:
     - name: Zendikar life counter
     - name: Player's Guide
-    - name: 40 card land pack
     - name: 2 Collectible Boxes
     sealed:
     - count: 8


### PR DESCRIPTION
Points each set's standard Bundle/Fat Pack basic-land pack at a `deck:`. These packs contain the set's full-art basics (some mixed with default-frame — EOE's four land lines, "10 Nonfoil / 10 Foil / 5 Nonfoil Full-art / 5 Foil Full-art", are consolidated into the one deck).

Only the standard bundles are linked; the **DSK Nightmare Bundle** and **DFT Finish Line Bundle** have distinct land packs and are left untouched.

Decklists added in taw/magic-preconstructed-decks#285.