### PR TITLE
TMT: link Pizza Bundle land pack to a deck

### DIFF
--- a/data/contents/TMT.yaml
+++ b/data/contents/TMT.yaml
@@ -67,9 +67,10 @@ products:
     - name: Enemy Deck
       set: tmt
   Teenage Mutant Ninja Turtles Pizza Bundle:
+    deck:
+    - name: Teenage Mutant Ninja Turtles Pizza Bundle Land Pack
+      set: tmt
     other:
-    - name: 5 traditional foil full-art pizza basic land cards
-    - name: 25 non-foil full-art pizza basic land cards
     - name: 2 of 6 pizza-themed promo cards
     - name: Oversized Pizza Bundle Spindown life counter
     sealed:


### PR DESCRIPTION
Points the Teenage Mutant Ninja Turtles Pizza Bundle's 30 full-art pizza lands at its `deck:`. Deck added in taw/magic-preconstructed-decks.