### PR TITLE
Fix Avatar Commander's Bundle promo cards (2 of 10, not all 10)

### DIFF
--- a/data/contents/TLA.yaml
+++ b/data/contents/TLA.yaml
@@ -73,11 +73,19 @@ products:
     - code: collector
       set: tla
   Avatar The Last Airbender Commanders Bundle:
-    card_count: 13
+    card:
+    - name: Arcane Signet
+      number: 315
+      set: tle
+    - name: Sol Ring
+      number: 316
+      set: tle
+    - name: Swiftfoot Boots
+      number: 317
+      set: tle
+    card_count: 5
     deck:
     - name: 'Avatar: The Last Airbender Bundle Land Pack'
-      set: tla
-    - name: Commander's Bundle
       set: tla
     other:
     - name: Click Wheel life counter
@@ -89,6 +97,50 @@ products:
     - count: 1
       name: Avatar The Last Airbender Collector Booster Pack
       set: tla
+    variable:
+    - card:
+      - name: Enlightened Tutor
+        number: 305
+        set: tle
+    - card:
+      - name: Flawless Maneuver
+        number: 306
+        set: tle
+    - card:
+      - name: Fierce Guardianship
+        number: 307
+        set: tle
+    - card:
+      - name: Mystical Tutor
+        number: 308
+        set: tle
+    - card:
+      - name: Deadly Rollick
+        number: 309
+        set: tle
+    - card:
+      - name: Entomb
+        number: 310
+        set: tle
+    - card:
+      - name: Deflecting Swat
+        number: 311
+        set: tle
+    - card:
+      - name: Gamble
+        number: 312
+        set: tle
+    - card:
+      - name: Obscuring Haze
+        number: 313
+        set: tle
+    - card:
+      - name: Worldly Tutor
+        number: 314
+        set: tle
+    variable_mode:
+      count: 2
+      replacement: false
   Avatar The Last Airbender Commanders Bundle Case:
     sealed:
     - count: 6


### PR DESCRIPTION
The **Avatar: The Last Airbender Commander's Bundle** EV comes out roughly **double**.

### Cause

The contents referenced the full 13-card `Commander's Bundle` decklist as a flat `deck:` with **no `variable_mode`**, so all **10 tutor / free-spell reprints** (Enlightened Tutor, Fierce Guardianship, Deadly Rollick, Deflecting Swat, …) were counted as **guaranteed**. Those reprints are the expensive cards in the product, so the whole thing inflates.

### Ground truth (collecting article)

> Each Commander's Bundle contains … **5 Non-foil promo cards**. **Three (3) of these promo cards are the same in each Commander's Bundle.**

So the promo slot is **3 fixed staples + 2 of 10 reprints**, not all 13:
- Fixed: Arcane Signet, Sol Ring, Swiftfoot Boots (TLE #315–317)
- Pool of 10 (draw 2): TLE #305–314

Source: https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender

### Change

- 3 staples → guaranteed `card:` entries
- 10 reprints → `variable:` pool with `variable_mode: {count: 2, replacement: false}` (→ C(10,2) = 45 configs)
- `card_count` 13 → 5 (the 5 promo cards)
- Land pack deck, 9 Play + 1 Collector boosters, click-wheel and storage box unchanged

Follows the existing Signature Spellbook / SLD variable-`card` precedent.

### Verification

- All 13 TLE references resolve by number **and** name against AllPrintings.
- The repo's `product_classes` compiles the entry cleanly: 3 cards + 1 deck + 2 sealed + **45 variable configs**.
- Diff is contents-only (+55/−3), touching only this product.

**Note:** this leaves the `Commander's Bundle` decklist in `magic-preconstructed-decks` unreferenced (the 13-card flat list was the source of the over-count). Happy to open a follow-up there to drop it or repurpose it as documentation.