### PR TITLE
Filter Secret Lair bundles and remove empty entries

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -284,8 +284,6 @@ products:
     - count: 1
       name: Secret Lair Bundle August Superdrop Non stop Non Foil
       set: sld
-  Secret Lair Bundle Burn Em All Bundle: []
-  Secret Lair Bundle Burn Em All Bundle Rainbow Foil: []
   Secret Lair Bundle Camp Totally Safe Superdrop Hatsune Miku Electric Entourage Bundle:
     sealed:
     - count: 1
@@ -423,12 +421,6 @@ products:
     - count: 1
       name: Secret Lair Drop Tome of the Astral Sorceress
       set: sld
-  Secret Lair Bundle Chill Beats Bundle: []
-  Secret Lair Bundle Chill Beats Bundle Rainbow Foil: []
-  Secret Lair Bundle Commander Reinforcements Counter Intelligence Bundle: []
-  Secret Lair Bundle Commander Reinforcements Counter Intelligence Bundle Galaxy Foil: []
-  Secret Lair Bundle Commander Reinforcements World Shaper Bundle: []
-  Secret Lair Bundle Commander Reinforcements World Shaper Bundle Galaxy Foil: []
   Secret Lair Bundle December Superdrop Foil:
     sealed:
     - count: 1
@@ -619,9 +611,6 @@ products:
     - count: 1
       name: Secret Lair Drop Secret Lair x Dungeons and Dragons Karlachs Rage
       set: sld
-  Secret Lair Bundle EVERYTHING IS ON FIRE Non Foil Playset: []
-  Secret Lair Bundle EVERYTHING IS ON FIRE Rainbow Foil Playset: []
-  Secret Lair Bundle EVERYTHING IS ON FIRE Raised Foil Playset: []
   Secret Lair Bundle Equinox Superdrop 2024 A Celebration of Everything Foil and Non Foil:
     card:
     - foil: true
@@ -866,14 +855,6 @@ products:
     - count: 1
       name: Secret Lair Bundle February Superdrop Non stop Non Foil
       set: sld
-  Secret Lair Bundle Inside an Elevator Superdrop Brain Dead: []
-  Secret Lair Bundle Inside an Elevator Superdrop Brain Dead Foil: []
-  Secret Lair Bundle Inside an Elevator Superdrop Small Talk: []
-  Secret Lair Bundle Inside an Elevator Superdrop Small Talk Foil: []
-  Secret Lair Bundle Inside an Elevator Superdrop Take Me to the Floor with Everything: []
-  Secret Lair Bundle Inside an Elevator Superdrop Take Me to the Floor with Foils: []
-  Secret Lair Bundle Inside an Elevator Superdrop Take Me to the Floor with Non Foils: []
-  Secret Lair Bundle Interim Bosss Bant: []
   Secret Lair Bundle June Superdrop Full of Foils:
     sealed:
     - count: 1
@@ -922,11 +903,6 @@ products:
     - count: 1
       name: Secret Lair Bundle June Superdrop Non stop Non Foil
       set: sld
-  Secret Lair Bundle KEXP Where the Music Matters Non Foil: []
-  Secret Lair Bundle KEXP Where the Music Matters Rainbow Foil: []
-  Secret Lair Bundle Marvel Superdrop The Astonishing Foil Bundle: []
-  Secret Lair Bundle Marvel Superdrop The Heroic Everything Bundle: []
-  Secret Lair Bundle Marvel Superdrop The Mighty Non Foil Bundle: []
   Secret Lair Bundle October Superdrop 2021 Boo Tacular Bundle:
     sealed:
     - count: 1
@@ -1067,10 +1043,6 @@ products:
     - count: 1
       name: Secret Lair Drop Secret Lair x Warhammer Age of Sigmar Foil
       set: sld
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Biggest Bundle Ever: []
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Break Room Disco Ball Made of Foils: []
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Cover the Bosss Office with Everything: []
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Desk Fort Made ofs: []
   Secret Lair Bundle Out of Time Superdrop The Worlds Bundliest Bundle:
     sealed:
     - count: 1
@@ -1160,10 +1132,6 @@ products:
     - count: 1
       name: Secret Lair Commander Deck Heads I Win Tails You Lose
       set: sld
-  Secret Lair Bundle Secret Lair Drop Series Full: []
-  Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Sonic 100pct Complete Bundle: []
-  Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Super Sonic Bundle Non Foil: []
-  Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Super Sonic Bundle Rainbow Foil: []
   Secret Lair Bundle Secretversary Superdrop 2023 Goodie Bag Loaded with Everything:
     sealed:
     - count: 1
@@ -1233,13 +1201,6 @@ products:
     - count: 1
       name: Secret Lair Drop Paradise Frost
       set: sld
-  Secret Lair Bundle Secretversary Superdrop 2023 Holiday Gift Bag: []
-  Secret Lair Bundle Secretversary Superdrop 2023 Holiday Gift Bag Foil: []
-  Secret Lair Bundle Secretversary Superdrop 2023 Jungle: []
-  Secret Lair Bundle Secretversary Superdrop 2023 Jungle Foil: []
-  Secret Lair Bundle Secretversary Superdrop 2023 Lara Crofts Adventuring: []
-  Secret Lair Bundle Secretversary Superdrop 2023 Lara Crofts Adventuring Foil: []
-  Secret Lair Bundle Secretversary Superdrop 2023 Welcome to Jurassic World: []
   Secret Lair Bundle Secretversary Superdrop Foils Forever Bundle: []
   Secret Lair Bundle Secretversary Superdrop No Foils No Nonsense Bundle: []
   Secret Lair Bundle Secretversary Superdrop The Bundle Bundle:
@@ -1250,9 +1211,6 @@ products:
     - count: 1
       name: Secret Lair Bundle Secretversary Superdrop No Foils No Nonsense Bundle
       set: sld
-  Secret Lair Bundle Smitten Superdrop All Our Love: []
-  Secret Lair Bundle Spongebob Squarepants: []
-  Secret Lair Bundle Spongebob Squarepants Rainbow Foil: []
   Secret Lair Bundle Spookydrop 2023 Cards in Costume:
     sealed:
     - count: 1
@@ -1388,14 +1346,6 @@ products:
       set: sld
   Secret Lair Bundle Spring Superdrop 2023 Those Foils Are Really Coming Down: []
   Secret Lair Bundle Spring Superdrop 2023 Those Non Foils Just Wont Let Up: []
-  Secret Lair Bundle Spring Superdrop 2024 All The Foils Are Blooming: []
-  Secret Lair Bundle Spring Superdrop 2024 All The Non Foils Are Blooming: []
-  Secret Lair Bundle Spring Superdrop 2024 Everything is Blooming: []
-  Secret Lair Bundle Spring Superdrop 2024 Hatsune Miku Sakura Superstar: []
-  Secret Lair Bundle Spring Superdrop 2024 Outlaws of Thunder Junction Bundle: []
-  Secret Lair Bundle Spring Superdrop 2024 Outlaws of Thunder Junction Foil: []
-  Secret Lair Bundle Spring Superdrop 2024 Spring Into Action: []
-  Secret Lair Bundle Spring Superdrop 2024 Spring Into Action Foil: []
   Secret Lair Bundle Summer Superdrop 2023 Carving Up A Barrel of Foils:
     sealed:
     - count: 1
@@ -1427,17 +1377,6 @@ products:
     - count: 1
       name: Secret Lair Drop More Adventures in Middle earth Foil
       set: sld
-  Secret Lair Bundle Summer Superdrop 2023 Seven In Heaven: []
-  Secret Lair Bundle Summer Superdrop 2023 Shredding A Wave of Everything: []
-  Secret Lair Bundle Summer Superdrop 2023 Tearing Up A Sick Tube of Non Foils: []
-  Secret Lair Bundle Summer Superdrop 2024 Hatsune Miku Digital Sensation: []
-  Secret Lair Bundle Summer Superdrop 2024 Showstopper Bundle: []
-  Secret Lair Bundle Summer Superdrop 2024 Showstopper Bundle Foil: []
-  Secret Lair Bundle Summer Superdrop 2024 The Stage with Everything: []
-  Secret Lair Bundle Summer Superdrop 2024 The Stage with Foils: []
-  Secret Lair Bundle Summer Superdrop 2024 The Stage with Non Foils: []
-  Secret Lair Bundle Summer Superdrop 2024 Virtuoso Foil: []
-  Secret Lair Bundle Summer Superdrop 2024 Virtuoson: []
   Secret Lair Bundle Summer Superdrop 2025 The Artist Spotlight Bundle Non Foil:
     sealed:
     - count: 1
@@ -1601,10 +1540,6 @@ products:
         set: slu
     variable_mode:
       count: 1
-  Secret Lair Bundle The Ultimate Pencil Almost Everything: []
-  Secret Lair Bundle The Ultimate Pencil Literally Everything: []
-  Secret Lair Bundle The Ultimate Pencil Non Foil: []
-  Secret Lair Bundle The Ultimate Pencil Rainbow Foil: []
   Secret Lair Bundle Theros Stargazing Vol I-V:
     sealed:
     - count: 1
@@ -1622,7 +1557,6 @@ products:
     - count: 1
       name: Secret Lair Drop Theros Stargazing Vol V Nylea
       set: sld
-  Secret Lair Bundle Whimsy and Wonder Bundle Rainbow Foil: []
   Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted: []
   Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Everything:
     sealed:
@@ -1633,24 +1567,6 @@ products:
       name: Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Foil
       set: sld
   Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Foil: []
-  Secret Lair Bundle Winter Superdrop 2024 All the Savory Non Foils: []
-  Secret Lair Bundle Winter Superdrop 2024 All the Sweet Foils: []
-  Secret Lair Bundle Winter Superdrop 2024 Beastly Breakfast Omens Foil: []
-  Secret Lair Bundle Winter Superdrop 2024 Beastly Breakfast Omens Non-Foil: []
-  Secret Lair Bundle Winter Superdrop 2024 Dark Mysteries Bundle Foil: []
-  Secret Lair Bundle Winter Superdrop 2024 Dark Mysteries Bundle Non-Foil: []
-  Secret Lair Bundle Winter Superdrop 2024 Everything on the Menu: []
-  Secret Lair Bundle Winter Superdrop 2025 Campfire Merriment Foil: []
-  Secret Lair Bundle Winter Superdrop 2025 Campfire Merriment Non Foil: []
-  Secret Lair Bundle Winter Superdrop 2025 Everything a Pioneer Needs: []
-  Secret Lair Bundle Winter Superdrop 2025 Hatsune Miku Winter Diva: []
-  Secret Lair Bundle Winter Superdrop 2025 Survival Grade Foils: []
-  Secret Lair Bundle Winter Superdrop 2025 Trail Ready Non Foils: []
-  Secret Lair Bundle Winter Superdrop 2025 Trailblazing Foil: []
-  Secret Lair Bundle Winter Superdrop 2025 Trailblazing Non Foil: []
-  Secret Lair Bundle vroooOOOMMMMMM Non Foil Playset: []
-  Secret Lair Bundle vroooOOOMMMMMM Rainbow Foil Playset: []
-  Secret Lair Bundle vroooOOOMMMMMM Raised Foil Playset: []
   Secret Lair Commander Deck 20 Ways to Win:
     card:
     - foil: true

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -195,18 +195,6 @@ products:
     identifiers:
       tcgplayerProductId: '283288'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Burn Em All Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646781'
-    release_date: '2025-06-16'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Burn Em All Bundle Rainbow Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646782'
-    release_date: '2025-06-16'
-    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Camp Totally Safe Superdrop Hatsune Miku Electric Entourage Bundle:
     category: BOX_SET
     identifiers:
@@ -254,42 +242,6 @@ products:
     identifiers:
       tcgplayerProductId: '584514'
     release_date: '2024-10-01'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Chill Beats Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646784'
-    release_date: '2025-06-16'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Chill Beats Bundle Rainbow Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646783'
-    release_date: '2025-06-16'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Commander Reinforcements Counter Intelligence Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646785'
-    release_date: '2025-07-29'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Commander Reinforcements Counter Intelligence Bundle Galaxy Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646786'
-    release_date: '2025-07-29'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Commander Reinforcements World Shaper Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646788'
-    release_date: '2025-07-29'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Commander Reinforcements World Shaper Bundle Galaxy Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646787'
-    release_date: '2025-07-29'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle December Superdrop Foil:
     category: BOX_SET
@@ -357,24 +309,6 @@ products:
     identifiers:
       tcgplayerProductId: '565538'
     release_date: '2024-08-28'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle EVERYTHING IS ON FIRE Non Foil Playset:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632032'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle EVERYTHING IS ON FIRE Rainbow Foil Playset:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632031'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle EVERYTHING IS ON FIRE Raised Foil Playset:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632029'
-    release_date: '2025-05-13'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Equinox Superdrop 2024 A Celebration of Everything Foil and Non Foil:
     category: BOX_SET
@@ -458,54 +392,6 @@ products:
     identifiers:
       tcgplayerProductId: '267767'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Inside an Elevator Superdrop Brain Dead:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '561540'
-    release_date: '2024-06-07'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Inside an Elevator Superdrop Brain Dead Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '561536'
-    release_date: '2024-06-07'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Inside an Elevator Superdrop Small Talk:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '561529'
-    release_date: '2024-07-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Inside an Elevator Superdrop Small Talk Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '561528'
-    release_date: '2024-07-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Inside an Elevator Superdrop Take Me to the Floor with Everything:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '561522'
-    release_date: '2024-07-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Inside an Elevator Superdrop Take Me to the Floor with Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '561525'
-    release_date: '2024-07-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Inside an Elevator Superdrop Take Me to the Floor with Non Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '561526'
-    release_date: '2024-07-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Interim Bosss Bant:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '624758'
-    release_date: '2025-03-25'
-    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle June Superdrop Full of Foils:
     category: BOX_SET
     identifiers:
@@ -520,37 +406,6 @@ products:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '275822'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle KEXP Where the Music Matters Non Foil:
-    category: BOX_SET
-    identifiers:
-      hareruyaId: '177517'
-      tcgplayerProductId: '632023'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle KEXP Where the Music Matters Rainbow Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632021'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Marvel Superdrop The Astonishing Foil Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '592059'
-    release_date: '2024-11-05'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Marvel Superdrop The Heroic Everything Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '592056'
-    release_date: '2024-11-05'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Marvel Superdrop The Mighty Non Foil Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '592060'
-    release_date: '2024-11-05'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle October Superdrop 2021 Boo Tacular Bundle:
     category: BOX_SET
@@ -600,30 +455,6 @@ products:
       tcgplayerProductId: '450513'
     release_date: '2022-12-05'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Biggest Bundle Ever:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '624906'
-    release_date: '2022-12-05'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Break Room Disco Ball Made of Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '624753'
-    release_date: '2025-03-25'
-    subtype: SECRET_LAIR
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Cover the Bosss Office with Everything:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '624759'
-    release_date: '2025-03-25'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Our Boss is on Vacation Superdrop Desk Fort Made ofs:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '624751'
-    release_date: '2025-03-25'
-    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Out of Time Superdrop The Worlds Bundliest Bundle:
     category: BOX_SET
     identifiers:
@@ -666,32 +497,6 @@ products:
       tcgplayerProductId: '258496'
     release_date: '2022-05-06'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secret Lair Drop Series Full:
-    category: BOX_SET
-    identifiers:
-      hareruyaId: '78420'
-      mcmId: '426601'
-      tcgplayerProductId: '205231'
-    release_date: '2019-11-26'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Sonic 100pct Complete Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '643599'
-    release_date: '2025-08-08'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Super Sonic Bundle Non Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '643597'
-    release_date: '2025-08-08'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secret Lair x Sonic the Hedgehog Superdrop Super Sonic Bundle Rainbow Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '643598'
-    release_date: '2025-08-08'
-    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Secretversary Superdrop 2023 Goodie Bag Loaded with Everything:
     category: BOX_SET
     identifiers:
@@ -708,48 +513,6 @@ products:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '528415'
-    release_date: '2023-09-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secretversary Superdrop 2023 Holiday Gift Bag:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '528410'
-    release_date: '2023-09-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secretversary Superdrop 2023 Holiday Gift Bag Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '528411'
-    release_date: '2023-09-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secretversary Superdrop 2023 Jungle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '528408'
-    release_date: '2023-09-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secretversary Superdrop 2023 Jungle Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '528409'
-    release_date: '2023-09-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secretversary Superdrop 2023 Lara Crofts Adventuring:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '528412'
-    release_date: '2023-09-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secretversary Superdrop 2023 Lara Crofts Adventuring Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '528413'
-    release_date: '2023-09-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Secretversary Superdrop 2023 Welcome to Jurassic World:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '528414'
     release_date: '2023-09-23'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Secretversary Superdrop Foils Forever Bundle:
@@ -776,26 +539,6 @@ products:
       tcgplayerProductId: '228711'
     release_date: '2021-03-15'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Smitten Superdrop All Our Love:
-    category: BOX_SET
-    identifiers:
-      cardtraderId: '152838'
-      mcmId: '540178'
-      tcgplayerProductId: '233762'
-    release_date: '2021-04-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spongebob Squarepants:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '624750'
-    release_date: '2025-03-25'
-    subtype: SECRET_LAIR
-  Secret Lair Bundle Spongebob Squarepants Rainbow Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '624749'
-    release_date: '2025-03-25'
-    subtype: SECRET_LAIR
   Secret Lair Bundle Spookydrop 2023 Cards in Costume:
     category: BOX_SET
     identifiers:
@@ -868,54 +611,6 @@ products:
       tcgplayerProductId: '493795'
     release_date: '2023-08-11'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 All The Foils Are Blooming:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551408'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 All The Non Foils Are Blooming:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551409'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 Everything is Blooming:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551407'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 Hatsune Miku Sakura Superstar:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551411'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 Outlaws of Thunder Junction Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551419'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 Outlaws of Thunder Junction Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551417'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 Spring Into Action:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551415'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2024 Spring Into Action Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '551413'
-    release_date: '2024-05-30'
-    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Summer Superdrop 2023 Carving Up A Barrel of Foils:
     category: BOX_SET
     identifiers:
@@ -927,72 +622,6 @@ products:
     identifiers:
       tcgplayerProductId: '501833'
     release_date: '2023-08-29'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2023 Seven In Heaven:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '511864'
-    release_date: '2023-08-29'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2023 Shredding A Wave of Everything:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '501823'
-    release_date: '2023-09-06'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2023 Tearing Up A Sick Tube of Non Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '501828'
-    release_date: '2023-08-29'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 Hatsune Miku Digital Sensation:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556779'
-    release_date: '2024-07-10'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 Showstopper Bundle:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556781'
-    release_date: '2024-07-10'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 Showstopper Bundle Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556780'
-    release_date: '2024-07-10'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 The Stage with Everything:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556776'
-    release_date: '2025-07-10'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 The Stage with Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556777'
-    release_date: '2024-07-10'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 The Stage with Non Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556778'
-    release_date: '2024-07-10'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 Virtuoso Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556782'
-    release_date: '2024-07-10'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Summer Superdrop 2024 Virtuoson:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '556783'
-    release_date: '2024-04-25'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Summer Superdrop 2025 The Artist Spotlight Bundle Non Foil:
     category: BOX_SET
@@ -1050,30 +679,6 @@ products:
       tcgplayerProductId: '214937'
     release_date: '2025-06-10'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle The Ultimate Pencil Almost Everything:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632044'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle The Ultimate Pencil Literally Everything:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632047'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle The Ultimate Pencil Non Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632040'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle The Ultimate Pencil Rainbow Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632042'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Theros Stargazing Vol I-V:
     category: BOX_SET
     identifiers:
@@ -1083,12 +688,6 @@ products:
       tcgplayerProductId: '209384'
       tntId: '1655972'
     release_date: '2020-02-14'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Whimsy and Wonder Bundle Rainbow Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '646780'
-    release_date: '2025-06-16'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted:
     category: BOX_SET
@@ -1107,114 +706,6 @@ products:
     identifiers:
       tcgplayerProductId: '480444'
     release_date: '2023-04-14'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2024 All the Savory Non Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '537667'
-    release_date: '2024-02-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2024 All the Sweet Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '537665'
-    release_date: '2024-02-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2024 Beastly Breakfast Omens Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '537671'
-    release_date: '2024-02-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2024 Beastly Breakfast Omens Non-Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '537672'
-    release_date: '2024-02-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2024 Dark Mysteries Bundle Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '537669'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2024 Dark Mysteries Bundle Non-Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '537670'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2024 Everything on the Menu:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '537661'
-    release_date: '2024-02-23'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Campfire Merriment Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618120'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Campfire Merriment Non Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618121'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Everything a Pioneer Needs:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618116'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Hatsune Miku Winter Diva:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618113'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Survival Grade Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618117'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Trail Ready Non Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618118'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Trailblazing Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618114'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2025 Trailblazing Non Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '618115'
-    release_date: '2025-02-11'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle vroooOOOMMMMMM Non Foil Playset:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632025'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle vroooOOOMMMMMM Rainbow Foil Playset:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632027'
-    release_date: '2025-05-13'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle vroooOOOMMMMMM Raised Foil Playset:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '632028'
-    release_date: '2025-05-13'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Commander Deck 20 Ways to Win:
     category: DECK

--- a/scripts/load_new_products.py
+++ b/scripts/load_new_products.py
@@ -137,7 +137,7 @@ def get_tcgplayer(api_version, auth_code):
                 if any(tag.lower() in product_name.lower() for tag in skip_tags):
                     continue
 
-                if "Secret Lair" in product_name:
+                if "secret lair" in group_id[1].lower() or "secret lair" in product_name.lower():
                     if any(tag.lower() in product_name.lower() for tag in sld_skip_tags):
                         continue
 


### PR DESCRIPTION
Exclude Secret Lair bundles during TCGplayer discovery and remove 84 unreferenced empty bundle entries from the SLD product catalog and contents.

Two commits:
- Recognize Secret Lair by catalog group or product title when filtering bundles, preserving ordinary set Bundles and individual drops.
- Remove the 84 empty placeholders, including all 41 flagged by the 2025 audit. Retain seven empty bundles still referenced by larger products to avoid dangling references.

No ignore-list additions or test files. TCGplayer filtering prevents rediscovery there; other vendor importers retain their existing behavior.

Validation: importer checked with mocked catalog responses; contents validator passed with existing category/subtype warnings; verified populated entries remain unchanged and the diff passes whitespace checks.
