### PR TITLE
Map Aetherdrift Finish Line Bundle lands

### DIFF
--- a/data/contents/DFT.yaml
+++ b/data/contents/DFT.yaml
@@ -64,9 +64,11 @@ products:
       name: Muraganda Raceway
       number: 426
       set: dft
+    deck:
+    - name: Aetherdrift Finish Line Bundle Land Pack
+      set: dft
     other:
-    - name: 15 Foil Basic Lands Bundle
-    - name: 5 First-Place Foil Basic Lands Bundle
+    - name: 2 Reference Cards
     - name: 5 Stickers
     - name: 1 Aetherdrift Spindown
     - name: 1 Aetherdrift Card Storage Box


### PR DESCRIPTION
Map the Aetherdrift Finish Line Bundle's 20 lands through a deck reference instead of two accessory descriptions. Also add its two reference cards, documented in the [product contents](https://www.target.com/p/-/A-94411719).

The land pack contains 15 traditional-foil basics and five first-place foil Driver's Seat lands, matching the [Wizards collecting guide](https://magic.wizards.com/en/news/feature/collecting-aetherdrift). The deck uses the existing Bundle convention for ordinary basic artwork allocation; exact collation is unverified.

Depends on https://github.com/taw/magic-preconstructed-decks/pull/312 merging and propagating to the deck export before this reference can resolve in the production build.

Validation: contents validator passed with existing category/subtype warnings; checked the new reference against the companion export, 20 foil lands, five explicit first-place collector numbers, and preserved the three Raceway promos and existing boosters. No test files added.
