### PR TITLE
TSP, ALA, SOM, ISD, DKA, AVR, DTK, FRF, MBS, NPH: link fat pack land packs to decks

### DIFF
--- a/data/contents/ALA.yaml
+++ b/data/contents/ALA.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: ala
   Shards of Alara Fat Pack:
+    deck:
+    - name: "Shards of Alara Fat Pack Land Pack"
+      set: ala
     other:
     - name: Shards of Alara Planeswalker's guide to Alara
     - name: 1 of 5 different card boxes with Shards of Alara artwork
-    - name: 40 card Shards basic land pack
     - name: 1 Shards Spindown life counter
     - name: 1 random Pro Tour Player card
     sealed:

--- a/data/contents/AVR.yaml
+++ b/data/contents/AVR.yaml
@@ -47,9 +47,11 @@ products:
       name: Avacyn Restored Event Deck Humanitys Vengeance
       set: avr
   Avacyn Restored Fat Pack:
+    deck:
+    - name: "Avacyn Restored Fat Pack Land Pack"
+      set: avr
     other:
     - name: Card Box with Avacyn Restored Artwork
-    - name: Avacyn Restored 70-card Basic Land Bundle
     - name: Avacyn Restored Spindown
     - name: Avacyn Restored Players Guide
     sealed:

--- a/data/contents/DKA.yaml
+++ b/data/contents/DKA.yaml
@@ -42,9 +42,11 @@ products:
       name: Dark Ascension Event Deck Spiraling Doom
       set: dka
   Dark Ascension Fat Pack:
+    deck:
+    - name: "Dark Ascension Fat Pack Land Pack"
+      set: dka
     other:
     - name: Dark Ascension Players Guide
-    - name: 70-card Basic Land Bundle
     - name: 10 checklist cards
     - name: Dark Ascension Spindown Life Counter
     - name: Two 60-card Deck Boxes

--- a/data/contents/DTK.yaml
+++ b/data/contents/DTK.yaml
@@ -21,8 +21,10 @@ products:
     - name: Landslide Charge
       set: dtk
   Dragons of Tarkir Fat Pack:
+    deck:
+    - name: "Dragons of Tarkir Fat Pack Land Pack"
+      set: dtk
     other:
-    - name: Dragons of Tarkir 80-card Basic Land Bundle
     - name: Dragons of Tarkir Special Edition Spindown
     - name: Full Art Card Box
     - name: Two Deck Boxes

--- a/data/contents/FRF.yaml
+++ b/data/contents/FRF.yaml
@@ -23,8 +23,10 @@ products:
     - name: Power
       set: frf
   Fate Reforged Fat Pack:
+    deck:
+    - name: "Fate Reforged Fat Pack Land Pack"
+      set: frf
     other:
-    - name: Fate Reforged 80-card Basic Land Bundle
     - name: Fate Reforged Special Edition Spindown
     - name: Full Art Card Box
     - name: Two Deck Boxes

--- a/data/contents/ISD.yaml
+++ b/data/contents/ISD.yaml
@@ -39,9 +39,11 @@ products:
       name: Innistrad Event Deck Hold the Line
       set: isd
   Innistrad Fat Pack:
+    deck:
+    - name: "Innistrad Fat Pack Land Pack"
+      set: isd
     other:
     - name: Innistrad Players Guide
-    - name: 70-card Basic Land Bundle
     - name: 10 checklist cards
     - name: Innistrad Spindown Life Counter
     - name: Two 60-card Deck Boxes

--- a/data/contents/MBS.yaml
+++ b/data/contents/MBS.yaml
@@ -59,8 +59,12 @@ products:
       name: Mirrodin Besieged Faction Booster Box
       set: mbs
   Mirrodin Besieged Fat Pack:
+    deck:
+    - name: Scars of Mirrodin Fat Pack Land Pack
+      set: som
+    - name: Mirrodin Besieged Fat Pack Land Pack
+      set: mbs
     other:
-    - name: 80 basic land cards
     - name: Mirrodin Besieged spindown life counter
     - name: player's guide
     - name: learn-to-play insert

--- a/data/contents/NPH.yaml
+++ b/data/contents/NPH.yaml
@@ -34,8 +34,12 @@ products:
       name: New Phyrexia Event Deck Rot from Within
       set: nph
   New Phyrexia Fat Pack:
+    deck:
+    - name: Scars of Mirrodin Fat Pack Land Pack
+      set: som
+    - name: New Phyrexia Fat Pack Land Pack
+      set: nph
     other:
-    - name: 80 basic land cards
     - name: New Phyrexia spindown life counter
     - name: player's guide
     - name: card storage box

--- a/data/contents/SOM.yaml
+++ b/data/contents/SOM.yaml
@@ -21,8 +21,10 @@ products:
     - code: draft
       set: som
   Scars of Mirrodin Fat Pack:
+    deck:
+    - name: "Scars of Mirrodin Fat Pack Land Pack"
+      set: som
     other:
-    - name: 40 basic land cards
     - name: Scars of Mirrodin spindown life counter
     - name: player's guide
     - name: card storage box

--- a/data/contents/TSP.yaml
+++ b/data/contents/TSP.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: tsp
   Time Spiral Fat Pack:
+    deck:
+    - name: "Time Spiral Fat Pack Land Pack"
+      set: tsp
     other:
     - name: 2 card deck boxes
     - name: Player's Guide
-    - name: 40 basic land cards
     - name: Time Spiral Spindown Life Counter
     - name: 1 Random Pro Tour player card
     - name: Time Spiral novel


### PR DESCRIPTION
Points each Fat Pack's basic land pack at a `deck:` (40-card for 2006-2010, 70-card for the Innistrad block, 80-card for 2015). Mirrodin Besieged and New Phyrexia's packs mix in Scars of Mirrodin basics.

Decklists added in taw/magic-preconstructed-decks#287.