### PR TITLE
Add Dominaria Booster Battle Pack contents

### DIFF
--- a/data/contents/DOM.yaml
+++ b/data/contents/DOM.yaml
@@ -1,6 +1,30 @@
 code: dom
 products:
-  Dominaria Booster Battle Pack: []
+  Dominaria Booster Battle Pack:
+    card_count: 60
+    sealed:
+    - count: 2
+      name: Dominaria Booster Pack
+      set: dom
+    variable:
+    - deck:
+      - name: Amonkhet Welcome Deck - White
+        set: w17
+    - deck:
+      - name: Amonkhet Welcome Deck - Blue
+        set: w17
+    - deck:
+      - name: Amonkhet Welcome Deck - Black
+        set: w17
+    - deck:
+      - name: Amonkhet Welcome Deck - Red
+        set: w17
+    - deck:
+      - name: Amonkhet Welcome Deck - Green
+        set: w17
+    variable_mode:
+      count: 2
+      replacement: false
   Dominaria Booster Box:
     sealed:
     - count: 36


### PR DESCRIPTION
Fills the empty `Dominaria Booster Battle Pack` contents. It follows the **welcome-deck-era battle pack** pattern — the same as the already-modeled **Ixalan Booster Battle Pack**:

- `sealed`: 2× Dominaria Booster Pack
- `variable`: the five **Amonkhet Welcome Deck 2017** (`w17`) decks, `variable_mode: {count: 2, replacement: false}`
- `card_count: 60` (the two ready-to-play 30-card decks)

A collector unboxing confirms the contents — two ready-to-play decks carrying the **'17' set mark** (Welcome Deck 2017) plus two Dominaria boosters and a quick-start guide: https://steemit.com/games/@jacobtothe/magic-the-gathering-dominaria-booster-battle-pack

There was no Welcome Deck 2018, so Dominaria reused the w17 decks (matching Ixalan). All referenced products (`Dominaria Booster Pack`, the five `w17` decks) already exist. YAML validated.