### PR TITLE
HOB: add and wire the five Hobbit Welcome Decks

### DIFF
--- a/data/contents/HOB.yaml
+++ b/data/contents/HOB.yaml
@@ -148,3 +148,8 @@ products:
     - count: 3
       name: The Hobbit Play Booster Pack
       set: hob
+  The Hobbit Welcome Deck Black: {}
+  The Hobbit Welcome Deck Blue: {}
+  The Hobbit Welcome Deck Green: {}
+  The Hobbit Welcome Deck Red: {}
+  The Hobbit Welcome Deck White: {}

--- a/data/contents/HOB.yaml
+++ b/data/contents/HOB.yaml
@@ -148,8 +148,28 @@ products:
     - count: 3
       name: The Hobbit Play Booster Pack
       set: hob
-  The Hobbit Welcome Deck Black: {}
-  The Hobbit Welcome Deck Blue: {}
-  The Hobbit Welcome Deck Green: {}
-  The Hobbit Welcome Deck Red: {}
-  The Hobbit Welcome Deck White: {}
+  The Hobbit Welcome Deck Black:
+    card_count: 40
+    deck:
+    - name: Black Deck
+      set: hob
+  The Hobbit Welcome Deck Blue:
+    card_count: 40
+    deck:
+    - name: Blue Deck
+      set: hob
+  The Hobbit Welcome Deck Green:
+    card_count: 40
+    deck:
+    - name: Green Deck
+      set: hob
+  The Hobbit Welcome Deck Red:
+    card_count: 40
+    deck:
+    - name: Red Deck
+      set: hob
+  The Hobbit Welcome Deck White:
+    card_count: 40
+    deck:
+    - name: White Deck
+      set: hob

--- a/data/products/HOB.yaml
+++ b/data/products/HOB.yaml
@@ -172,3 +172,28 @@ products:
       tcgplayerProductId: '692969'
     release_date: '2026-08-14'
     subtype: OTHER
+  The Hobbit Welcome Deck Black:
+    category: DECK
+    identifiers:
+      cardtraderId: '405094'
+    subtype: WELCOME
+  The Hobbit Welcome Deck Blue:
+    category: DECK
+    identifiers:
+      cardtraderId: '405093'
+    subtype: WELCOME
+  The Hobbit Welcome Deck Green:
+    category: DECK
+    identifiers:
+      cardtraderId: '405096'
+    subtype: WELCOME
+  The Hobbit Welcome Deck Red:
+    category: DECK
+    identifiers:
+      cardtraderId: '405095'
+    subtype: WELCOME
+  The Hobbit Welcome Deck White:
+    category: DECK
+    identifiers:
+      cardtraderId: '405092'
+    subtype: WELCOME

--- a/data/review.yaml
+++ b/data/review.yaml
@@ -327,31 +327,6 @@ cardTrader:
     identifiers:
       cardtraderId: '400891'
     subtype: UNKNOWN
-  The Hobbit Welcome Deck Black:
-    category: UNKNOWN
-    identifiers:
-      cardtraderId: '405094'
-    subtype: UNKNOWN
-  The Hobbit Welcome Deck Blue:
-    category: UNKNOWN
-    identifiers:
-      cardtraderId: '405093'
-    subtype: UNKNOWN
-  The Hobbit Welcome Deck Green:
-    category: UNKNOWN
-    identifiers:
-      cardtraderId: '405096'
-    subtype: UNKNOWN
-  The Hobbit Welcome Deck Red:
-    category: UNKNOWN
-    identifiers:
-      cardtraderId: '405095'
-    subtype: UNKNOWN
-  The Hobbit Welcome Deck White:
-    category: UNKNOWN
-    identifiers:
-      cardtraderId: '405092'
-    subtype: UNKNOWN
 coolstuffinc: {}
 hareruya: {}
 miniaturemarket:


### PR DESCRIPTION
Adds the five **The Hobbit Welcome Deck** products (definitions + contents) — each a 40-card monocolor deck mixing The Hobbit (HOB) with Eternal-legal HOC reprints, per the [official announcement](https://magic.wizards.com/en/news/announcements/the-hobbit-welcome-decks).

Two commits: the product definitions (identifiers/subtype), and the contents wiring (`card_count: 40` + `deck:` refs).

**Depends on** taw/magic-preconstructed-decks#301 for the deck lists (`data/welcome/hob/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)