### PR TITLE
Reference the Commander's Bundle promo pack instead of a flat decklist

### DIFF
--- a/data/contents/TLA.yaml
+++ b/data/contents/TLA.yaml
@@ -73,15 +73,15 @@ products:
     - code: collector
       set: tla
   Avatar The Last Airbender Commanders Bundle:
-    card_count: 13
     deck:
     - name: 'Avatar: The Last Airbender Bundle Land Pack'
-      set: tla
-    - name: Commander's Bundle
       set: tla
     other:
     - name: Click Wheel life counter
     - name: Card storage box
+    pack:
+    - code: commander-bundle
+      set: tla
     sealed:
     - count: 9
       name: Avatar The Last Airbender Play Booster Pack


### PR DESCRIPTION
Supersedes #515 with the cleaner architecture requested by the maintainer.

The **Avatar Commander's Bundle** EV came out ~2× too high because the contents referenced the full 13-card `Commander's Bundle` decklist as guaranteed, so all **10 tutor/free-spell reprints** were counted. The bundle actually holds **5 promo cards: 3 fixed staples + 2 of 10 reprints** (collecting article: *"5 Non-foil promo cards. Three (3) of these promo cards are the same in each Commander's Bundle."*).

Rather than enumerate the pick inline, the promos are now a real pack:
- **magic-search-engine**: `tla-commander-bundle` booster (3 guaranteed + 2-of-10) — taw/magic-search-engine#541
- **magic-preconstructed-decks**: the flat decklist is removed — taw/magic-preconstructed-decks#298
- **here**: reference it via `pack: {code: commander-bundle}`

Land pack, 9 Play + 1 Collector boosters, and extras unchanged.

### Dependency

`pack: {code: commander-bundle}` resolves only once the booster reaches MTGJSON via `taw/magic-sealed-data`. Until then the compiler will emit `Booster code commander-bundle not found in set tla` — expected, clears when the booster propagates. **Merge order: search-engine #541 → (magic-sealed-data regen) → this.**

Verified in the search engine: the pack builds to total 5.000/pack (staples 1.000, reprints 0.200 each).