### PR TITLE
Correct Karlov Manor prerelease count and Commander contents

### DIFF
--- a/data/contents/MKC.yaml
+++ b/data/contents/MKC.yaml
@@ -8,6 +8,8 @@ products:
     other:
     - name: Deck Box
     - name: Life Wheel
+    - name: 10 Double-sided tokens
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Murders at Karlov Manor Collector Booster Sample Pack
@@ -20,6 +22,8 @@ products:
     other:
     - name: Deck Box
     - name: Life Wheel
+    - name: 10 Double-sided tokens
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Murders at Karlov Manor Collector Booster Sample Pack
@@ -32,6 +36,8 @@ products:
     other:
     - name: Deck Box
     - name: Life Wheel
+    - name: 10 Double-sided tokens
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Murders at Karlov Manor Collector Booster Sample Pack
@@ -58,6 +64,8 @@ products:
     other:
     - name: Deck Box
     - name: Life Wheel
+    - name: 10 Double-sided tokens
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Murders at Karlov Manor Collector Booster Sample Pack

--- a/data/contents/MKM.yaml
+++ b/data/contents/MKM.yaml
@@ -68,7 +68,7 @@ products:
     - code: play
       set: mkm
   Murders at Karlov Manor Prerelease Pack:
-    card_count: 1
+    card_count: 2
     other:
     - name: Murders at Karlov Manor Spindown
     pack:


### PR DESCRIPTION
Correct the Karlov Manor Prerelease Pack’s direct card count from one to two. The existing prerelease booster definition already supplies the year-stamped promo plus one foil Melek, Tomik, or Voja; this brings the declared count into agreement.

Also add the ten double-sided tokens and strategy insert missing from each of the four Commander deck product descriptions.

Source: [Wizards’ collecting guide](https://magic.wizards.com/en/news/feature/collecting-murders-at-karlov-manor), under Prerelease Pack and Commander Decks.

Validation: contents validator passed with existing category/subtype warnings; all six MKM/CLU paper booster definitions compiled against the fresh index. Verified the prerelease definition supplies two cards and its bonus pool is exactly foil MKM 430–432. `git diff --check` passed. No companion repository changes are needed.
