### PR TITLE
Add Edge of Eternities Bundle reference cards

### DIFF
--- a/data/contents/EOE.yaml
+++ b/data/contents/EOE.yaml
@@ -11,6 +11,7 @@ products:
     - name: Edge of Eternities Bundle Land Pack
       set: eoe
     other:
+    - name: 2 Reference Cards
     - name: Edge of Eternities Spindown
     - name: Edge of Eternities Card Storage Box
     sealed:


### PR DESCRIPTION
Adds the two reference cards missing from the Edge of Eternities Bundle contents, as listed in [Wizards’ collecting guide](https://magic.wizards.com/en/news/feature/collecting-edge-of-eternities).

Validated with `scripts/contents_validator.py` (all products validated; existing category/subtype warnings) and `git diff --check`.
