### PR TITLE
Map Strixhaven land packs and complete product accessories

### DIFF
--- a/data/contents/SOC.yaml
+++ b/data/contents/SOC.yaml
@@ -5,16 +5,28 @@ products:
     deck:
     - name: Lorehold Spirit
       set: soc
+    other:
+    - name: 10 Double-sided tokens
+    - name: 1 Reference card
+    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Prismari Artistry:
     card_count: 100
     deck:
     - name: Prismari Artistry
       set: soc
+    other:
+    - name: 10 Double-sided tokens
+    - name: 1 Reference card
+    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Quandrix Unlimited:
     card_count: 100
     deck:
     - name: Quandrix Unlimited
       set: soc
+    other:
+    - name: 10 Double-sided tokens
+    - name: 1 Reference card
+    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Set of 5:
     sealed:
     - count: 1
@@ -37,8 +49,16 @@ products:
     deck:
     - name: Silverquill Influence
       set: soc
+    other:
+    - name: 10 Double-sided tokens
+    - name: 1 Reference card
+    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Witherbloom Pestilence:
     card_count: 100
     deck:
     - name: Witherbloom Pestilence
       set: soc
+    other:
+    - name: 10 Double-sided tokens
+    - name: 1 Reference card
+    - name: 1 Deck box

--- a/data/contents/SOC.yaml
+++ b/data/contents/SOC.yaml
@@ -8,7 +8,6 @@ products:
     other:
     - name: 10 Double-sided tokens
     - name: 1 Reference card
-    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Prismari Artistry:
     card_count: 100
     deck:
@@ -17,7 +16,6 @@ products:
     other:
     - name: 10 Double-sided tokens
     - name: 1 Reference card
-    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Quandrix Unlimited:
     card_count: 100
     deck:
@@ -26,7 +24,6 @@ products:
     other:
     - name: 10 Double-sided tokens
     - name: 1 Reference card
-    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Set of 5:
     sealed:
     - count: 1
@@ -52,7 +49,6 @@ products:
     other:
     - name: 10 Double-sided tokens
     - name: 1 Reference card
-    - name: 1 Deck box
   Secrets of Strixhaven Commander Deck Witherbloom Pestilence:
     card_count: 100
     deck:
@@ -61,4 +57,3 @@ products:
     other:
     - name: 10 Double-sided tokens
     - name: 1 Reference card
-    - name: 1 Deck box

--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -227,64 +227,46 @@ products:
     deck:
     - name: Black Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck Blue Deck:
     card_count: 40
     deck:
     - name: Blue Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck Green Deck:
     card_count: 40
     deck:
     - name: Green Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck Red Deck:
     card_count: 40
     deck:
     - name: Red Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck White Deck:
     card_count: 40
     deck:
     - name: White Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Welcome Deck 2026 Black Deck:
     card_count: 40
     deck:
     - name: Black Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Welcome Deck 2026 Blue Deck:
     card_count: 40
     deck:
     - name: Blue Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Welcome Deck 2026 Green Deck:
     card_count: 40
     deck:
     - name: Green Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Welcome Deck 2026 Red Deck:
     card_count: 40
     deck:
     - name: Red Deck
       set: sos
-    other:
-    - name: 1 Deck box
   Welcome Deck 2026 Set of 5:
     sealed:
     - count: 1
@@ -307,5 +289,3 @@ products:
     deck:
     - name: White Deck
       set: sos
-    other:
-    - name: 1 Deck box

--- a/data/contents/SOS.yaml
+++ b/data/contents/SOS.yaml
@@ -41,6 +41,7 @@ products:
     - name: Secrets of Strixhaven Bundle Land Pack
       set: sos
     other:
+    - name: 2 Reference cards
     - name: 1 Spindown die
     - name: 1 Card-storage box
     sealed:
@@ -53,11 +54,14 @@ products:
       name: Secrets of Strixhaven Bundle
       set: sos
   Secrets of Strixhaven Codex Bundle:
-    card_count: 2
+    card_count: 22
+    deck:
+    - name: Secrets of Strixhaven Codex Bundle Land Pack
+      set: sos
     other:
     - name: 1 Spindown die
-    - name: 20 Foil basic lands
-    - name: 1 Codex Booster
+    - name: 2 Reference cards
+    - name: 1 Card-storage box
     pack:
     - code: codex-bundle
       set: sos
@@ -94,8 +98,12 @@ products:
     - code: collector
       set: sos
   Secrets of Strixhaven Draft Night:
+    card_count: 90
+    deck:
+    - name: Secrets of Strixhaven Draft Night Land Pack
+      set: sos
     other:
-    - name: 90 Non-foil basic lands
+    - name: 10 Non-foil double-sided tokens
     - name: 1 Draft insert
     sealed:
     - count: 12
@@ -219,46 +227,64 @@ products:
     deck:
     - name: Black Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck Blue Deck:
     card_count: 40
     deck:
     - name: Blue Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck Green Deck:
     card_count: 40
     deck:
     - name: Green Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck Red Deck:
     card_count: 40
     deck:
     - name: Red Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Secrets of Strixhaven Welcome Deck White Deck:
     card_count: 40
     deck:
     - name: White Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Welcome Deck 2026 Black Deck:
     card_count: 40
     deck:
     - name: Black Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Welcome Deck 2026 Blue Deck:
     card_count: 40
     deck:
     - name: Blue Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Welcome Deck 2026 Green Deck:
     card_count: 40
     deck:
     - name: Green Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Welcome Deck 2026 Red Deck:
     card_count: 40
     deck:
     - name: Red Deck
       set: sos
+    other:
+    - name: 1 Deck box
   Welcome Deck 2026 Set of 5:
     sealed:
     - count: 1
@@ -281,3 +307,5 @@ products:
     deck:
     - name: White Deck
       set: sos
+    other:
+    - name: 1 Deck box


### PR DESCRIPTION
Strixhaven Codex Bundle and Draft Night currently describe their lands only as accessories. Map the 20 foil and 90 nonfoil lands through deck references. Codex retains its existing two-card promo pack and records 22 direct cards; remove its duplicate Codex Booster accessory description.

Add the advertised Bundle/Codex reference cards, Codex storage box, Draft Night tokens, and Commander tokens/reference cards.

The new deck references require https://github.com/taw/magic-preconstructed-decks/pull/310 to be available upstream.

Source: https://magic.wizards.com/en/news/feature/collecting-secrets-of-strixhaven

Validation: contents_validator.py passed with existing unrelated metadata warnings; both references resolve in the companion deck export with the expected totals/finishes; whitespace checks passed.
