### PR TITLE
Complete Modern Horizons 3 inserts and ripple-foil descriptions

### DIFF
--- a/data/contents/M3C.yaml
+++ b/data/contents/M3C.yaml
@@ -6,10 +6,10 @@ products:
     - name: Creative Energy
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
     - name: 10 double sided tokens
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack
@@ -20,10 +20,10 @@ products:
     - name: Creative Energy Collector's Edition
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
-    - name: 10 double sided tokens
+    - name: 10 double-sided tokens (ripple foil front, non-foil back)
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack
@@ -62,10 +62,10 @@ products:
     - name: Eldrazi Incursion
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
     - name: 10 double sided tokens
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack
@@ -76,10 +76,10 @@ products:
     - name: Eldrazi Incursion Collector's Edition
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
-    - name: 10 double sided tokens
+    - name: 10 double-sided tokens (ripple foil front, non-foil back)
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack
@@ -90,10 +90,10 @@ products:
     - name: Graveyard Overdrive
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
     - name: 10 double sided tokens
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack
@@ -104,10 +104,10 @@ products:
     - name: Graveyard Overdrive Collector's Edition
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
-    - name: 10 double sided tokens
+    - name: 10 double-sided tokens (ripple foil front, non-foil back)
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack
@@ -118,10 +118,10 @@ products:
     - name: Tricky Terrain
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
     - name: 10 double sided tokens
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack
@@ -132,10 +132,10 @@ products:
     - name: Tricky Terrain Collector's Edition
       set: m3c
     other:
-    - name: Foil etched display commander
     - name: Life wheel
-    - name: 10 double sided tokens
+    - name: 10 double-sided tokens (ripple foil front, non-foil back)
     - name: Deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Modern Horizons 3 Collector Booster Sample Pack

--- a/data/contents/MH3.yaml
+++ b/data/contents/MH3.yaml
@@ -11,6 +11,7 @@ products:
       set: mh3
     other:
     - name: Card storage box
+    - name: 2 Reference Cards
     - name: Modern Horizons 3 spindown
     sealed:
     - count: 9
@@ -52,6 +53,7 @@ products:
       set: mh3
     other:
     - name: Card storage box
+    - name: 2 Reference Cards
     - name: Modern Horizons 3 spindown
     sealed:
     - count: 9


### PR DESCRIPTION
Complete Modern Horizons 3 product descriptions to match [Wizards’ collecting guide](https://magic.wizards.com/en/news/feature/collecting-modern-horizons-3):

- Add two reference cards to both the Bundle and Gift Bundle.
- Add a strategy insert to each of the eight regular and Collector’s Edition Commander decks.
- Remove redundant display-commander descriptions from all eight decks: their deck lists already map these in the Display Commander section.
- Specify that Collector’s Edition tokens have ripple-foil fronts and nonfoil backs.

Validation: contents validator passed with existing category/subtype warnings; all four MH3 paper booster definitions compiled and sampled with the expected 14/15/2/1 card totals. Current deck export confirms 100 gameplay cards per Commander deck, two foils in regular editions and 100 in Collector’s Editions. `git diff --check` passed.
