### PR TITLE
DIS, PLC, FUT, CON, ARB, AER, MAT: reuse the block's land pack

### DIFF
--- a/data/contents/AER.yaml
+++ b/data/contents/AER.yaml
@@ -16,9 +16,11 @@ products:
     - code: draft
       set: aer
   Aether Revolt Bundle:
+    deck:
+    - name: "Kaladesh Bundle Land Pack"
+      set: kld
     other:
     - name: Aether Revolt Player's Guide
-    - name: 80 Basic Land Pack
     - name: Magic Learn-to-play Guide
     - name: Aether Revolt Spindown
     - name: 2 Deck Boxes

--- a/data/contents/ARB.yaml
+++ b/data/contents/ARB.yaml
@@ -16,11 +16,13 @@ products:
     - code: draft
       set: arb
   Alara Reborn Fat Pack:
+    deck:
+    - name: "Shards of Alara Fat Pack Land Pack"
+      set: ala
     other:
     - name: Card Box
     - name: The Alara Reborn Player's Guide
     - name: Learn-to-play insert
-    - name: 40 Basic land pack
     - name: Alara Reborn Spindown
     sealed:
     - count: 8

--- a/data/contents/CON_.yaml
+++ b/data/contents/CON_.yaml
@@ -16,12 +16,14 @@ products:
     - code: draft
       set: con
   Conflux Fat Pack:
+    deck:
+    - name: "Shards of Alara Fat Pack Land Pack"
+      set: ala
     other:
     - name: One card box
     - name: The Conflux Player's Guide
     - name: A learn-to-play insert
     - name: A sample chapter from Agents of Artifice
-    - name: A pack of 40 basic land
     - name: Conflux Spindown Life Counter
     sealed:
     - count: 8

--- a/data/contents/DIS.yaml
+++ b/data/contents/DIS.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: dis
   Dissension Fat Pack:
+    deck:
+    - name: "Ravnica Fat Pack Land Pack"
+      set: rav
     other:
     - name: Dissension Player's Guide and Visual Encyclopedia
     - name: 2 Card Boxes and 6 Dividers
-    - name: 40-card Ravnica Basic Land Pack
     - name: Dissension Life Counter
     - name: Random Pro Tour Player Card
     - name: Dissension Novel

--- a/data/contents/FUT.yaml
+++ b/data/contents/FUT.yaml
@@ -16,8 +16,10 @@ products:
     - code: draft
       set: fut
   Future Sight Fat Pack:
+    deck:
+    - name: "Time Spiral Fat Pack Land Pack"
+      set: tsp
     other:
-    - name: 40 Basic Land Pack
     - name: 2 Card Storage Boxes
     - name: Future Sight Spindown
     - name: Future Sight Novel

--- a/data/contents/MAT.yaml
+++ b/data/contents/MAT.yaml
@@ -6,9 +6,11 @@ products:
       name: Spark Rupture
       number: 229
       set: mat
+    deck:
+    - name: "March of the Machine Bundle Land Pack"
+      set: mom
     other:
     - name: March of the Machine The Aftermath Spindown
-    - name: March of the Machine The Aftermath Land Pack
     sealed:
     - count: 8
       name: March of the Machine The Aftermath Epilogue Booster Pack

--- a/data/contents/PLC.yaml
+++ b/data/contents/PLC.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: plc
   Planar Chaos Fat Pack:
+    deck:
+    - name: "Time Spiral Fat Pack Land Pack"
+      set: tsp
     other:
     - name: 2 card deck boxes
     - name: Player's Guide
-    - name: 40 basic land cards
     - name: Planar Chaos Spindown Life Counter
     - name: 1 Random Pro Tour player card from PT07 set
     - name: Planar Chaos novel


### PR DESCRIPTION
These small sets have no basic lands of their own, so their fat pack / bundle used the block's big set's land pack. Each now points at the existing land-pack deck (via `deck:`) instead of a loose `other:` line:

| Set | reuses |
|---|---|
| Dissension | Ravnica Fat Pack Land Pack |
| Planar Chaos, Future Sight | Time Spiral Fat Pack Land Pack |
| Conflux, Alara Reborn | Shards of Alara Fat Pack Land Pack |
| Aether Revolt | Kaladesh Bundle Land Pack |
| March of the Machine: The Aftermath | March of the Machine Bundle Land Pack |

Same block-share pattern as the existing GPT→Ravnica, MOR→Lorwyn, EVE→Shadowmoor links. Time Spiral / Shards of Alara / Kaladesh / March of the Machine land-pack decks are added in the taw/magic-preconstructed-decks land-pack PRs.