### PR TITLE
M12, M13, M14, M15, ORI: link fat pack land packs to decks

### DIFF
--- a/data/contents/M12.yaml
+++ b/data/contents/M12.yaml
@@ -41,11 +41,13 @@ products:
       name: 2012 Core Set Event Deck Vampire Onslaught
       set: m12
   2012 Core Set Fat Pack:
+    deck:
+    - name: "Magic 2012 Fat Pack Land Pack"
+      set: m12
     other:
     - name: Magic 2012 Card Box
     - name: Magic 2012 Player's Guide
     - name: Learn-to-Play Insert
-    - name: 80-card basic land pack
     - name: Magic 2012 Spindown Life Counter
     sealed:
     - count: 9

--- a/data/contents/M13.yaml
+++ b/data/contents/M13.yaml
@@ -50,10 +50,12 @@ products:
       name: 2013 Core Set Event Deck Sweet Revenge
       set: m13
   2013 Core Set Fat Pack:
+    deck:
+    - name: "Magic 2013 Fat Pack Land Pack"
+      set: m13
     other:
     - name: Magic 2013 Player's Guide
     - name: Magic 2013 Card Box
-    - name: 80-card basic land pack
     - name: Special edition spindown life counter
     - name: Two deck boxes
     sealed:

--- a/data/contents/M14.yaml
+++ b/data/contents/M14.yaml
@@ -24,10 +24,12 @@ products:
     - name: Rush of the Wild
       set: m14
   2014 Core Set Fat Pack:
+    deck:
+    - name: "Magic 2014 Fat Pack Land Pack"
+      set: m14
     other:
     - name: Magic 2014 Player's Guide
     - name: Magic 2014 Card Box
-    - name: 80-card basic land pack
     - name: Special edition spindown life counter
     - name: Two deck boxes
     sealed:

--- a/data/contents/M15.yaml
+++ b/data/contents/M15.yaml
@@ -82,9 +82,11 @@ products:
       count: 4
       replacement: false
   2015 Core Set Fat Pack:
+    deck:
+    - name: "Magic 2015 Fat Pack Land Pack"
+      set: m15
     other:
     - name: M15 Player's Guide and Visual Encyclopedia
-    - name: M15 Fat Pack 80-card Land Bundle
     - name: Special Edition Life Counter
     - name: Two Deck Boxes
     sealed:

--- a/data/contents/ORI.yaml
+++ b/data/contents/ORI.yaml
@@ -24,9 +24,11 @@ products:
       set: ori
   Magic Origins Deck Builders Toolkit: []
   Magic Origins Fat Pack:
+    deck:
+    - name: "Magic Origins Fat Pack Land Pack"
+      set: ori
     other:
     - name: Magic Origins Player's Guide and Visual Encyclopedia
-    - name: Magic Origins 80-card Land Bundle
     - name: Special Edition Life Counter
     - name: Two Deck Boxes
     sealed:


### PR DESCRIPTION
Points each 2011-2015 core set Fat Pack's 80-card basic land pack at a `deck:`.

Decklists added in taw/magic-preconstructed-decks#286.