### PR TITLE
Complete Assassin's Creed Bundle and Starter Kit accessories

### DIFF
--- a/data/contents/ACR.yaml
+++ b/data/contents/ACR.yaml
@@ -27,6 +27,8 @@ products:
       set: acr
     other:
     - name: Assassin's Creed spindown
+    - name: Card storage box
+    - name: 2 Reference Cards
     sealed:
     - count: 9
       name: Assassins Creed Beyond Booster Pack
@@ -58,6 +60,8 @@ products:
       set: acr
     - name: Ancient Arsenal
       set: acr
+    other:
+    - name: Magic Play Guide booklet
   Assassins Creed Starter Kit Case:
     sealed:
     - count: 12


### PR DESCRIPTION
Add the missing storage box and two reference cards to the Assassin’s Creed Bundle, plus the Magic Play Guide booklet to the Starter Kit.

Sources: [collecting guide](https://magic.wizards.com/en/news/feature/collecting-assassins-creed) and [Starter Kit contents](https://magic.wizards.com/en/news/announcements/assassins-creed-starter-kit-decklists).

Validation: contents validator passed with existing category/subtype warnings; both booster definitions compile and produce the expected seven/ten cards, excluding Starter Kit-only printings. `git diff --check` passed.
