### PR TITLE
CI hardening: fix weekly dep crash, upgrade actions, add pip cache

### DIFF
--- a/.github/workflows/build_caches.yml
+++ b/.github/workflows/build_caches.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
 
       - name: install python packages
         run: |
@@ -47,7 +48,7 @@ jobs:
           echo "card_map.json has $KEYS entries"
 
       - name: commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Build cached content
           push_options: --force

--- a/.github/workflows/daily_rebuild_outputs.yml
+++ b/.github/workflows/daily_rebuild_outputs.yml
@@ -1,4 +1,4 @@
-name: Daily Rebuild Outputs
+name: Twice-Daily Rebuild Outputs
 on:
   schedule:
     - cron: 0 */12 * * *
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
 
       - name: install python packages
         run: |
@@ -39,7 +40,7 @@ jobs:
 
       - name: execute contents compiler
         run: python scripts/product_contents_compiler.py
-        
+
       - name: execute manual products compiler
         run: python scripts/new_products_compiler.py
 
@@ -66,7 +67,7 @@ jobs:
           echo "card_map.json has $KEYS entries"
 
       - name: commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Pull new daily content
           push_options: --force

--- a/.github/workflows/rebuild_outputs.yml
+++ b/.github/workflows/rebuild_outputs.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
+      - synchronize
 
 permissions: write-all
 
@@ -23,6 +25,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
 
       - name: install python packages
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,12 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout repo content
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: 'pip'
 
     - name: install python packages
       run: |

--- a/.github/workflows/weekly_rebuild_outputs.yml
+++ b/.github/workflows/weekly_rebuild_outputs.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
 
       - name: install python packages
         run: |
@@ -30,7 +31,7 @@ jobs:
         run: python scripts/gatherer_original_printing_details_generator.py
 
       - name: commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: 'outputs/*.json'
           commit_message: Pull new weekly content

--- a/.github/workflows/weekly_rebuild_outputs.yml
+++ b/.github/workflows/weekly_rebuild_outputs.yml
@@ -30,6 +30,20 @@ jobs:
       - name: execute gatherer original printing generator
         run: python scripts/gatherer_original_printing_details_generator.py
 
+      - name: validate gatherer_mapping is populated
+        run: |
+          FILE=outputs/gatherer_mapping.json
+          if [ ! -s "$FILE" ]; then
+            echo "ERROR: $FILE is empty or missing"
+            exit 1
+          fi
+          KEYS=$(python -c "import json; print(len(json.load(open('$FILE'))))")
+          if [ "$KEYS" -lt 50000 ]; then
+            echo "ERROR: $FILE has only $KEYS entries (expected >= 50000); refusing to commit a degraded scrape"
+            exit 1
+          fi
+          echo "$FILE has $KEYS entries"
+
       - name: commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@ unidecode~=1.4.0
 tqdm~=4.66.1
 ijson~=3.2.3
 pyyaml~=6.0.1
-pathlib~=1.0.1
-requests>=2.33.0
+# requests 2.34+ breaks requests_cache 1.2.1's cattrs serializer
+# (NameError: RequestsCookieJar); keep below 2.34 until requests_cache updates.
+requests>=2.33.0,<2.34
 requests_cache~=1.2.1
 beautifulsoup4~=4.12.2
 urllib3>=2.7.0
 ratelimit~=2.2.1
 mkmsdk==0.6.0
-beautifulsoup4
 thefuzz


### PR DESCRIPTION
Follow-up to #518. Audited all five workflows and fixed the remaining issues.

## Health audit

| Workflow | Before | After |
|---|---|---|
| Rebuild Outputs (push/PR) | ✅ (via #518) | ✅ |
| Twice-Daily Rebuild Outputs | ⚠️ stale card-mapper failure (pre-#518) | ✅ clears next run |
| Weekly Rebuild Outputs | ❌ crashing since 2026-07-26 | ✅ fixed here |
| Build Caches / validate contents | ✅ | ✅ |

## 1. Weekly failure — `requests` dependency, not our code

`gatherer_original_printing_details_generator.py` crashed inside `requests_cache`'s cattrs serializer:

```
NameError: name 'RequestsCookieJar' is not defined
```

`requirements.txt` left `cattrs` unpinned, so the obvious suspect was cattrs 26 — but testing showed the real trigger is **`requests` 2.34.0**, which broke `requests_cache` 1.2.1's forward-ref resolution. Verified the exact boundary against the real serialize path:

| requests | result |
|---|---|
| 2.33.0 / 2.33.1 | ✅ SERIALIZE_OK |
| 2.34.0 / 2.34.1 / 2.34.2 | ❌ NameError |

Our pin was `requests>=2.33.0` (allowed the broken 2.34.x). Capped to `requests>=2.33.0,<2.34`; the latest cattrs (26.1.0) works fine once requests is capped. Also dropped the `pathlib` backport (shadows the Py3 stdlib) and a duplicate `beautifulsoup4` line.

Verified with a clean `pip install -r requirements.txt` (exit 0, requests 2.33.1) + the exact caching path returning `SERIALIZE_OK 200`.

## 2. Workflow hygiene

- **Deprecated actions**: `checkout@v2 → v4`, `setup-python@v4 → v5` (validate.yml); `git-auto-commit-action@v4 → v7` (commit workflows).
- **pip caching**: `cache: pip` on every `setup-python`.
- **Naming**: "Daily Rebuild Outputs" → "Twice-Daily Rebuild Outputs" (its cron is `0 */12 * * *`).
- **PR trigger**: Rebuild Outputs now re-runs on `reopened`/`synchronize`, not just `opened`.

Left untouched by request: `permissions: write-all` and `concurrency` (no change this round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDg674k8sZw1bX8roTsjFJ