### PR TITLE
CLB, ONE Compleat: link bundle land packs to decks

### DIFF
--- a/data/contents/CLB.yaml
+++ b/data/contents/CLB.yaml
@@ -11,9 +11,11 @@ products:
       name: Wand of Wonder
       number: 935
       set: clb
+    deck:
+    - name: 'Commander Legends: Battle for Baldur''s Gate Bundle Land Pack'
+      set: clb
     other:
     - name: Commander Legends Battle for Baldurs Gate Spindown
-    - name: Commander Legends Battle for Baldurs Gate Land Bundle
     sealed:
     - count: 8
       name: Commander Legends Battle for Baldurs Gate Set Booster Pack

--- a/data/contents/ONE.yaml
+++ b/data/contents/ONE.yaml
@@ -44,8 +44,9 @@ products:
       name: Phyrexian Arena
       number: 283
       set: one
-    other:
-    - name: Phyrexia All Will Be One Compleat Edition Land Pack
+    deck:
+    - name: 'Phyrexia: All Will Be One Bundle Land Pack'
+      set: one
     sealed:
     - count: 12
       name: Phyrexia All Will Be One Set Booster Pack


### PR DESCRIPTION
Points two bundle land packs at their `deck:`:

- **CLB** Bundle → Commander Legends: Battle for Baldur's Gate Bundle Land Pack (40, 20 foil + 20 non-foil)
- **ONE Compleat Bundle** → the normal Phyrexia: All Will Be One Bundle Land Pack. Its Compleat Edition booster (2 oil-slick raised-foil mythics + 10 oil-slick lands) is already modeled (`one-compleat`) and referenced via the Compleat Edition Booster Pack.

Decks: taw/magic-preconstructed-decks#291 (CLB); ONE reuses the existing bundle deck.