### PR TITLE
BFZ, OGW: link full-art fat pack land packs to decks

### DIFF
--- a/data/contents/BFZ.yaml
+++ b/data/contents/BFZ.yaml
@@ -21,10 +21,12 @@ products:
     - name: Ultimate Sacrifice
       set: bfz
   Battle for Zendikar Fat Pack:
+    deck:
+    - name: "Battle for Zendikar Fat Pack Land Pack"
+      set: bfz
     other:
     - name: Battle for Zendikar Player's Guide
     - name: Battle for Zendikar Card Box
-    - name: Battle for Zendikar Basic Land Bundle
     - name: Battle for Zendikar Premium Spindown
     sealed:
     - count: 9

--- a/data/contents/OGW.yaml
+++ b/data/contents/OGW.yaml
@@ -16,10 +16,12 @@ products:
     - code: draft
       set: ogw
   Oath of the Gatewatch Fat Pack:
+    deck:
+    - name: "Oath of the Gatewatch Fat Pack Land Pack"
+      set: ogw
     other:
     - name: Oath of the Gatewatch Player's Guide
     - name: Oath of the Gatewatch Card Box
-    - name: Oath of the Gatewatch Basic Land Bundle
     - name: Oath of the Gatewatch Premium Spindown
     sealed:
     - count: 9


### PR DESCRIPTION
Points the Battle for Zendikar and Oath of the Gatewatch **fat pack** land packs (80 full-art basics each) at their `deck:`.

- **BFZ Fat Pack** → Battle for Zendikar Fat Pack Land Pack (full-art; distinct from the BFZ Gift Box's non-full-art pack)
- **OGW Fat Pack** → Oath of the Gatewatch Fat Pack Land Pack (66 BFZ full-art colored + 14 full-art Wastes)

Decks added in taw/magic-preconstructed-decks#289.