### PR TITLE
Add Festival in a Box: Amsterdam 2026 (with the Wild in Bloom drop)

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -11353,7 +11353,30 @@ products:
         set: sld
     variable_mode:
       count: 1
-  Secret Lair Festival in a Box Amsterdam 2026 Bundle: {}
+  Secret Lair Festival in a Box Amsterdam 2026 Bundle:
+    card:
+    - foil: true
+      name: Llanowar Elves
+      number: 8
+      set: pf26
+    - foil: true
+      name: Utopia Sprawl
+      number: 9
+      set: pf26
+    - foil: true
+      name: Atraxa, Praetors' Voice
+      number: 10
+      set: pf26
+    - name: Bicycle Elemental
+      number: 11
+      set: pf26
+    sealed:
+    - count: 1
+      name: Mystery Booster 2 Booster Box
+      set: mb2
+    - count: 1
+      name: Secret Lair Drop Wild in Bloom
+      set: sld
   Secret Lair Festival in a Box Atlanta 2025 Bundle:
     card:
     - foil: true


### PR DESCRIPTION
Fills the empty `Secret Lair Festival in a Box Amsterdam 2026 Bundle` contents.

### Contents (per the Secret Lair product page)

> 1x Mystery Booster 2 Display · 1x Wild in Bloom Foil Edition Secret Lair Drop · 4x Promo Cards: Foil Llanowar Elves, Foil Utopia Sprawl, Foil Atraxa, Praetors' Voice, Bicycle Elemental Playtest Card

Modeled as:
- `sealed`: 1× Mystery Booster 2 Booster Box + 1× Secret Lair Drop Wild in Bloom
- `card`: pf26 #8 Llanowar Elves (foil), #9 Utopia Sprawl (foil), #10 Atraxa, Praetors' Voice (foil), #11 Bicycle Elemental (non-foil playtest)

Source: https://secretlair.wizards.com/us/en/product/1251828/festival-in-a-box

### Scope change since first opened

This PR originally also added the **Wild in Bloom** drop (its product entry and `deck`-referencing contents). Both have since landed on `main` independently via the daily scraper, so after rebasing this PR is *just* the bundle fill — a single-file, additions-only change replacing the `{}` placeholder (+24/−1). The `Wild in Bloom` decklist dependency (taw/magic-preconstructed-decks#300) has also merged, so the drop's `deck` ref resolves.

### Verified

- YAML parses; rebased clean onto `main` (no conflict markers).
- All sealed refs resolve: `Mystery Booster 2 Booster Box` (MB2) and `Secret Lair Drop Wild in Bloom` (SLD) both exist as products on `main`.
- pf26 card names/numbers/finishes match mtgjson exactly (three foil, Bicycle Elemental non-foil playtest).
- `product_contents_compiler` on the rebased branch produces no `missing contents` or unresolved-ref warnings for the bundle.
