### PR TITLE
Add reusable sealed product audit skill

### DIFF
--- a/.agents/skills/mtg-sealed-product-audit/SKILL.md
+++ b/.agents/skills/mtg-sealed-product-audit/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: mtg-sealed-product-audit
+description: Audit Magic sealed products against Wizards collecting guides and trace missing card mappings across mtg-sealed-content, magic-preconstructed-decks, and magic-search-engine. Use for annual release audits, productless-card investigations, and product-content corrections.
+---
+
+# MTG sealed product audit
+
+Compare physical product contents with the three source layers; distinguish wrong source data from missing upstream printings and delayed downstream publication. Scope can be one release or a release year. An audit request authorizes investigation; use existing conversation authorization when deciding whether to send fixes as PRs. Do not silently expand an annual audit into unrelated tooling changes.
+
+## Source layers
+
+- `mtgjson/mtg-sealed-content` (`main`): `data/products/SET.yaml` defines products/identifiers; `data/contents/SET.yaml` describes cards, decks, packs, nested sealed products and accessories.
+- `taw/magic-preconstructed-decks` (`master`): `data/<type>/<set>/<deck>.txt` is canonical deck data. `bin/build_jsons <output>` exports sectioned deck JSON. `lib/deck_types.yaml` constrains permitted counts.
+- `taw/magic-search-engine` (`master`): `data/boosters/<set>[-<pack>].yaml` defines booster slots/queries; `index/sets.json` supplies set dates; the card index resolves printings and finishes.
+- MTGBAN productless search is a downstream symptom, not authoritative evidence that source data is missing.
+
+Use isolated worktrees and fresh origin default-branch tips in every touched repository. Follow local checkout instructions: never switch or reset the user's checkout. If its checked-out default cannot safely be fast-forwarded, leave it untouched, use the fresh origin tip in an isolated worktree and disclose the distinction. Do not measure a stale feature branch. Target each PR at its repository's default branch, never another PR. Stage only intentional source files: the sealed validator can rewrite `status.txt`, and LFS/generated outputs are unrelated to content edits.
+
+## Inventory and evidence
+
+1. Determine the requested year/releases and exclusions from the conversation. Promo Packs, unreleased sets, accessories, and Secret Lair drops are scope decisions, not automatic exclusions. If the user excludes deck boxes, preserve existing entries and omit newly proposed ones.
+2. Export current decks. Run `scripts/inventory.py` with the three worktree paths, deck JSON and year. The helper inventories date-selected products and checks empty content, unresolved references, copy cycles and deck-count discrepancies. It reports candidates, not defects.
+3. Augment date-based inventory with products in official guides: supplemental sets may be absent from the set index, and new products can use an older set code. Explicit product release dates take precedence over inherited set dates. Report cases/bundles separately from unique standalone product types. Do not call the inventory exhaustive when undated SKUs or retailer exclusives remain unreviewed.
+4. Read each guide's full product sections, not search snippets. Verify HTML extraction reaches the product details: selecting only the first `<article>` can truncate multi-section Wizards pages (observed with Innistrad Remastered). Usual URL: `https://magic.wizards.com/en/news/feature/collecting-<release>`. Search when the slug differs. First-look articles can be updated in place. Use official decklists, product pages or WPN pages for missing details. Retailer listings/unboxings can corroborate case quantities and exact printing/finish questions; label the evidence level.
+5. Compare boosters per box, boxes per case, fixed promos versus random pools, decks, land packs, finish variants, tokens/art cards and accessories. A land list in `other` contributes no mapped cards. An existing top-level topper product still needs a reference from each eligible box.
+
+## Card mapping decisions
+
+- Welcome Deck boxes may contain one fixed half-deck plus a second random half-deck of another color. A correct single half-deck list does not describe the whole sealed product. Model the random choice at the deck level, preserving card correlations.
+- Check set code, collector number, finish and product family together. A scene in a booster is not necessarily a Scene Box scene. Commander/deck, Jumpstart, tutorial and booster printings can share names but differ in numbers.
+- Distinguish fixed Bundle promos from variable pools. A missing `bundle-promo` definition does not prove there is a random pack: directly map a known single card.
+- Different bundles may share a promo but have different land lists. Verify traditional foil versus surge/etched variants; the deck syntax may encode special finishes via a separate collector number plus `[foil]`.
+- Don't infer exact art distribution from a total such as “30 lands.” Use identified printings where verified. Default-frame `SET:*` round-robin selectors and evenly split Draft Night basics are existing conventions, not proof of physical collation; disclose assumptions. Don't silently extend a convention to special-art lands.
+- Read repeated bullets in context. Seek corroboration before interpreting a duplicated seasonal-land bullet as twice as many cards.
+- Store fixed lands in a deck list or direct `card` entries. A new legitimate land-pack size may require a narrow addition to the deck-type validator.
+- Do not force every `card_count` to the sum of a deck: mixed products historically use inconsistent conventions; separately count fixed cards, randomized packs, nested sealed contents and bonus cards. Display commanders and ordinary tokens are not gameplay count. Some products (e.g. TMNT Enemy Deck) intentionally use token-typed gameplay cards and must not be reduced to zero.
+- A published decklist may still lack exact stamped reprints in the card index. Match official original-printing tables against the correct stamped set, not the unstamped original. Separate unresolved references from confirmed absences; normalize split/double-faced names and front/back identity before counting. If exact printings remain unavailable, report the dependency instead of substituting wrong cards.
+
+## Validation and delivery
+
+Read [references/validation.md](references/validation.md) for concrete commands when validating changes.
+
+Compile relevant existing boosters against the fresh index. Compilation verifies query counts/pools, not all slot odds or correlations. Only add rates supported by published data or explicitly identified repository conventions. Count physical front/back pairs as one card.
+
+For fixes, export decks, validate metadata/card names, validate sealed YAML and check cross-references against the companion export. Assert meaningful invariants: total cards, foil/nonfoil split, excluded wrong printings, fixed seasonal variants, correct nested product counts. Review the final diff for unrelated regenerated files.
+
+Work one release at a time when requested. Open separate PRs per affected repository and link cross-repository dependencies; describe what must propagate before the sealed build can resolve new references. Don't assume the user saying “merged” means every companion repository merged: fetch and verify.
+
+Deliver a sourced report by release: confirmed fixes, unresolved evidence, upstream-data dependencies, and skipped scope. Include inventory/check limits. If MTGBAN still lists cards already fixed on current defaults, check publication/rebuild state before proposing duplicate fixes. Productless pages may cap at 100; do not report that cap as a total.

--- a/.agents/skills/mtg-sealed-product-audit/references/validation.md
+++ b/.agents/skills/mtg-sealed-product-audit/references/validation.md
@@ -1,0 +1,69 @@
+# Validation recipes
+
+Use the repositories' documented dependency environments. The inventory helper requires Python 3 and PyYAML; deck and booster validation require their Ruby dependencies and generated card data. Verify the selected interpreter after changing PATH. Git LFS may need access to the shared repository's cache even from an isolated worktree.
+
+## Inventory
+
+From the sealed worktree, after exporting decks:
+
+```sh
+python3 .agents/skills/mtg-sealed-product-audit/scripts/inventory.py \
+  --sealed . \
+  --search /path/to/magic-search-engine-worktree \
+  --decks-json /tmp/audit-decks.json \
+  --year 2025 \
+  --output /tmp/audit-inventory.json
+```
+
+Replace the year and paths with the current audit scope. Repeat `--include-set CODE` to include a set outside the date selection. The helper only reads source data and writes the requested report; findings require manual verification.
+
+## Decks
+
+From the isolated deck worktree:
+
+```
+ruby bin/build_jsons /tmp/audit-decks.json
+ruby bin/validate_card_names
+```
+
+Use the repository's dependency environment. `build_jsons` requires an output argument; without it, it validates but saves nothing. Export contains `set_code`, `name`, `release_date` and `cards` keyed by section. Inspect all gameplay sections and preserve display/token distinctions.
+
+## Sealed
+
+```
+python3 scripts/contents_validator.py
+git diff --check -- data/contents/SET.yaml
+```
+
+The validator may emit pre-existing category/subtype warnings and rewrite `status.txt`; retain its output and distinguish success from warnings. It does not prove that a deck/booster reference resolves upstream. Check the new references against fresh exports separately. Don't stage the generated status/output files.
+
+## Booster compilation
+
+From the search worktree, with the `search-engine/Gemfile` dependency environment:
+
+```ruby
+require_relative 'search-engine/lib/card_database'
+require_relative 'booster_indexer/lib/booster_indexer'
+db = CardDatabase.load
+indexer = BoosterIndexer.new
+indexer.load_data
+code = 'hob-prerelease' # replace with target
+set_code, pack_code = code.split('-', 2)
+data = PreprocessBooster.new(indexer, code, YAML.load_file("data/boosters/#{code}.yaml")).call
+pack = PackFactory.new(db, db.sets.fetch(set_code), pack_code || 'default', data).build_pack
+puts pack.cards.size
+```
+
+Inspect physical card finishes and compare pool membership; `db.search(...).printings` can contain both faces while compiled packs count physical cards. A successful compilation is not evidence that an inferred probability is official.
+
+## PRs
+
+Inspect remotes before pushing: origin may be upstream read-only, while a `github` remote points to the user's writable fork. Use explicit default bases and body files with real newlines. Keep the description about the final implementation, validation and dependencies.
+
+Useful 2026 examples (historical evidence, not current status):
+- Decks #307 / sealed #541: tutorial/Commander collector numbers and separate Marvel Bundle/Gift Bundle lands.
+- Sealed #542–544: missing prerelease boosters, Draft Night land references, accessories and case quantities.
+- Decks #311 / search #562 / sealed #545: 34-land Hobbit bundles, fixed promo, four seasonal Plains and topper links.
+- Sealed #546: ten land cards confused with five distinct names.
+
+Known deferred example: Miku decklist was published but many stamped source printings were absent from the inspected index. Recheck before reusing that finding; don't treat its historical missing count as current.

--- a/.agents/skills/mtg-sealed-product-audit/scripts/inventory.py
+++ b/.agents/skills/mtg-sealed-product-audit/scripts/inventory.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Inventory an MTG release year; output candidates, never automatic fixes."""
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+import yaml
+
+p = argparse.ArgumentParser(description=__doc__)
+p.add_argument('--sealed', type=Path, required=True)
+p.add_argument('--search', type=Path, required=True)
+p.add_argument('--decks-json', type=Path, required=True)
+p.add_argument('--year', type=int, required=True)
+p.add_argument('--include-set', action='append', default=[])
+p.add_argument('--output', type=Path, required=True)
+a = p.parse_args()
+sets = json.loads((a.search / 'index/sets.json').read_text())
+decks = {(d['set_code'].lower(), d['name']): d for d in json.loads(a.decks_json.read_text())}
+contents = {f.stem.lower(): (yaml.safe_load(f.read_text()) or {}).get('products', {})
+            for f in (a.sealed / 'data/contents').glob('*.yaml')}
+rows, issues, undated = [], [], []
+
+def issue(product, kind, detail):
+    issues.append({'product': product, 'kind': kind, 'detail': detail})
+
+def scan(value, product, code, seen):
+    if isinstance(value, list):
+        for v in value:
+            scan(v, product, code, seen)
+    elif isinstance(value, dict):
+        for key, values in value.items():
+            if key == 'copy':
+                target = (code, values)
+                if target in seen:
+                    issue(product, 'copy_cycle', values)
+                elif values not in contents.get(code, {}):
+                    issue(product, 'missing_copy', values)
+                else:
+                    scan(contents[code][values], product, code, seen | {target})
+            elif key in ('deck', 'pack', 'sealed'):
+                for r in values:
+                    sc = r.get('set', code).lower()
+                    if key == 'deck' and (sc, r['name']) not in decks:
+                        issue(product, 'missing_deck', r)
+                    elif key == 'sealed' and r['name'] not in contents.get(sc, {}):
+                        issue(product, 'missing_sealed', r)
+                    elif key == 'pack':
+                        filename = sc + ('' if r['code'] == 'default' else '-' + r['code']) + '.yaml'
+                        if not (a.search / 'data/boosters' / filename).exists():
+                            issue(product, 'missing_pack', r)
+            else:
+                scan(values, product, code, seen)
+
+for f in sorted((a.sealed / 'data/products').glob('*.yaml')):
+    code = f.stem.lower()
+    for name, info in (yaml.safe_load(f.read_text()) or {}).get('products', {}).items():
+        if not isinstance(info, dict):
+            continue
+        explicit = info.get('release_date')
+        date = str(explicit or sets.get(code, {}).get('release_date') or '')
+        if not date:
+            undated.append({'code': code, 'name': name})
+        if not date.startswith(str(a.year)) and code not in a.include_set:
+            continue
+        product = code + '/' + name
+        row = {'code': code, 'name': name, 'date': date,
+               'date_source': 'product' if explicit else 'set' if date else 'manual',
+               'category': info.get('category'), 'subtype': info.get('subtype')}
+        rows.append(row)
+        value = contents.get(code, {}).get(name)
+        if not value:
+            issue(product, 'empty_contents', {})
+            continue
+        scan(value, product, code, {(code, name)})
+        if isinstance(value, dict) and value.get('deck'):
+            refs = [(r.get('set', code).lower(), r['name']) for r in value['deck']]
+            if all(r in decks for r in refs):
+                count = sum(c['count'] for r in refs for section, cards in decks[r]['cards'].items()
+                            if section != 'Display Commander' for c in cards if not c.get('token'))
+                if count != value.get('card_count'):
+                    issue(product, 'count_review', {'stored': value.get('card_count'),
+                          'deck_gameplay_count': count, 'other_content_fields': sorted(set(value) - {'deck', 'card_count'})})
+result = {'year': a.year, 'products': rows, 'issues': issues,
+          'undated_products': undated,
+          'limits': ['Date-selected catalog entries, not proof of complete SKU coverage.',
+                     'Count differences require manual review of mixed products and gameplay tokens.',
+                     'Pack existence checks do not compile queries or verify slot probabilities.']}
+a.output.write_text(json.dumps(result, indent=2, default=str) + '\n')
+print(json.dumps({'products': len(rows), 'sets': dict(Counter(r['code'] for r in rows)),
+                  'issues': dict(Counter(i['kind'] for i in issues)), 'undated': len(undated)}, indent=2))


### PR DESCRIPTION
Add a reusable product-audit skill under `.agents/skills/mtg-sealed-product-audit` so contributors can repeat the collecting-guide audits across sealed contents, preconstructed decks, and booster definitions.

Includes the source-mapping workflow, validation recipes, and a read-only inventory helper for annual product selection, missing references, empty contents, copy cycles, and count-review candidates. Documents limitations around collation assumptions, mixed-product counts, and downstream productless results.

Validation: skill validator passed; helper CLI checked; synthetic inventory verified empty contents, missing packs, copy cycles, and count discrepancies. The helper also completed the 2025 inventory before being copied into this PR. No product data changes.
