### PR TITLE
Reference Hobbit scene box decks in sealed contents

### DIFF
--- a/data/contents/HOB.yaml
+++ b/data/contents/HOB.yaml
@@ -126,8 +126,9 @@ products:
       set: hob
   The Hobbit Scene Box Crack the Plates:
     card_count: 6
-    other:
-    - name: 6 borderless scene cards
+    deck:
+    - name: Crack the Plates
+      set: hob
     sealed:
     - count: 3
       name: The Hobbit Play Booster Pack
@@ -142,8 +143,9 @@ products:
       set: hob
   The Hobbit Scene Box Treasures of Smaug:
     card_count: 6
-    other:
-    - name: 6 borderless scene cards
+    deck:
+    - name: Treasures of Smaug
+      set: hob
     sealed:
     - count: 3
       name: The Hobbit Play Booster Pack


### PR DESCRIPTION
Replace the generic `other` entry for the six borderless scene cards in each Hobbit Scene Box with its named `hob` deck reference: Crack the Plates and Treasures of Smaug. This allows the fixed foil cards to resolve through the deck lists while preserving each box's six-card count and three Play Boosters.

The deck lists were added in https://github.com/taw/magic-preconstructed-decks/pull/306 (merged).

Validation: `python3 scripts/contents_validator.py` completed with “All products validated”; `git diff --check` passed.
