### PR TITLE
Add Ikoria Japanese Draft and Collector Booster products

### DIFF
--- a/data/contents/IKO.yaml
+++ b/data/contents/IKO.yaml
@@ -67,6 +67,31 @@ products:
     pack:
     - code: draft
       set: iko
+  Ikoria Lair of Behemoths Japanese Collector Booster Box:
+    sealed:
+    - count: 12
+      name: Ikoria Lair of Behemoths Japanese Collector Booster Pack
+      set: iko
+  Ikoria Lair of Behemoths Japanese Collector Booster Pack:
+    card_count: 15
+    pack:
+    - code: collector-jp
+      set: iko
+  Ikoria Lair of Behemoths Japanese Draft Booster Box:
+    sealed:
+    - count: 36
+      name: Ikoria Lair of Behemoths Japanese Draft Booster Pack
+      set: iko
+  Ikoria Lair of Behemoths Japanese Draft Booster Box Case:
+    sealed:
+    - count: 6
+      name: Ikoria Lair of Behemoths Japanese Draft Booster Box
+      set: iko
+  Ikoria Lair of Behemoths Japanese Draft Booster Pack:
+    card_count: 15
+    pack:
+    - code: jp
+      set: iko
   Ikoria Lair of Behemoths MTGO Redemption:
     card_count: 274
     deck:

--- a/data/products/IKO.yaml
+++ b/data/products/IKO.yaml
@@ -101,6 +101,31 @@ products:
       tntId: '1605706'
     release_date: '2020-05-15'
     subtype: DRAFT
+  Ikoria Lair of Behemoths Japanese Collector Booster Box:
+    category: BOOSTER_BOX
+    identifiers: {}
+    language: Japanese
+    subtype: COLLECTOR
+  Ikoria Lair of Behemoths Japanese Collector Booster Pack:
+    category: BOOSTER_PACK
+    identifiers: {}
+    language: Japanese
+    subtype: COLLECTOR
+  Ikoria Lair of Behemoths Japanese Draft Booster Box:
+    category: BOOSTER_BOX
+    identifiers: {}
+    language: Japanese
+    subtype: DRAFT
+  Ikoria Lair of Behemoths Japanese Draft Booster Box Case:
+    category: BOOSTER_CASE
+    identifiers: {}
+    language: Japanese
+    subtype: DRAFT
+  Ikoria Lair of Behemoths Japanese Draft Booster Pack:
+    category: BOOSTER_PACK
+    identifiers: {}
+    language: Japanese
+    subtype: DRAFT
   Ikoria Lair of Behemoths MTGO Redemption:
     category: BOX_SET
     identifiers:


### PR DESCRIPTION
`s:IKO is:productless` surfaces three cards (both finishes, 6 entries): **Mysterious Egg #385**, **Dirge Bat #386** and **Crystalline Giant #387** — the three **Japanese-language exclusive Godzilla Series Monsters**.

They differ from their neighbours: #380–384 are `[boxtopper, godzillaseries, boosterfun]` in English, while #385–387 are `[godzillaseries, boosterfun]` in **Japanese** with no `boxtopper`.

### Why they were productless

MTGJSON already carries the sheets that contain them:

```
collector-jp/godzilla      -> #385 #386 #387
collector-jp/godzillaFoil  -> #385 #386 #387
jp/foil                    -> #385 #386 #387
jp/rareMythicWithShowcase  -> #386 #387
jp/commonWithShowcase      -> #385
```

But **nothing referenced those booster codes** — Ikoria had no Japanese products at all — so `sourceProducts` came back `{}` for all three.

### Change

Adds the Japanese products, following the existing **War of the Spark Japanese booster** entries:

- Japanese Draft Booster Pack (`code: jp`, 15 cards) + Box (36) + Box Case (6)
- Japanese Collector Booster Pack (`code: collector-jp`, 15 cards) + Box (12)

Per the collecting article: *"Japanese Collector Boosters may also contain one of the 3 Japanese-language exclusive cards"* and *"In Japanese Draft Boosters, 1 in 12 packs will have a non-foil Godzilla Series Monster card. 1 in 60 will have a foil."*

### Notes

- `identifiers: {}` left empty — happy to fill in any IDs you have.
- The Japanese **box topper** (18 cards vs 15 in other languages) is deliberately *not* modelled: there's no `box-topper-jp` booster code to point at. Adding the 18-card Japanese box topper to the search engine is a separate change.
- Verified: every `pack` code exists in IKO's MTGJSON booster set, and every `sealed` reference resolves to a product in this file. Diff is additions only (50 lines); files re-emitted with the repo's own dumper so ordering/formatting are unchanged.