### PR TITLE
Complete Lorwyn prerelease, Draft Night and Commander contents

### DIFF
--- a/data/contents/ECC.yaml
+++ b/data/contents/ECC.yaml
@@ -5,11 +5,19 @@ products:
     deck:
     - name: Blight Curse
       set: ecc
+    other:
+    - name: 10 Double-sided tokens or punch-out counters
+    - name: 1 Reference card
+    - name: 1 Deck box
   Lorwyn Eclipsed Commander Deck Dance of the Elements:
     card_count: 100
     deck:
     - name: Dance of the Elements
       set: ecc
+    other:
+    - name: 10 Double-sided tokens or punch-out counters
+    - name: 1 Reference card
+    - name: 1 Deck box
   Lorwyn Eclipsed Commander Deck Display:
     sealed:
     - count: 2

--- a/data/contents/ECL.yaml
+++ b/data/contents/ECL.yaml
@@ -75,8 +75,11 @@ products:
     - code: collector
       set: ecl
   Lorwyn Eclipsed Draft Night:
+    card_count: 90
+    deck:
+    - name: Lorwyn Eclipsed Draft Night Land Pack
+      set: ecl
     other:
-    - name: 90 Non-foil basic lands
     - name: 10 Non-foil double-sided tokens
     - name: 1 Draft insert
     sealed:
@@ -118,4 +121,8 @@ products:
     - name: Spindown die
     pack:
     - code: prerelease
+      set: ecl
+    sealed:
+    - count: 6
+      name: Lorwyn Eclipsed Play Booster Pack
       set: ecl


### PR DESCRIPTION
Lorwyn Eclipsed Prerelease Packs currently omit their six Play Boosters, and Draft Night's 90 basic lands are only accessory text. Add the boosters and map the lands through a deck reference with card_count 90. Also add the advertised tokens/counters, reference card, and deck box to both Commander decks.

The new land-deck reference is supplied by https://github.com/taw/magic-preconstructed-decks/pull/308 and requires that upstream deck list to be available to the build.

Source: https://magic.wizards.com/en/news/feature/collecting-lorwyn-eclipsed

Validation: contents_validator.py completed successfully (existing unrelated category/subtype warnings); canonical deck JSON resolves the new reference and contains 90 nonfoil lands; checked the six-booster reference and git diff whitespace.
