### PR TITLE
Correct Forgotten Realms Secret Lair land-drop counts

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -3985,7 +3985,7 @@ products:
     - name: Reliquary Tower
       number: 7104
       set: sld
-    card_count: 5
+    card_count: 10
     deck:
     - name: 'Dungeons & Dragons: Lands of the Forgotten Realms'
       set: sld
@@ -3995,7 +3995,7 @@ products:
       name: Reliquary Tower
       number: 7104
       set: sld
-    card_count: 5
+    card_count: 10
     deck:
     - name: 'Dungeons & Dragons: Lands of the Forgotten Realms Foil Edition'
       set: sld


### PR DESCRIPTION
Both Lands of the Forgotten Realms drops record five cards, but each deck contains two of each basic land (ten cards). Correct card_count to 10 for the nonfoil and foil products, matching the existing canonical deck lists and Wizards’ published contents.

Source: https://magic.wizards.com/en/news/announcements/secret-lair-roll-for-initiative-superdrop

Validation: both counts checked against the existing two-of-each-basic lists; contents_validator.py passed with existing unrelated metadata warnings; whitespace checks passed.
