### PR TITLE
RTR, THS, SOI + block small sets: link fat pack land packs

### DIFF
--- a/data/contents/BNG.yaml
+++ b/data/contents/BNG.yaml
@@ -31,10 +31,12 @@ products:
     - name: Underworld Herald
       set: bng
   Born of the Gods Fat Pack:
+    deck:
+    - name: "Theros Fat Pack Land Pack"
+      set: ths
     other:
     - name: Player's guide with encyclopedia
     - name: Born of the Gods card box
-    - name: 80-card basic land pack
     - name: Special edition spindown life counter
     - name: Two deck boxes
     sealed:

--- a/data/contents/DGM.yaml
+++ b/data/contents/DGM.yaml
@@ -26,11 +26,13 @@ products:
     - name: Strength Of Selesnya
       set: dgm
   Dragons Maze Fat Pack:
+    deck:
+    - name: "Return to Ravnica Fat Pack Land Pack"
+      set: rtr
     other:
     - name: Card Box
     - name: Dragon's Maze Spindown Counter
     - name: Player's Guide
-    - name: 80-card Land Pack
     - name: Learn to Play Insert
     sealed:
     - count: 9

--- a/data/contents/EMN.yaml
+++ b/data/contents/EMN.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: emn
   Eldritch Moon Fat Pack:
+    deck:
+    - name: "Shadows over Innistrad Fat Pack Land Pack"
+      set: soi
     other:
     - name: Eldritch Moon Player's Guide
     - name: Eldritch Moon Card Box
-    - name: Eldritch Moon 80-card Basic Land Bundle
     - name: Eldritch Moon Spindown
     sealed:
     - count: 9

--- a/data/contents/GTC.yaml
+++ b/data/contents/GTC.yaml
@@ -71,11 +71,13 @@ products:
       name: Gatecrash Event Deck Thrive and Thrash
       set: gtc
   Gatecrash Fat Pack:
+    deck:
+    - name: "Return to Ravnica Fat Pack Land Pack"
+      set: rtr
     other:
     - name: Gatecrash themed card box
     - name: Gatecrash player's guide
     - name: Two deck boxes
-    - name: Gatecrash 40-card basic land pack
     - name: Gatecrash spindown
     sealed:
     - count: 9

--- a/data/contents/JOU.yaml
+++ b/data/contents/JOU.yaml
@@ -31,10 +31,12 @@ products:
     - name: Wrath of the Mortals
       set: jou
   Journey Into Nyx Fat Pack:
+    deck:
+    - name: "Theros Fat Pack Land Pack"
+      set: ths
     other:
     - name: Player's guide with encyclopedia
     - name: Journey Into Nyx card box
-    - name: 80-card basic land pack
     - name: Special edition spindown life counter
     - name: Two deck boxes
     sealed:

--- a/data/contents/RTR.yaml
+++ b/data/contents/RTR.yaml
@@ -49,11 +49,13 @@ products:
     - name: Wrack and Rage
       set: rtr
   Return to Ravnica Fat Pack:
+    deck:
+    - name: "Return to Ravnica Fat Pack Land Pack"
+      set: rtr
     other:
     - name: Return to Ravnica themed card box
     - name: Return to Ravnica player's guide
     - name: Two deck boxes
-    - name: 80-card basic land pack
     - name: Return to Ravnica spindown
     sealed:
     - count: 9

--- a/data/contents/SOI.yaml
+++ b/data/contents/SOI.yaml
@@ -17,10 +17,12 @@ products:
       set: soi
   Shadows over Innistrad Deck Builders Toolkit: []
   Shadows over Innistrad Fat Pack:
+    deck:
+    - name: "Shadows over Innistrad Fat Pack Land Pack"
+      set: soi
     other:
     - name: Shadows over Innistrad Player's Guide
     - name: Shadows over Innistrad Card Box
-    - name: Shadows over Innistrad 80-card Basic Land Bundle
     - name: Shadows over Innistrad Spindown
     sealed:
     - count: 9

--- a/data/contents/THS.yaml
+++ b/data/contents/THS.yaml
@@ -26,10 +26,12 @@ products:
     - name: Inspiring Heroics
       set: ths
   Theros Fat Pack:
+    deck:
+    - name: "Theros Fat Pack Land Pack"
+      set: ths
     other:
     - name: Player's guide with encyclopedia
     - name: Theros card box
-    - name: 80-card basic land pack
     - name: Special edition spindown life counter
     - name: Two deck boxes
     sealed:


### PR DESCRIPTION
Points each Fat Pack's 80-card land pack at a `deck:`. The block small sets (no basics of their own) reuse the big set's fat pack pack:

| Set | reuses |
|---|---|
| Dragon's Maze, **Gatecrash** | Return to Ravnica Fat Pack Land Pack |
| Born of the Gods, Journey into Nyx | Theros Fat Pack Land Pack |
| Eldritch Moon | Shadows over Innistrad Fat Pack Land Pack |

⚠️ **Gatecrash**: its contents line read `40-card`, but it's the same RtR block and era (2013) as Return to Ravnica and Dragon's Maze — both 80 — so it's treated as **80** here (the lone 40 looks like a typo). Flag if Gatecrash's fat pack really was 40 and I'll give it a separate 40-card deck.

Decks added in taw/magic-preconstructed-decks#290.