### PR TITLE
Complete Final Fantasy product contents

### DIFF
--- a/data/contents/FIC.yaml
+++ b/data/contents/FIC.yaml
@@ -7,6 +7,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 6 Double-Sided Tokens
     - name: 4 Punch-Out Counter Cards
     sealed:
@@ -20,6 +21,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 6 Surge Foil Double-Sided Tokens
     - name: 4 Punch-Out Counter Cards
     sealed:
@@ -33,6 +35,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 10 Double-Sided Tokens
     sealed:
     - count: 1
@@ -45,6 +48,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 10 Surge Foil Double-Sided Tokens
     sealed:
     - count: 1
@@ -56,9 +60,9 @@ products:
       name: Cloud, Midgar Mercenary
       number: 2025-21
       set: pmei
-    card_count: 100
+    card_count: 1
     other:
-    - name: Code to redeedm for Final Fantasy VII digital game
+    - name: Code to redeem for Final Fantasy VII digital game
     sealed:
     - count: 1
       name: Final Fantasy Commander Deck Limit Break
@@ -75,6 +79,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 10 Double-Sided Tokens
     sealed:
     - count: 1
@@ -87,6 +92,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 10 Surge Foil Double-Sided Tokens
     sealed:
     - count: 1
@@ -99,6 +105,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 10 Double-Sided Tokens
     sealed:
     - count: 1
@@ -111,6 +118,7 @@ products:
       set: fic
     other:
     - name: Deck Box
+    - name: 1 Reference Card
     - name: 10 Surge Foil Double-Sided Tokens
     sealed:
     - count: 1

--- a/data/contents/FIN.yaml
+++ b/data/contents/FIN.yaml
@@ -1,25 +1,5 @@
 code: fin
 products:
-  Final Fantasy Box Set Camp Comrades:
-    card_count: 6
-    deck:
-    - name: Camp Comrades
-      set: fin
-  Final Fantasy Box Set Children of Fate:
-    card_count: 6
-    deck:
-    - name: Children of Fate
-      set: fin
-  Final Fantasy Box Set Garland at the Chaos Shrine:
-    card_count: 6
-    deck:
-    - name: Garland at the Chaos Shrine
-      set: fin
-  Final Fantasy Box Set The Siege of Alexandria:
-    card_count: 6
-    deck:
-    - name: The Siege of Alexandria
-      set: fin
   Final Fantasy Bundle:
     card_count: 2
     deck:
@@ -41,6 +21,7 @@ products:
       name: Final Fantasy Bundle
       set: fin
   Final Fantasy Chocobo Booster Pack:
+    card_count: 12
     pack:
     - code: chocobo-bundle
       set: fin
@@ -55,7 +36,7 @@ products:
     - name: Final Fantasy Bundle Land Pack
       set: fin
     other:
-    - name: Final Fantasy Spindown
+    - name: Final Fantasy Chocobo Click Wheel
     - name: Final Fantasy Card Storage Box
     pack:
     - code: chocobo-bundle-scene
@@ -185,6 +166,15 @@ products:
       set: fin
   Final Fantasy Scene Box Set of 4:
     sealed:
+    - count: 1
+      name: Final Fantasy Scene Box Camp Comrades
+      set: fin
+    - count: 1
+      name: Final Fantasy Scene Box Children of Fate
+      set: fin
+    - count: 1
+      name: Final Fantasy Scene Box Garland at the Chaos Shrine
+      set: fin
     - count: 1
       name: Final Fantasy Scene Box The Siege of Alexandria
       set: fin

--- a/data/products/FIN.yaml
+++ b/data/products/FIN.yaml
@@ -1,25 +1,5 @@
 code: fin
 products:
-  Final Fantasy Box Set Camp Comrades:
-    category: BOX_SET
-    identifiers: {}
-    release_date: '2025-06-13'
-    subtype: OTHER
-  Final Fantasy Box Set Children of Fate:
-    category: BOX_SET
-    identifiers: {}
-    release_date: '2025-06-13'
-    subtype: OTHER
-  Final Fantasy Box Set Garland at the Chaos Shrine:
-    category: BOX_SET
-    identifiers: {}
-    release_date: '2025-06-13'
-    subtype: OTHER
-  Final Fantasy Box Set The Siege of Alexandria:
-    category: BOX_SET
-    identifiers: {}
-    release_date: '2025-06-13'
-    subtype: OTHER
   Final Fantasy Bundle:
     category: BUNDLE
     identifiers:


### PR DESCRIPTION
Complete the Final Fantasy Scene Box Set of 4, which currently includes only The Siege of Alexandria. Add the other three boxes so the set contains 24 foil scene cards and 12 Play Boosters.

Also:
- Remove four identifier-free `Box Set` duplicates introduced by an older deck import. The complete `Scene Box` records remain; the current importer recognizes their deck references and skips recreation.
- Set the Chocobo Booster count to 12 and correct the Chocobo Bundle counter to a click wheel.
- Add one reference card to each of the eight regular/Collector's Edition Commander decks.
- Correct Game Edition's direct card count from 100 to 1: Cloud is direct, while the 100-card Limit Break deck and its sample pack are already nested. Fix the game-code description typo.

Source: [Wizards' collecting guide](https://magic.wizards.com/en/news/feature/collecting-final-fantasy).

Validation: contents validator passed with existing category/subtype warnings; checked four unique scenes, 24 scene cards, 12 Play Boosters, all FIN/FIC sealed references, and importer duplicate prevention. The current Chocobo booster compiles with 12 slots. `git diff --check` passed. No test files added.
