### PR TITLE
import_new_decks: build decklist JSON from source so new decks are same-day

### DIFF
--- a/.github/workflows/daily_rebuild_outputs.yml
+++ b/.github/workflows/daily_rebuild_outputs.yml
@@ -26,7 +26,29 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      # Build the decklist JSON straight from the magic-preconstructed-decks
+      # source so decks added today are available today, rather than waiting for
+      # the separately-scheduled magic-preconstructed-decks-data export.
+      - name: checkout preconstructed decklists source
+        uses: actions/checkout@v4
+        with:
+          repository: taw/magic-preconstructed-decks
+          path: preconstructed-decks
+
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: preconstructed-decks
+
+      - name: build decklist json from source
+        working-directory: preconstructed-decks
+        run: bundle exec ruby bin/build_jsons "$RUNNER_TEMP/decks.json"
+
       - name: execute import of new deck
+        env:
+          DECKS_JSON: ${{ runner.temp }}/decks.json
         run: python scripts/import_new_decks.py
 
       - name: execute new products

--- a/.github/workflows/daily_rebuild_outputs.yml
+++ b/.github/workflows/daily_rebuild_outputs.yml
@@ -27,7 +27,29 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      # Build the decklist JSON straight from the magic-preconstructed-decks
+      # source so decks added today are available today, rather than waiting for
+      # the separately-scheduled magic-preconstructed-decks-data export.
+      - name: checkout preconstructed decklists source
+        uses: actions/checkout@v4
+        with:
+          repository: taw/magic-preconstructed-decks
+          path: preconstructed-decks
+
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: preconstructed-decks
+
+      - name: build decklist json from source
+        working-directory: preconstructed-decks
+        run: bundle exec ruby bin/build_jsons "$RUNNER_TEMP/decks.json"
+
       - name: execute import of new deck
+        env:
+          DECKS_JSON: ${{ runner.temp }}/decks.json
         run: python scripts/import_new_decks.py
 
       - name: execute new products

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,5 +22,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: test deck card counts
+      run: python -m unittest discover -s tests
+
     - name: execute new products
       run: python scripts/contents_validator.py

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pyvenv.cfg
 caches/
 .DS_Store
 .claude/
+# daily workflow: source checkout used to build the decklist JSON
+/preconstructed-decks/

--- a/scripts/deck_card_count.py
+++ b/scripts/deck_card_count.py
@@ -1,0 +1,22 @@
+def deck_card_count(deck):
+    """Count playable deck contents in either source or compiled deck JSON."""
+    cards = deck["cards"]
+    if isinstance(cards, dict):
+        # Source JSON keeps tokens inline and display commanders in a section.
+        sections = [
+            section for name, section in cards.items()
+            if name != "Display Commander"
+        ]
+    else:
+        # Compiled JSON separates these from the main deck. Tokens and display
+        # commanders are accessories and do not contribute to card_count.
+        sections = [cards] + [
+            deck.get(name, [])
+            for name in ("commander", "sideboard", "planarDeck", "schemeDeck")
+        ]
+    return sum(
+        card["count"]
+        for section in sections
+        for card in section
+        if not card.get("token", False)
+    )

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from pathlib import Path
 import requests
@@ -31,14 +32,33 @@ def load_referenced_decks():
 
 referenced_decks = load_referenced_decks()
 
-gh_request = requests.get("https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json")
+# Prefer a locally-built decklist JSON when one is supplied via $DECKS_JSON. The
+# daily workflow builds it straight from the magic-preconstructed-decks source
+# (its own bin/build_jsons), so a decklist added today is picked up today rather
+# than waiting for the separately-scheduled magic-preconstructed-decks-data
+# export. Fall back to the compiled snapshot when run by hand.
+local_decks = os.environ.get("DECKS_JSON")
+if local_decks and Path(local_decks).exists():
+    with open(local_decks) as f:
+        decks = json.load(f)
+    print(f"Loaded {len(decks)} decks from local build {local_decks}")
+else:
+    gh_request = requests.get("https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json")
 
-try:
-    decks = json.loads(gh_request.content)
-except json.JSONDecodeError:
-    print("unable to load magic-preconstructed-decks-data file, here are the contents")
-    print(gh_request.content)
-    sys.exit(1)
+    try:
+        decks = json.loads(gh_request.content)
+    except json.JSONDecodeError:
+        print("unable to load magic-preconstructed-decks-data file, here are the contents")
+        print(gh_request.content)
+        sys.exit(1)
+
+# bin/build_jsons (v1) emits `cards` as a sections dict ({"Main Deck": [...]});
+# the compiled decks_v2.json emits a flat list. Flatten so the card_count sum
+# below works with either source.
+for deck in decks:
+    cards = deck.get("cards")
+    if isinstance(cards, dict):
+        deck["cards"] = [card for section in cards.values() for card in section]
 
 skip_types = [
     # skip mtgo decks

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 import requests
 import yaml
+from deck_card_count import deck_card_count
 
 
 def load_referenced_decks():
@@ -51,14 +52,6 @@ else:
         print("unable to load magic-preconstructed-decks-data file, here are the contents")
         print(gh_request.content)
         sys.exit(1)
-
-# bin/build_jsons (v1) emits `cards` as a sections dict ({"Main Deck": [...]});
-# the compiled decks_v2.json emits a flat list. Flatten so the card_count sum
-# below works with either source.
-for deck in decks:
-    cards = deck.get("cards")
-    if isinstance(cards, dict):
-        deck["cards"] = [card for section in cards.values() for card in section]
 
 skip_types = [
     # skip mtgo decks
@@ -183,7 +176,7 @@ def add_content(set_code, name, deck):
         if not isinstance(content, dict):
             content = {}
 
-        card_count = sum(card["count"] for card in deck["cards"])
+        card_count = deck_card_count(deck)
         content.setdefault("card_count", card_count)
 
         new_deck = [{

--- a/tests/test_deck_card_count.py
+++ b/tests/test_deck_card_count.py
@@ -1,0 +1,62 @@
+import unittest
+
+from scripts.deck_card_count import deck_card_count
+
+
+class DeckCardCountTests(unittest.TestCase):
+    def assert_formats(self, source, compiled, expected):
+        for label, deck in (("source", source), ("compiled", compiled)):
+            with self.subTest(format=label):
+                self.assertEqual(deck_card_count(deck), expected)
+
+    def test_commander_excludes_display_card(self):
+        self.assert_formats(
+            {"cards": {
+                "Main Deck": [{"count": 99}],
+                "Commander": [{"count": 1}],
+                "Display Commander": [{"count": 1}],
+            }},
+            {"cards": [{"count": 99}], "commander": [{"count": 1}],
+             "displayCommander": [{"count": 1}]},
+            100,
+        )
+
+    def test_tokens_do_not_inflate_secret_lair_count(self):
+        self.assert_formats(
+            {"cards": {"Main Deck": [
+                {"count": 8}, {"count": 1, "token": True},
+            ]}},
+            {"cards": [{"count": 8}], "tokens": [{"count": 1}]},
+            8,
+        )
+
+    def test_includes_sideboard(self):
+        self.assert_formats(
+            {"cards": {"Main Deck": [{"count": 60}],
+                       "Sideboard": [{"count": 15}]}},
+            {"cards": [{"count": 60}], "sideboard": [{"count": 15}]},
+            75,
+        )
+
+    def test_includes_planar_and_scheme_decks(self):
+        for source_name, compiled_name in (
+            ("Planar Deck", "planarDeck"), ("Scheme Deck", "schemeDeck"),
+        ):
+            with self.subTest(section=source_name):
+                self.assert_formats(
+                    {"cards": {"Main Deck": [{"count": 60}],
+                               source_name: [{"count": 10}]}},
+                    {"cards": [{"count": 60}], compiled_name: [{"count": 10}]},
+                    70,
+                )
+
+    def test_scene_box_without_extra_sections(self):
+        self.assert_formats(
+            {"cards": {"Main Deck": [{"count": 1} for _ in range(6)]}},
+            {"cards": [{"count": 1} for _ in range(6)]},
+            6,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New deck lists currently reach the daily importer only after the separately scheduled `magic-preconstructed-decks-data` export runs. Build the canonical JSON directly from `taw/magic-preconstructed-decks` in the daily workflow and pass it to the importer through `DECKS_JSON`, so the daily run can see newly added lists immediately. Manual runs retain the compiled snapshot fallback.

Count playable contents consistently across both JSON formats: include main decks, commanders, sideboards, planar decks, and scheme decks; exclude tokens and display commanders. For example, Stranger Things counts as 8 cards and Peer Through Time as 100 regardless of input format. Existing product counts remain preserved.

The source checkout is gitignored, and generated deck JSON stays in the runner's temporary directory. Downstream MTGJSON printing resolution still depends on its own compiled deck data; this change addresses freshness in the sealed-content importer.

Validation:
- Built current source deck JSON successfully.
- Compared all 3,029 decks shared by the current source and compiled exports: no card-count differences.
- Reproduced full imports of Stranger Things and Peer Through Time with both formats: 8 and 100 cards respectively.
- Five regression tests pass and now run in validation CI, covering tokens, display commanders, sideboards, planar/scheme decks, and scene boxes.
- Contents validator and `git diff --check` pass.
