### PR TITLE
Complete Thunder Junction Bundle and Commander accessories

### DIFF
--- a/data/contents/OTC.yaml
+++ b/data/contents/OTC.yaml
@@ -9,6 +9,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Outlaws of Thunder Junction Collector Booster Sample Pack
@@ -36,6 +37,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Outlaws of Thunder Junction Collector Booster Sample Pack
@@ -49,6 +51,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Outlaws of Thunder Junction Collector Booster Sample Pack
@@ -62,6 +65,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Outlaws of Thunder Junction Collector Booster Sample Pack

--- a/data/contents/OTJ.yaml
+++ b/data/contents/OTJ.yaml
@@ -11,6 +11,7 @@ products:
       set: otj
     other:
     - name: Outlaws of Thunder Junction Spindown
+    - name: Card Storage Box
     sealed:
     - count: 9
       name: Outlaws of Thunder Junction Play Booster Pack


### PR DESCRIPTION
Add the missing card-storage box to the Outlaws of Thunder Junction Bundle and the missing strategy insert to each of its four Commander decks, matching [Wizards’ collecting guide](https://magic.wizards.com/en/news/feature/collecting-outlaws-of-thunder-junction).

Validation: contents validator passed with existing category/subtype warnings; `git diff --check` passed. Existing deck export confirms each Commander deck has 100 gameplay cards and two foils, and the Bundle land pack has 30 cards split evenly between foil and nonfoil.
