### PR TITLE
SLD: add Secret Lair x The Hobbit (A Marvelous Mathoms Superdrop) drops and bundles

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -1161,6 +1161,119 @@ products:
       name: Secret Lair Commander Deck Heads I Win Tails You Lose
       set: sld
   Secret Lair Bundle Secret Lair Drop Series Full: []
+  Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond:
+    card_count: 7
+    deck:
+    - name: 'The Hobbit: Second Breakfast and Beyond'
+      set: sld
+  Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond Foil:
+    card_count: 7
+    deck:
+    - name: 'The Hobbit: Second Breakfast and Beyond Foil Edition'
+      set: sld
+  Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild:
+    card_count: 5
+    deck:
+    - name: 'The Hobbit: Over the Edge of the Wild'
+      set: sld
+    other:
+    - name: Bonus card unknown
+  Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild Foil:
+    card_count: 5
+    deck:
+    - name: 'The Hobbit: Over the Edge of the Wild Foil Edition'
+      set: sld
+    other:
+    - name: Bonus card unknown
+  Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils:
+    card_count: 5
+    deck:
+    - name: 'The Hobbit: Smaug''s Spoils'
+      set: sld
+    other:
+    - name: Bonus card unknown
+  Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils Foil:
+    card_count: 5
+    deck:
+    - name: 'The Hobbit: Smaug''s Spoils Foil Edition'
+      set: sld
+    other:
+    - name: Bonus card unknown
+  Secret Lair Drop Secret Lair x The Hobbit Desolation:
+    card_count: 5
+    deck:
+    - name: 'The Hobbit: Desolation'
+      set: sld
+    other:
+    - name: Bonus card unknown
+  Secret Lair Drop Secret Lair x The Hobbit Desolation Foil:
+    card_count: 5
+    deck:
+    - name: 'The Hobbit: Desolation Foil Edition'
+      set: sld
+    other:
+    - name: Bonus card unknown
+  Secret Lair Drop Secret Lair x The Hobbit He Who Walks Unseen Out of Sight Foil:
+    card_count: 5
+    deck:
+    - name: 'The Hobbit: He Who Walks Unseen Out of Sight Foil Edition'
+      set: sld
+    other:
+    - name: Bonus card unknown
+  Secret Lair Bundle Secret Lair x The Hobbit A Marvelous Mathoms Superdrop A Marvelous Mathoms Everything Bundle:
+    sealed:
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Desolation
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Desolation Foil
+      set: sld
+  Secret Lair Bundle Secret Lair x The Hobbit A Marvelous Mathoms Superdrop Riddles in the Dark Foil Bundle:
+    sealed:
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Desolation Foil
+      set: sld
+  Secret Lair Bundle Secret Lair x The Hobbit A Marvelous Mathoms Superdrop The Bag End Non Foil Bundle:
+    sealed:
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Secret Lair x The Hobbit Desolation
+      set: sld
   Secret Lair Bundle Secret Lair x PlayStation Superdrop Foil Trophy Bundle:
     sealed:
     - count: 1

--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -1161,6 +1161,96 @@ products:
       name: Secret Lair Commander Deck Heads I Win Tails You Lose
       set: sld
   Secret Lair Bundle Secret Lair Drop Series Full: []
+  Secret Lair Bundle Secret Lair x PlayStation Superdrop Foil Trophy Bundle:
+    sealed:
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part I Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part II Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Greek Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Norse Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Horizon Into the Forbidden West Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Uncharted Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Ghost of Tsushima Foil
+      set: sld
+  Secret Lair Bundle Secret Lair x PlayStation Superdrop Platinum Trophy Bundle:
+    sealed:
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part I Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part II Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Greek Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Norse Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Horizon Into the Forbidden West Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Uncharted Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Ghost of Tsushima Foil
+      set: sld
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part I
+      set: sld
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part II
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Greek
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Norse
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Horizon Into the Forbidden West
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Uncharted
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Ghost of Tsushima
+      set: sld
+  Secret Lair Bundle Secret Lair x PlayStation Superdrop Non Foil Trophy Bundle:
+    sealed:
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part I
+      set: sld
+    - count: 1
+      name: Secret Lair Drop The Last of Us Part II
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Greek
+      set: sld
+    - count: 1
+      name: Secret Lair Drop God of War Norse
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Horizon Into the Forbidden West
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Uncharted
+      set: sld
+    - count: 1
+      name: Secret Lair Drop Ghost of Tsushima
+      set: sld
   Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Sonic 100pct Complete Bundle: []
   Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Super Sonic Bundle Non Foil: []
   Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Super Sonic Bundle Rainbow Foil: []

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -674,6 +674,80 @@ products:
       tcgplayerProductId: '205231'
     release_date: '2019-11-26'
     subtype: SECRET_LAIR_BUNDLE
+  Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '707501'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit Second Breakfast and Beyond Foil:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '707502'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711014'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit Over the Edge of the Wild Foil:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711015'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711016'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit Smaugs Spoils Foil:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711017'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit Desolation:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711019'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit Desolation Foil:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711024'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Drop Secret Lair x The Hobbit He Who Walks Unseen Out of Sight Foil:
+    category: BOX_SET
+    identifiers:
+      cardtraderId: '406643'
+      mcmId: '903128'
+      tcgplayerProductId: '711390'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR
+  Secret Lair Bundle Secret Lair x The Hobbit A Marvelous Mathoms Superdrop A Marvelous Mathoms Everything Bundle:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711392'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR_BUNDLE
+  Secret Lair Bundle Secret Lair x The Hobbit A Marvelous Mathoms Superdrop Riddles in the Dark Foil Bundle:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711393'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR_BUNDLE
+  Secret Lair Bundle Secret Lair x The Hobbit A Marvelous Mathoms Superdrop The Bag End Non Foil Bundle:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '711394'
+    release_date: '2026-08-17'
+    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Secret Lair x PlayStation Superdrop Foil Trophy Bundle:
     category: BOX_SET
     identifiers:

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -674,6 +674,24 @@ products:
       tcgplayerProductId: '205231'
     release_date: '2019-11-26'
     subtype: SECRET_LAIR_BUNDLE
+  Secret Lair Bundle Secret Lair x PlayStation Superdrop Foil Trophy Bundle:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '660336'
+    release_date: '2025-11-06'
+    subtype: SECRET_LAIR_BUNDLE
+  Secret Lair Bundle Secret Lair x PlayStation Superdrop Platinum Trophy Bundle:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '660335'
+    release_date: '2025-11-06'
+    subtype: SECRET_LAIR_BUNDLE
+  Secret Lair Bundle Secret Lair x PlayStation Superdrop Non Foil Trophy Bundle:
+    category: BOX_SET
+    identifiers:
+      tcgplayerProductId: '660337'
+    release_date: '2025-11-06'
+    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Sonic 100pct Complete Bundle:
     category: BOX_SET
     identifiers:


### PR DESCRIPTION
Adds the 9 drops and 3 bundles from the A Marvelous Mathoms Superdrop (on sale 2026-08-17) with TCGplayer IDs, plus contents.