### PR TITLE
Correct Mana Symbiote Raised Foil card count

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -8422,7 +8422,7 @@ products:
     - code: spider-man
       set: sld
   Secret Lair Drop Secret Lair x Marvels Spider-Man Mana Symbiote Raised Foil:
-    card_count: 5
+    card_count: 10
     deck:
     - name: 'Marvel''s Spider-Man: Mana Symbiote Raised Foil Edition'
       set: sld


### PR DESCRIPTION
Correct Mana Symbiote Raised Foil’s card count from five to ten: the product contains two copies of each basic land, as listed on [Wizards’ product page](https://secretlair.wizards.com/us/en/product/1246589/secret-lair-x-marvel-s-spider-man-mana-symbiote-raised-foil-edition). Its existing deck reference already maps all ten cards.

Validation: contents validator passed with existing category/subtype warnings; checked gameplay card totals against a fresh deck export for all 159 deck-backed SLD products explicitly dated 2025, excluding tokens and sideboard/display sections. All counts match after this correction. `git diff --check` passed.
