### PR TITLE
SOS: fix MTGO Redemption subtype (unbreaks the validator)

### DIFF
--- a/data/products/SOS.yaml
+++ b/data/products/SOS.yaml
@@ -120,7 +120,7 @@ products:
     category: BOX_SET
     identifiers: {}
     release_date: '2026-05-20'
-    subtype: MTGO_REDEMPTION
+    subtype: REDEMPTION
   Secrets of Strixhaven Play Booster Box:
     category: BOOSTER_BOX
     identifiers:


### PR DESCRIPTION
`MTGO_REDEMPTION` isn't in the validator's `valid_subtypes`, so `contents_validator.py` currently **raises on every run** on main. The convention is `REDEMPTION` (as used by the other MTGO Redemption products, e.g. TDM). One-line fix; validator passes again after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)