### PR TITLE
Resolve token-numbered card references (e.g. SLD 918 "Food")

### DIFF
--- a/scripts/product_classes.py
+++ b/scripts/product_classes.py
@@ -23,8 +23,16 @@ class card:
 
     def get_uuids(self, uuid_map):
         try:
-            self.uuid = uuid_map[self.set.lower()]["cards"][str(self.number)][0]
-            if self.name not in uuid_map[self.set.lower()]["cards"][str(self.number)][1]:
+            set_map = uuid_map[self.set.lower()]
+            number = str(self.number)
+            # Tokens (e.g. SLD 918 "Food") live in a separate map, so fall back
+            # to it when the number isn't among the regular cards.
+            if number in set_map["cards"]:
+                entry = set_map["cards"][number]
+            else:
+                entry = set_map["tokens"][number]
+            self.uuid = entry[0]
+            if self.name not in entry[1]:
                 raise ValueError("name and number do not match", self.name, self.name)
         except KeyError:
             with open("status.txt", "a") as f:

--- a/scripts/product_contents_compiler.py
+++ b/scripts/product_contents_compiler.py
@@ -46,6 +46,7 @@ def build_uuid_map(mtgjson_path):
                 "decks": set(),
                 "sealedProduct": {},
                 "cards": {},
+                "tokens": {},
             }
             status = ""
         elif prefix == f"data.{current_set}" and event == "map_key":
@@ -92,6 +93,27 @@ def build_uuid_map(mtgjson_path):
             elif prefix == f"data.{current_set}.cards.item" and event == "end_map":
                 if holding != "skip":
                     uuids[ccode]["cards"][number] = (uuid, name)
+                holding = ""
+        elif status == "tokens":
+            # Tokens live in a separate array from cards but are referenced the
+            # same way (by collector number), e.g. SLD 918 "Food". Index them so
+            # card lookups can fall back here. Only keep the "main" face.
+            if prefix == f"data.{current_set}.tokens.item.side":
+                if value != "a":
+                    holding = "skip"
+            if prefix == f"data.{current_set}.tokens.item" and event == "start_map":
+                number = ""
+                name = ""
+                uuid = ""
+            elif prefix == f"data.{current_set}.tokens.item.number":
+                number = value
+            elif prefix == f"data.{current_set}.tokens.item.name":
+                name = value
+            elif prefix == f"data.{current_set}.tokens.item.uuid":
+                uuid = value
+            elif prefix == f"data.{current_set}.tokens.item" and event == "end_map":
+                if holding != "skip":
+                    uuids[ccode]["tokens"][number] = (uuid, name)
                 holding = ""
 
     if mtgjson_path:


### PR DESCRIPTION
## Problem

The contents compiler logged, on every run:

```
Card number sld:918 not found in set sld
```

SLD 918 is the **Food** token (Garfield: Lasagna Food Token drop). Tokens live in MTGJSON's separate `tokens` array, but `build_uuid_map` only indexed `cards`, so any product whose `card:` content references a token by collector number failed the lookup, warned, and emitted the content **without a uuid**.

## Fix

- `product_contents_compiler.build_uuid_map` now also indexes the `tokens` array into a parallel `tokens` map (same `number`/`name`/`uuid` fields, same "keep only the main face" handling for double-faced tokens).
- `product_classes.card.get_uuids` looks the number up in `cards` first, then falls back to `tokens`.

Cards keep precedence (no collision risk if a number appears in both), and the name-match validation plus both warning paths are unchanged.

## Verification

Ran `build_uuid_map` + `card.get_uuids` against a synthetic AllPrintings slice and against the real MTGJSON `SLD.json`:

- Food 918 now resolves to its token uuid `9edb0c2d-4ab6-5240-8c37-bc97bcf71eaa` — no warning.
- Regular cards still resolve from `cards` (e.g. Arcane Signet 908).
- A double-faced token keeps only side `a`.
- Genuinely missing numbers and name mismatches still produce the existing warnings.

## No MTGJSON change required

MTGJSON already publishes the token with `number: "918"` in its `tokens` array, and its built `sealedProduct` for the Food Token drop already carries the token uuid as a `card` content — MTGJSON was re-resolving it from name+number itself. This change just makes the compiler resolve it directly so `contents.json` carries the uuid and the spurious warning goes away. Tokens-as-bonus remain correctly modeled under the existing `card` content key; no schema or content-type change is needed.