### PR TITLE
Remove duplicate MSH products and stop the importer recreating them

### DIFF
--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -34,16 +34,6 @@ products:
     - count: 3
       name: Marvel Super Heroes Beginner Box
       set: msh
-  Marvel Super Heroes Box Set Heroes United:
-    card_count: 6
-    deck:
-    - name: Heroes United
-      set: msh
-  Marvel Super Heroes Box Set Villains Unleashed:
-    card_count: 6
-    deck:
-    - name: Villains Unleashed
-      set: msh
   Marvel Super Heroes Bundle: []
   Marvel Super Heroes Bundle Case: []
   Marvel Super Heroes Collector Booster Box:
@@ -177,17 +167,7 @@ products:
     deck:
     - name: Black Deck
       set: msh
-  Marvel Super Heroes Welcome Deck Black Deck:
-    card_count: 30
-    deck:
-    - name: Black Deck
-      set: msh
   Marvel Super Heroes Welcome Deck Blue:
-    card_count: 30
-    deck:
-    - name: Blue Deck
-      set: msh
-  Marvel Super Heroes Welcome Deck Blue Deck:
     card_count: 30
     deck:
     - name: Blue Deck
@@ -197,27 +177,12 @@ products:
     deck:
     - name: Green Deck
       set: msh
-  Marvel Super Heroes Welcome Deck Green Deck:
-    card_count: 30
-    deck:
-    - name: Green Deck
-      set: msh
   Marvel Super Heroes Welcome Deck Red:
     card_count: 30
     deck:
     - name: Red Deck
       set: msh
-  Marvel Super Heroes Welcome Deck Red Deck:
-    card_count: 30
-    deck:
-    - name: Red Deck
-      set: msh
   Marvel Super Heroes Welcome Deck White:
-    card_count: 30
-    deck:
-    - name: White Deck
-      set: msh
-  Marvel Super Heroes Welcome Deck White Deck:
     card_count: 30
     deck:
     - name: White Deck

--- a/data/products/MSH.yaml
+++ b/data/products/MSH.yaml
@@ -16,16 +16,6 @@ products:
     identifiers:
       tcgplayerProductId: '675614'
     subtype: STARTER
-  Marvel Super Heroes Box Set Heroes United:
-    category: BOX_SET
-    identifiers: {}
-    release_date: '2026-06-26'
-    subtype: OTHER
-  Marvel Super Heroes Box Set Villains Unleashed:
-    category: BOX_SET
-    identifiers: {}
-    release_date: '2026-06-26'
-    subtype: OTHER
   Marvel Super Heroes Bundle:
     category: BUNDLE
     identifiers:
@@ -211,21 +201,11 @@ products:
       cardtraderId: '395271'
       mcmId: '894059'
     subtype: WELCOME
-  Marvel Super Heroes Welcome Deck Black Deck:
-    category: DECK
-    identifiers: {}
-    release_date: '2026-06-26'
-    subtype: WELCOME
   Marvel Super Heroes Welcome Deck Blue:
     category: DECK
     identifiers:
       cardtraderId: '395270'
       mcmId: '894058'
-    subtype: WELCOME
-  Marvel Super Heroes Welcome Deck Blue Deck:
-    category: DECK
-    identifiers: {}
-    release_date: '2026-06-26'
     subtype: WELCOME
   Marvel Super Heroes Welcome Deck Green:
     category: DECK
@@ -233,30 +213,15 @@ products:
       cardtraderId: '395273'
       mcmId: '894062'
     subtype: WELCOME
-  Marvel Super Heroes Welcome Deck Green Deck:
-    category: DECK
-    identifiers: {}
-    release_date: '2026-06-26'
-    subtype: WELCOME
   Marvel Super Heroes Welcome Deck Red:
     category: DECK
     identifiers:
       cardtraderId: '395272'
       mcmId: '894060'
     subtype: WELCOME
-  Marvel Super Heroes Welcome Deck Red Deck:
-    category: DECK
-    identifiers: {}
-    release_date: '2026-06-26'
-    subtype: WELCOME
   Marvel Super Heroes Welcome Deck White:
     category: DECK
     identifiers:
       cardtraderId: '395269'
       mcmId: '894057'
-    subtype: WELCOME
-  Marvel Super Heroes Welcome Deck White Deck:
-    category: DECK
-    identifiers: {}
-    release_date: '2026-06-26'
     subtype: WELCOME

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -5,8 +5,31 @@ import requests
 import yaml
 
 
-with open("outputs/deck_map.json", "rb") as f:
-    current_decks = json.load(f)
+def load_referenced_decks():
+    """Collect every (set, deck_name) already referenced by a `deck` entry in
+    any data/contents/*.yaml.
+
+    This is a live scan of the source files. It replaces an earlier check against
+    outputs/deck_map.json, which is a compiled snapshot that can lag behind
+    manually-added products: a deck already modeled under a hand-authored product
+    name (e.g. "... Welcome Deck Black" referencing the "Black Deck" decklist)
+    would then get a second stub product created for it ("... Welcome Deck Black
+    Deck") on the next run.
+    """
+    referenced = set()
+    for path in Path("data/contents").glob("*.yaml"):
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        for product in (data.get("products") or {}).values():
+            if not isinstance(product, dict):
+                continue
+            for entry in product.get("deck", []) or []:
+                if isinstance(entry, dict) and entry.get("name"):
+                    referenced.add((entry.get("set"), entry["name"]))
+    return referenced
+
+
+referenced_decks = load_referenced_decks()
 
 gh_request = requests.get("https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json")
 
@@ -173,13 +196,11 @@ for deck in decks:
 
     set_code = deck["set_code"]
 
-    is_present = False
-    for current_deck in current_decks.get(set_code, []):
-        if current_deck == deck["name"]:
-            is_present = True
-            break
-
-    if is_present:
+    # If this decklist is already referenced by an existing contents entry, it is
+    # already modeled (often under a hand-authored product name) -- don't create a
+    # duplicate stub product for it.
+    if (set_code, deck["name"]) in referenced_decks:
+        print(f"Skipping {deck['name']} in {set_code}: deck already referenced in contents")
         continue
 
     print(f"Adding {deck['name']} to {set_code}")


### PR DESCRIPTION
The daily deck import (fe3290615434) reintroduced **seven duplicate stub products** in Marvel Super Heroes, one per decklist that was already modeled by a hand-authored product:

| Duplicate stub (empty identifiers) | Real product it duplicated |
|---|---|
| `Welcome Deck {Black,Blue,Green,Red,White} Deck` | `Welcome Deck {color}` (cardtraderId / mcmId) |
| `Box Set Heroes United` / `Box Set Villains Unleashed` | `Scene Box Heroes United` / `Villains Unleashed` (full identifiers incl. `scgId: SLD-MTG-BXS-MSHSCENE-…`, boosters, easel) |

**Commit 1** removes the seven duplicates from `data/products/MSH.yaml` and `data/contents/MSH.yaml` (pure deletions).

**Commit 2** fixes the root cause in `scripts/import_new_decks.py`. The dedup check read `outputs/deck_map.json` — a *compiled snapshot* that lags behind manually-added products, so a deck already modeled but not yet recompiled slipped through and got a stub product. It's replaced with a live scan of `data/contents/*.yaml` that collects every `(set, deck_name)` already referenced by a `deck:` entry and skips any incoming deck already present. This reads the same references the snapshot was compiled from (verified: `deck_links()` only iterates top-level `deck:` entries), so it's a strict superset with no dependency on regeneration timing.

Verified: script compiles; after the cleanup, the live guard still resolves all seven decks to *skip* (the real products keep referencing them).