### PR TITLE
Add missing Bloomburrow Starter Kit and Commander contents

### DIFF
--- a/data/contents/BLB.yaml
+++ b/data/contents/BLB.yaml
@@ -86,6 +86,10 @@ products:
       set: blb
     - name: Hare Raising
       set: blb
+    other:
+    - name: 4 double sided tokens
+    - name: 2 MTG Arena code cards (available in select regions)
+    - name: Starter Kit Play Guide
   Bloomburrow Starter Kit Case:
     sealed:
     - count: 12

--- a/data/contents/BLC.yaml
+++ b/data/contents/BLC.yaml
@@ -9,6 +9,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Bloomburrow Collector Booster Sample Pack
@@ -36,6 +37,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Bloomburrow Collector Booster Sample Pack
@@ -49,6 +51,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Bloomburrow Collector Booster Sample Pack
@@ -62,6 +65,7 @@ products:
     - name: Spinning life counter
     - name: 10 double sided tokens
     - name: Paper deck box
+    - name: Strategy insert
     sealed:
     - count: 1
       name: Bloomburrow Collector Booster Sample Pack


### PR DESCRIPTION
Bloomburrow's Starter Kit omits its four double-sided tokens, two MTG Arena code cards (available in select regions), and play guide. Add these contents and the strategy insert included with each of the four Commander decks.

Sources: [Starter Kit contents](https://magic.wizards.com/en/news/announcements/bloomburrow-starter-kit-decklists) and [collecting Bloomburrow](https://magic.wizards.com/en/news/feature/collecting-bloomburrow).

Validation: contents validator passed (existing Tarkir category warnings); git diff --check passed. Current deck data has two 60-card Starter decks, four 100-card Commander decks, and the 30-card Bundle land pack. All five existing paper booster definitions compile and produce the expected 14/15/2/1/7-card packs; this does not independently verify every slot probability.
