### PR TITLE
Add Secret Lair Commander Deck: Hatsune Miku

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -1701,6 +1701,16 @@ products:
     deck:
     - name: Goblin Storm
       set: sld
+  Secret Lair Commander Deck Hatsune Miku:
+    card:
+    - foil: true
+      name: Tigereye Cameo
+      number: 7093
+      set: sld
+    card_count: 100
+    deck:
+    - name: Hatsune Miku
+      set: sld
   Secret Lair Commander Deck Heads I Win Tails You Lose:
     card_count: 100
     deck:

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -1265,6 +1265,14 @@ products:
       tcgplayerProductId: '693209'
     release_date: '2026-05-22'
     subtype: COMMANDER
+  Secret Lair Commander Deck Hatsune Miku:
+    category: DECK
+    identifiers:
+      cardtraderId: '402410'
+      mcmId: '902208'
+      tcgplayerProductId: '709981'
+    release_date: '2026-08-10'
+    subtype: COMMANDER
   Secret Lair Commander Deck Heads I Win Tails You Lose:
     category: DECK
     identifiers:

--- a/data/review.yaml
+++ b/data/review.yaml
@@ -88,12 +88,6 @@ cardMarket:
       mcmId: '902217'
     release_date: '2026-08-11'
     subtype: UNKNOWN
-  'Secret Lair Commander Deck: Hatsune Miku':
-    category: UNKNOWN
-    identifiers:
-      mcmId: '902208'
-    release_date: '2026-08-10'
-    subtype: UNKNOWN
   'Secret Lair Drop Series: A Marvelous Mathom Superdrop: Secret Lair x The Hobbit: Desolation':
     category: UNKNOWN
     identifiers:
@@ -207,11 +201,6 @@ cardTrader:
     category: UNKNOWN
     identifiers:
       cardtraderId: '406069'
-    subtype: UNKNOWN
-  'Secret Lair Commander Deck: Hatsune Miku':
-    category: UNKNOWN
-    identifiers:
-      cardtraderId: '402410'
     subtype: UNKNOWN
   'Secret Lair x Marvel: True Belivers in Love':
     category: UNKNOWN
@@ -397,12 +386,6 @@ tcgplayer:
     category: UNKNOWN
     identifiers:
       tcgplayerProductId: '684659'
-    subtype: UNKNOWN
-  Secret Lair Commander Deck Hatsune Miku:
-    category: UNKNOWN
-    identifiers:
-      tcgplayerProductId: '709981'
-    release_date: '2026-08-16'
     subtype: UNKNOWN
   Secret Lair Drop Secret Lair x The Hobbit Desolation Non Foil Edition:
     category: UNKNOWN


### PR DESCRIPTION
Promotes the three review.yaml stubs (mcm 902208, cardtrader 402410, tcgplayer 709981) into a product entry for the Secret Lair Commander Deck: Hatsune Miku, released 2026-08-10.

Contents mirror the Goblin Storm commander deck: 100-card deck reference plus the foil bonus card, Tigereye Cameo (SLD 7093). The new-art cards (SLD 2429–2442, 2444–2445, 7093) are already in AllPrintings.

Sources: [Wizards decklist announcement](https://magic.wizards.com/en/news/announcements/secret-lair-commander-deck-hatsune-miku-decklist), [Secret Lair product page](https://secretlair.wizards.com/us/en/product/1248797/secret-lair-commander-deck-hatsune-miku), Scryfall.

`contents_validator.py` passes.