### PR TITLE
card2product: try live AllPrintings first, fall back to v5_backup + use .xz

### DIFF
--- a/scripts/card_to_product_compiler.py
+++ b/scripts/card_to_product_compiler.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import pathlib
 from collections import defaultdict
 from typing import Any, Dict, Set, List
@@ -32,8 +33,16 @@ class MtgjsonCardLinker:
             with open(mtgjson_path) as f:
                 self.mtgjson_data = json.load(f).get("data")
         else:
-            print("Downloading latest AllPrintings.json")
-            _all_printings_url = "https://mtgjson.com/api/v5/AllPrintings.json"
+            # NOTE (2026-07-31): the live v5 build (5.3.0+20260731) temporarily
+            # dropped `sealedProduct` and `decks` from AllPrintings, which this
+            # mapper requires. Fall back to the v5_backup snapshot (last good:
+            # 2026-07-30) until the live feed is fixed. Set the env var below to
+            # the v5 URL to revert once upstream is restored.
+            _all_printings_url = os.environ.get(
+                "MTGJSON_ALLPRINTINGS_URL",
+                "https://mtgjson.com/api/v5_backup/AllPrintings.json",
+            )
+            print(f"Downloading latest AllPrintings.json from {_all_printings_url}")
             request_wrapper = requests.get(_all_printings_url)
             request_wrapper.raise_for_status()
 

--- a/scripts/card_to_product_compiler.py
+++ b/scripts/card_to_product_compiler.py
@@ -28,36 +28,60 @@ class Card:
 class MtgjsonCardLinker:
     mtgjson_data: Dict[str, Any]
 
+    # We grab the .xz build (~92 MB vs ~622 MB raw) and decompress with stdlib
+    # lzma. Try the live v5 feed first, then fall back to the v5_backup snapshot
+    # if it's unreachable or missing the sealed/deck data this mapper needs (as
+    # happened with the 5.3.0+20260731 build). Both are overridable via env.
+    PRIMARY_URL = os.environ.get(
+        "MTGJSON_ALLPRINTINGS_URL",
+        "https://mtgjson.com/api/v5/AllPrintings.json.xz",
+    )
+    BACKUP_URL = os.environ.get(
+        "MTGJSON_ALLPRINTINGS_BACKUP_URL",
+        "https://mtgjson.com/api/v5_backup/AllPrintings.json.xz",
+    )
+
     def __init__(self, mtgjson_path: str):
         if mtgjson_path:
             print("Loading local AllPrintings.json")
             with open(mtgjson_path) as f:
                 self.mtgjson_data = json.load(f).get("data")
         else:
-            # Prefer the .xz build: ~92 MB vs ~622 MB for the raw .json, so the
-            # download is several times faster and stdlib lzma handles it.
-            #
-            # NOTE (2026-07-31): the live v5 build (5.3.0+20260731) temporarily
-            # dropped `sealedProduct` and `decks` from AllPrintings, which this
-            # mapper requires. Fall back to the v5_backup snapshot (last good:
-            # 2026-07-30) until the live feed is fixed. Set the env var below to
-            # the v5 URL to revert once upstream is restored.
-            _all_printings_url = os.environ.get(
-                "MTGJSON_ALLPRINTINGS_URL",
-                "https://mtgjson.com/api/v5_backup/AllPrintings.json.xz",
-            )
-            print(f"Downloading latest AllPrintings.json from {_all_printings_url}")
-            request_wrapper = requests.get(_all_printings_url)
-            request_wrapper.raise_for_status()
-
-            content = request_wrapper.content
-            if _all_printings_url.endswith(".xz"):
-                content = lzma.decompress(content)
-
-            self.mtgjson_data = json.loads(content).get("data")
+            self.mtgjson_data = self._download_mtgjson_data()
 
         if not self.mtgjson_data:
             raise RuntimeError("AllPrintings data is empty or missing 'data' key")
+
+    def _download_mtgjson_data(self) -> Dict[str, Any]:
+        try:
+            data = self._fetch_all_printings(self.PRIMARY_URL)
+            if self._has_required_data(data):
+                return data
+            print("Live AllPrintings is missing sealed/deck data, using backup")
+        except requests.RequestException as exc:
+            print(f"Failed to download live AllPrintings ({exc}), using backup")
+
+        return self._fetch_all_printings(self.BACKUP_URL)
+
+    @staticmethod
+    def _fetch_all_printings(url: str) -> Dict[str, Any]:
+        print(f"Downloading AllPrintings from {url}")
+        request_wrapper = requests.get(url)
+        request_wrapper.raise_for_status()
+
+        content = request_wrapper.content
+        if url.endswith(".xz"):
+            content = lzma.decompress(content)
+
+        return json.loads(content).get("data")
+
+    @staticmethod
+    def _has_required_data(data: Dict[str, Any]) -> bool:
+        if not data:
+            return False
+        has_sealed = any(s.get("sealedProduct") for s in data.values())
+        has_decks = any(s.get("decks") for s in data.values())
+        return has_sealed and has_decks
 
     def build(self, code: str, debug: bool) -> Dict[Card, Set[str]]:
         return_value = defaultdict(set)

--- a/scripts/card_to_product_compiler.py
+++ b/scripts/card_to_product_compiler.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import lzma
 import os
 import pathlib
 from collections import defaultdict
@@ -33,6 +34,9 @@ class MtgjsonCardLinker:
             with open(mtgjson_path) as f:
                 self.mtgjson_data = json.load(f).get("data")
         else:
+            # Prefer the .xz build: ~92 MB vs ~622 MB for the raw .json, so the
+            # download is several times faster and stdlib lzma handles it.
+            #
             # NOTE (2026-07-31): the live v5 build (5.3.0+20260731) temporarily
             # dropped `sealedProduct` and `decks` from AllPrintings, which this
             # mapper requires. Fall back to the v5_backup snapshot (last good:
@@ -40,13 +44,17 @@ class MtgjsonCardLinker:
             # the v5 URL to revert once upstream is restored.
             _all_printings_url = os.environ.get(
                 "MTGJSON_ALLPRINTINGS_URL",
-                "https://mtgjson.com/api/v5_backup/AllPrintings.json",
+                "https://mtgjson.com/api/v5_backup/AllPrintings.json.xz",
             )
             print(f"Downloading latest AllPrintings.json from {_all_printings_url}")
             request_wrapper = requests.get(_all_printings_url)
             request_wrapper.raise_for_status()
 
-            self.mtgjson_data = json.loads(request_wrapper.content).get("data")
+            content = request_wrapper.content
+            if _all_printings_url.endswith(".xz"):
+                content = lzma.decompress(content)
+
+            self.mtgjson_data = json.loads(content).get("data")
 
         if not self.mtgjson_data:
             raise RuntimeError("AllPrintings data is empty or missing 'data' key")


### PR DESCRIPTION
## Problem

`Rebuild Outputs` (and the daily/weekly variants) have failed on every run since **2026-07-30 13:48** — last green run was 2026-07-30 02:00. The failing step is `card_to_product_compiler.py`:

```
Sealed Product for 10E not found, skipping
... (every set) ...
RuntimeError: Build produced no card-to-product mappings; refusing to write empty output
```

## Root cause

MTGJSON's live `v5` build (**5.3.0+20260731**) dropped `sealedProduct` **and** `decks` from `AllPrintings.json` (`DeckList.json` also returns 0 decks). The mapper reads those keys to build the card→product map, finds nothing, and correctly trips the empty-output guard. Upstream data regression — no code in this repo changed.

This repo can't fully reconstruct the map locally: product UUIDs are derivable (`uuid5(NAMESPACE_DNS, name)`), but **52% of products (2072/3981) reference decks**, and deck→card lists live only on the MTGJSON side.

## Changes

**1. Live-first with backup fallback (self-healing).** Download the live `v5` feed, and fall back to the `v5_backup` snapshot only when live is unreachable **or** missing the sealed/deck data (`_has_required_data` checks that at least one set has `sealedProduct` and one has `decks`). Once MTGJSON fixes the live build there's nothing to revert. Both URLs are overridable via `MTGJSON_ALLPRINTINGS_URL` / `MTGJSON_ALLPRINTINGS_BACKUP_URL`.

**2. Download the `.xz` build.** ~92 MB compressed vs ~622 MB raw `.json`, decompressed with stdlib `lzma`. A `.json` override still works — decompression is gated on the `.xz` suffix.

## Verification

Ran against the currently-broken live feed: it downloads live `v5`, detects the missing sealed/deck data, logs the fallback, pulls `v5_backup`, and maps all 19 BLB products (including deck-based `Bloomburrow MTGO Redemption`, `Bloomburrow Starter Kit`) — 1760 card entries, correct foil/nonfoil split.

```
Downloading AllPrintings from https://mtgjson.com/api/v5/AllPrintings.json.xz
Live AllPrintings is missing sealed/deck data, using backup
Downloading AllPrintings from https://mtgjson.com/api/v5_backup/AllPrintings.json.xz
Building BLB
```

Full run dropped from 120s+ to ~45s on the happy path thanks to `.xz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDg674k8sZw1bX8roTsjFJ