### PR TITLE
Complete Marvel bundle contents and product accessories

### DIFF
--- a/data/contents/MSC.yaml
+++ b/data/contents/MSC.yaml
@@ -5,11 +5,19 @@ products:
     deck:
     - name: Avengers Assemble
       set: msc
+    other:
+    - name: 10 Non-foil double-sided tokens
+    - name: Reference card
+    - name: Deck box
   Marvel Super Heroes Commander Deck Avengers Assemble Collector's Edition:
     card_count: 100
     deck:
     - name: Avengers Assemble Collector's Edition
       set: msc
+    other:
+    - name: 10 Double-sided tokens (surge foil front, non-foil back)
+    - name: Reference card
+    - name: Deck box
   Marvel Super Heroes Commander Deck Collector's Edition Set of 4:
     sealed:
     - count: 1
@@ -29,11 +37,19 @@ products:
     deck:
     - name: Doom Prevails
       set: msc
+    other:
+    - name: 10 Non-foil double-sided tokens
+    - name: Reference card
+    - name: Deck box
   Marvel Super Heroes Commander Deck Doom Prevails Collector's Edition:
     card_count: 100
     deck:
     - name: Doom Prevails Collector's Edition
       set: msc
+    other:
+    - name: 10 Double-sided tokens (surge foil front, non-foil back)
+    - name: Reference card
+    - name: Deck box
   Marvel Super Heroes Commander Deck Set of 4:
     sealed:
     - count: 1
@@ -53,18 +69,34 @@ products:
     deck:
     - name: The Fantastic Four
       set: msc
+    other:
+    - name: 10 Non-foil double-sided tokens
+    - name: Reference card
+    - name: Deck box
   Marvel Super Heroes Commander Deck The Fantastic Four Collector's Edition:
     card_count: 100
     deck:
     - name: The Fantastic Four Collector's Edition
       set: msc
+    other:
+    - name: 10 Double-sided tokens (surge foil front, non-foil back)
+    - name: Reference card
+    - name: Deck box
   Marvel Super Heroes Commander Deck Wakanda Forever:
     card_count: 100
     deck:
     - name: Wakanda Forever
       set: msc
+    other:
+    - name: 10 Non-foil double-sided tokens
+    - name: Reference card
+    - name: Deck box
   Marvel Super Heroes Commander Deck Wakanda Forever Collector's Edition:
     card_count: 100
     deck:
     - name: Wakanda Forever Collector's Edition
       set: msc
+    other:
+    - name: 10 Double-sided tokens (surge foil front, non-foil back)
+    - name: Reference card
+    - name: Deck box

--- a/data/contents/MSH.yaml
+++ b/data/contents/MSH.yaml
@@ -27,6 +27,7 @@ products:
     - name: 5 double-sided tokens
     - name: 2 Gameboard playmats
     - name: 2 How to Play guides
+    - name: 2 Reference cards
     - name: Reference guide booklet
     - name: 2 Spindown life counters
   Marvel Super Heroes Beginner Box Case:
@@ -34,8 +35,29 @@ products:
     - count: 3
       name: Marvel Super Heroes Beginner Box
       set: msh
-  Marvel Super Heroes Bundle: []
-  Marvel Super Heroes Bundle Case: []
+  Marvel Super Heroes Bundle:
+    card:
+    - foil: true
+      name: The Scarlet Witch
+      number: 431
+      set: msh
+    card_count: 1
+    deck:
+    - name: Marvel Super Heroes Bundle Land Pack
+      set: msh
+    other:
+    - name: 2 Reference cards
+    - name: Oversized spindown life counter
+    - name: Card storage box
+    sealed:
+    - count: 9
+      name: Marvel Super Heroes Play Booster Pack
+      set: msh
+  Marvel Super Heroes Bundle Case:
+    sealed:
+    - count: 6
+      name: Marvel Super Heroes Bundle
+      set: msh
   Marvel Super Heroes Collector Booster Box:
     sealed:
     - count: 12
@@ -62,6 +84,7 @@ products:
       set: msh
     other:
     - name: 1 Draft insert
+    - name: 10 Non-foil double-sided tokens
     sealed:
     - count: 12
       name: Marvel Super Heroes Play Booster Pack
@@ -82,11 +105,12 @@ products:
       set: msh
     card_count: 1
     deck:
-    - name: Marvel Super Heroes Bundle Land Pack
+    - name: Marvel Super Heroes Gift Bundle Land Pack
       set: msh
     other:
-    - name: Spindown life counter
-    - name: Foil card storage box
+    - name: 2 Reference cards
+    - name: Oversized spindown life counter
+    - name: Card storage box
     sealed:
     - count: 9
       name: Marvel Super Heroes Play Booster Pack


### PR DESCRIPTION
Fill the empty Marvel Super Heroes Bundle and Bundle Case definitions: the Bundle includes its land pack, foil The Scarlet Witch promo (MSH 431), nine Play Boosters, reference cards, storage box, and spindown; the case contains six Bundles.

Point the Gift Bundle at its own city-calm land pack instead of the regular Bundle's city-chaos pack. Add omitted reference cards, Draft Night tokens, and Commander deck accessories, including the Collector's Edition tokens' surge-foil front/nonfoil back treatment.

The new Gift Bundle deck and printing corrections are in https://github.com/taw/magic-preconstructed-decks/pull/307; that deck source needs to merge and propagate before the new reference can resolve downstream.

Sources: [Wizards collecting guide](https://magic.wizards.com/en/news/feature/collecting-marvel-super-heroes), [Beginner Box contents](https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents), [six-Bundle sealed case](https://flipsidegaming.com/products/mtg-marvel-super-heroes-x6-bundle-sealed-case).

Validation: contents validator and `git diff --check` pass. Every MSH/MSC deck reference resolves against the companion source build.
