### PR TITLE
Correct Avatar product counts and missing inserts

### DIFF
--- a/data/contents/TLA.yaml
+++ b/data/contents/TLA.yaml
@@ -1,7 +1,7 @@
 code: tla
 products:
   Avatar The Last Airbender Beginner Box:
-    card_count: 202
+    card_count: 200
     deck:
     - name: Beginner Box - Aang Tutorial
       set: tla
@@ -46,6 +46,7 @@ products:
     - name: 'Avatar: The Last Airbender Bundle Land Pack'
       set: tla
     other:
+    - name: 2 Reference Cards
     - name: Avatar The Last Airbender Spindown
     - name: Avatar The Last Airbender Card Storage Box
     sealed:
@@ -177,7 +178,7 @@ products:
       name: Avatar The Last Airbender Play Booster Pack
       set: tla
   Avatar The Last Airbender Prerelease Pack Zuko:
-    card_count: 1
+    card_count: 15
     other:
     - name: 2 Non-foil double-sided tokens
     - name: Avatar The Last Airbender Spindown


### PR DESCRIPTION
Correct three Avatar product-content omissions and counts:

- Beginner Box: 202 → 200 cards, matching its ten 20-card half-decks. Tokens and reference cards are already listed separately.
- Zuko Prerelease Pack: 1 → 15 direct-pack cards (14-card seeded Character Booster plus one promo), matching the other four variants. Its five Play Boosters remain nested sealed contents.
- Bundle: add two reference cards.

Source: [Wizards’ Avatar collecting guide](https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender).

Validation: contents validator passed with existing category/subtype warnings; fresh deck export confirms all ten Beginner Box decks contain 20 cards; fresh booster compilation confirms the Zuko seeded pack has 14 slots and the prerelease promo has one. `git diff --check` passed.
