### PR TITLE
SLD: Flag the Garfield lasagna Food token as a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,13 @@ name: [str] Full card name
 set: [str] Set code
 number: [str or int] Collector number
 foil: [bool, optional] True if card is traditional or etched foil
+token: [bool, optional] True if the collector number refers to a token instead of a card, ie. SLD 918 "Food"
 uuid: [str, calculated] The card's MTGJson UUID. This is calculated by the compiler and you should not enter this in the YAML.
 ```
+
+Tokens live in `{set}.tokens` rather than `{set}.cards` in MTGJson, so the flag
+tells the compiler where to resolve the collector number, and is carried into the
+output so consumers know to look for the UUID in the same place.
 
 Example card YAML input:
 

--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -6911,6 +6911,7 @@ products:
       name: Food
       number: 918
       set: sld
+      token: true
     card_count: 1
   Secret Lair Drop Secret Lair Promo x Marvel Arcane Signet:
     card:

--- a/scripts/product_classes.py
+++ b/scripts/product_classes.py
@@ -9,6 +9,7 @@ class card:
         self.number = contents["number"]
         self.etched = contents.get("etched", False)
         self.foil = contents.get("foil", False)
+        self.token = contents.get("token", False)
         self.uuid = contents.get("uuid", False)
 
     def toJson(self):
@@ -19,18 +20,29 @@ class card:
             data["foil"] = self.foil
         if self.etched:
             data["etched"] = self.etched
+        if self.token:
+            data["token"] = self.token
         return data
 
     def get_uuids(self, uuid_map):
         try:
             set_map = uuid_map[self.set.lower()]
             number = str(self.number)
-            # Tokens (e.g. SLD 918 "Food") live in a separate map, so fall back
-            # to it when the number isn't among the regular cards.
-            if number in set_map["cards"]:
-                entry = set_map["cards"][number]
+            # Tokens (e.g. SLD 918 "Food") live in a separate map from the
+            # regular cards, and the token flag picks which one to look in.
+            primary = "tokens" if self.token else "cards"
+            fallback = "cards" if self.token else "tokens"
+            if number in set_map[primary]:
+                entry = set_map[primary][number]
             else:
-                entry = set_map["tokens"][number]
+                # Still resolve it, but report the mismatch so the flag can be
+                # corrected in the YAML.
+                entry = set_map[fallback][number]
+                with open("status.txt", "a") as f:
+                    f.write(
+                        f"Card number {self.set}:{self.number} found in {fallback}, "
+                        f"token flag should be {not self.token}\n"
+                    )
             self.uuid = entry[0]
             if self.name not in entry[1]:
                 raise ValueError("name and number do not match", self.name, self.name)


### PR DESCRIPTION
The only content of `Secret Lair Drop Secret Lair Promo x Garfield Lasagna Food Token` is SLD 918 "Food", which is a token: in MTGJson it lives in `SLD.tokens`, not `SLD.cards`, and consumers that look up the UUID in the card list come up empty.

Mark it explicitly with a `token` flag rather than inferring it from where the collector number happens to resolve:

- `card` entries accept `token: [bool, optional]`, documented in the README.
- The compiler resolves flagged entries against the set's tokens and unflagged ones against its cards. If the flag and the data disagree it still resolves, but reports the mismatch in `status.txt` so the YAML can be corrected — previously a card number missing from `cards` would silently pick up a same-numbered token.
- The flag is carried into `contents.json` so downstream knows which list holds the UUID.

Compiled against a local AllPrintings; the product resolves to `9edb0c2d-4ab6-5240-8c37-bc97bcf71eaa`, which is `SLD.tokens` 918 Food, and `scripts/contents_validator.py` passes. Checking all 985 `card:` references in `data/contents` against AllPrintings, SLD 918 is the only one that resolves to a token, so nothing else needs the flag.

The matching MTGJson change (which otherwise drops the flag before it reaches AllPrintings) is mtgjson/mtgjson#1700.