### PR TITLE
Complete Spider-Man Welcome Deck boxes and bundle contents

### DIFF
--- a/data/contents/SPM.yaml
+++ b/data/contents/SPM.yaml
@@ -13,6 +13,7 @@ products:
     - name: Marvel's Spider-Man Bundle Land Pack
       set: spm
     other:
+    - name: 2 Reference Cards
     - name: Marvels Spider Man Spindown
     - name: Marvels Spider Man Card Storage Box
     sealed:
@@ -52,6 +53,7 @@ products:
     - name: Marvel's Spider-Man Bundle Land Pack
       set: spm
     other:
+    - name: 2 Reference Cards
     - name: Marvels Spider Man Spindown
     - name: Marvels Spider Man Card Storage Box
     sealed:
@@ -116,25 +118,105 @@ products:
       name: Marvels Spider Man Scene Box
       set: spm
   Marvels Spider Man Welcome Deck Black:
+    card_count: 60
     deck:
     - name: Black Deck
       set: spm
+    other:
+    - name: 2 Reference Cards
+    variable:
+    - deck:
+      - name: Blue Deck
+        set: spm
+    - deck:
+      - name: Green Deck
+        set: spm
+    - deck:
+      - name: Red Deck
+        set: spm
+    - deck:
+      - name: White Deck
+        set: spm
   Marvels Spider Man Welcome Deck Blue:
+    card_count: 60
     deck:
     - name: Blue Deck
       set: spm
+    other:
+    - name: 2 Reference Cards
+    variable:
+    - deck:
+      - name: Black Deck
+        set: spm
+    - deck:
+      - name: Green Deck
+        set: spm
+    - deck:
+      - name: Red Deck
+        set: spm
+    - deck:
+      - name: White Deck
+        set: spm
   Marvels Spider Man Welcome Deck Green:
+    card_count: 60
     deck:
     - name: Green Deck
       set: spm
+    other:
+    - name: 2 Reference Cards
+    variable:
+    - deck:
+      - name: Black Deck
+        set: spm
+    - deck:
+      - name: Blue Deck
+        set: spm
+    - deck:
+      - name: Red Deck
+        set: spm
+    - deck:
+      - name: White Deck
+        set: spm
   Marvels Spider Man Welcome Deck Red:
+    card_count: 60
     deck:
     - name: Red Deck
       set: spm
+    other:
+    - name: 2 Reference Cards
+    variable:
+    - deck:
+      - name: Black Deck
+        set: spm
+    - deck:
+      - name: Blue Deck
+        set: spm
+    - deck:
+      - name: Green Deck
+        set: spm
+    - deck:
+      - name: White Deck
+        set: spm
   Marvels Spider Man Welcome Deck White:
+    card_count: 60
     deck:
     - name: White Deck
       set: spm
+    other:
+    - name: 2 Reference Cards
+    variable:
+    - deck:
+      - name: Black Deck
+        set: spm
+    - deck:
+      - name: Blue Deck
+        set: spm
+    - deck:
+      - name: Green Deck
+        set: spm
+    - deck:
+      - name: Red Deck
+        set: spm
   Marvels Spider Man Welcome Decks Set of 5:
     sealed:
     - count: 1


### PR DESCRIPTION
Spider-Man Welcome Deck boxes currently map only their named 30-card half-deck. Add a variable second half-deck drawn from the other four colors and record each box as 60 cards. The existing set-of-five references now include all ten half-decks.

Also add the two reference cards included in each Welcome Deck, Bundle, and Gift Bundle.

Sources: [Wizards’ Welcome Deck guide](https://magic.wizards.com/en/news/feature/spider-man-welcome-decks) specifies the fixed color plus a random other color; the [collecting guide](https://magic.wizards.com/en/news/feature/collecting-marvels-spider-man) lists the reference cards.

Validation: contents validator passed with existing category/subtype warnings; fresh deck export resolved all references and confirmed all 20 combinations contain 60 cards. Checked serialized variable configurations and `git diff --check`. No companion repository changes are required.
