### PR TITLE
Fix token mapping isolation, review queue preservation, and content validation

### DIFF
--- a/data/contents/10E.yaml
+++ b/data/contents/10E.yaml
@@ -37,7 +37,7 @@ products:
     - name: Tenth Edition Foil Redemption
       set: 10e
   Tenth Edition Sample Deck Ajani Goldmane:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: White Deck A
@@ -49,7 +49,7 @@ products:
       count: 1
       replacement: false
   Tenth Edition Sample Deck Chandra Nalaar:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Red Deck A
@@ -61,7 +61,7 @@ products:
       count: 1
       replacement: false
   Tenth Edition Sample Deck Garruk Wildspeaker:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Green Deck A
@@ -73,7 +73,7 @@ products:
       count: 1
       replacement: false
   Tenth Edition Sample Deck Jace Beleren:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Blue Deck A
@@ -85,7 +85,7 @@ products:
       count: 1
       replacement: false
   Tenth Edition Sample Deck Liliana Vess:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Black Deck A

--- a/data/contents/M11.yaml
+++ b/data/contents/M11.yaml
@@ -159,7 +159,7 @@ products:
     - name: Magic 2011 Foil Redemption
       set: m11
   2011 Core Set Sample Deck Ajani Goldmane:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: White Deck A
@@ -171,7 +171,7 @@ products:
       count: 1
       replacement: false
   2011 Core Set Sample Deck Chandra Nalaar:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Red Deck A
@@ -183,7 +183,7 @@ products:
       count: 1
       replacement: false
   2011 Core Set Sample Deck Garruk Wildspeaker:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Green Deck A
@@ -195,7 +195,7 @@ products:
       count: 1
       replacement: false
   2011 Core Set Sample Deck Jace Beleren:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Blue Deck A
@@ -207,7 +207,7 @@ products:
       count: 1
       replacement: false
   2011 Core Set Sample Deck Liliana Vess:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Black Deck A

--- a/data/contents/M12.yaml
+++ b/data/contents/M12.yaml
@@ -143,7 +143,7 @@ products:
     - name: Magic 2012 Foil Redemption
       set: m12
   2012 Core Set Sample Deck Chandra Nalaar:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Red Deck A
@@ -155,7 +155,7 @@ products:
       count: 1
       replacement: false
   2012 Core Set Sample Deck Garruk Wildspeaker:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Green Deck A
@@ -167,7 +167,7 @@ products:
       count: 1
       replacement: false
   2012 Core Set Sample Deck Gideon Jura:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: White Deck A
@@ -179,7 +179,7 @@ products:
       count: 1
       replacement: false
   2012 Core Set Sample Deck Jace Beleren:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Blue Deck A
@@ -191,7 +191,7 @@ products:
       count: 1
       replacement: false
   2012 Core Set Sample Deck Sorin Markov:
-    card count: 30
+    card_count: 30
     variable:
     - deck:
       - name: Black Deck A

--- a/data/contents/M13.yaml
+++ b/data/contents/M13.yaml
@@ -210,27 +210,27 @@ products:
     - name: Magic 2013 Foil Redemption
       set: m13
   2013 Core Set Sample Deck Ajani Goldmane:
-    card count: 30
+    card_count: 30
     deck:
     - name: White Sample Deck
       set: m13
   2013 Core Set Sample Deck Chandra Nalaar:
-    card count: 30
+    card_count: 30
     deck:
     - name: Red Sample Deck
       set: m13
   2013 Core Set Sample Deck Garruk Wildspeaker:
-    card count: 30
+    card_count: 30
     deck:
     - name: Green Sample Deck
       set: m13
   2013 Core Set Sample Deck Jace Beleren:
-    card count: 30
+    card_count: 30
     deck:
     - name: Blue Sample Deck
       set: m13
   2013 Core Set Sample Deck Liliana Vess:
-    card count: 30
+    card_count: 30
     deck:
     - name: Black Sample Deck
       set: m13

--- a/data/contents/M14.yaml
+++ b/data/contents/M14.yaml
@@ -185,27 +185,27 @@ products:
     - name: Magic 2014 Foil Redemption
       set: m14
   2014 Core Set Sample Deck Ajani Goldmane:
-    card count: 35
+    card_count: 35
     deck:
     - name: White Deck
       set: m14
   2014 Core Set Sample Deck Chandra Nalaar:
-    card count: 35
+    card_count: 35
     deck:
     - name: Red Deck
       set: m14
   2014 Core Set Sample Deck Garruk Wildspeaker:
-    card count: 35
+    card_count: 35
     deck:
     - name: Green Deck
       set: m14
   2014 Core Set Sample Deck Jace Beleren:
-    card count: 35
+    card_count: 35
     deck:
     - name: Blue Deck
       set: m14
   2014 Core Set Sample Deck Liliana Vess:
-    card count: 35
+    card_count: 35
     deck:
     - name: Black Deck
       set: m14

--- a/data/contents/ORI.yaml
+++ b/data/contents/ORI.yaml
@@ -246,27 +246,27 @@ products:
       name: Magic Origins Prerelease Kit Nissa
       set: ori
   Magic Origins Sample Deck Chandra Nalaar:
-    card count: 35
+    card_count: 35
     deck:
     - name: Red Deck
       set: ori
   Magic Origins Sample Deck Gideon Jura:
-    card count: 35
+    card_count: 35
     deck:
     - name: White Deck
       set: ori
   Magic Origins Sample Deck Jace Beleren:
-    card count: 35
+    card_count: 35
     deck:
     - name: Blue Deck
       set: ori
   Magic Origins Sample Deck Liliana Vess:
-    card count: 35
+    card_count: 35
     deck:
     - name: Black Deck
       set: ori
   Magic Origins Sample Deck Nissa Revane:
-    card count: 35
+    card_count: 35
     deck:
     - name: Green Deck
       set: ori

--- a/scripts/contents_validator.py
+++ b/scripts/contents_validator.py
@@ -161,6 +161,64 @@ valid_subtypes = [
     "SEALED_SET", "PRERELEASE", "OTHER", "CHALLENGER", "SIX", "CONVENTION", "MTGO_REDEMPTION",
 ]
 
+CONTENT_FIELDS = {
+    "card": {"name", "set", "number", "foil", "etched", "token", "uuid", "count"},
+    "pack": {"set", "code"},
+    "deck": {"set", "name"},
+    "sealed": {"set", "name", "count", "uuid"},
+    "other": {"name"},
+}
+
+
+def check_fields(value, allowed, path):
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must be a mapping")
+    unknown = value.keys() - allowed
+    if unknown:
+        raise ValueError(f"{path}: unknown fields {sorted(unknown)}")
+
+
+def check_count(value, path, minimum=1):
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{path} must be an integer >= {minimum}")
+
+
+def validate_content_fields(contents, path="contents"):
+    # Empty entries are intentional placeholders for unresearched products.
+    if contents is None or contents == []:
+        return
+    check_fields(contents, set(CONTENT_FIELDS) | {
+        "variable", "variable_mode", "card_count", "chance", "weight"
+    }, path)
+    for key in ("card_count", "chance", "weight"):
+        if key in contents:
+            check_count(contents[key], f"{path}.{key}", minimum=0)
+    for kind, fields in CONTENT_FIELDS.items():
+        entries = contents.get(kind, [])
+        if not isinstance(entries, list):
+            raise ValueError(f"{path}.{kind} must be a list")
+        for index, entry in enumerate(entries):
+            entry_path = f"{path}.{kind}[{index}]"
+            check_fields(entry, fields, entry_path)
+            if "count" in entry:
+                check_count(entry["count"], f"{entry_path}.count")
+    if "variable" in contents:
+        if not isinstance(contents["variable"], list):
+            raise ValueError(f"{path}.variable must be a list")
+        for index, entry in enumerate(contents["variable"]):
+            validate_content_fields(entry, f"{path}.variable[{index}]")
+    if "variable_mode" in contents:
+        mode = contents["variable_mode"]
+        check_fields(mode, {"count", "replacement", "weight"}, f"{path}.variable_mode")
+        if "variable" not in contents:
+            raise ValueError(f"{path}.variable_mode requires variable")
+        for key in ("count", "weight"):
+            if key in mode:
+                check_count(mode[key], f"{path}.variable_mode.{key}")
+        if "replacement" in mode and type(mode["replacement"]) is not bool:
+            raise ValueError(f"{path}.variable_mode.replacement must be a boolean")
+
+
 def validate_structure():
     contentFolder = Path("data/contents/")
     failed = False
@@ -169,18 +227,13 @@ def validate_structure():
             contents = yaml.safe_load(f)
 
         for name, p in contents["products"].items():
-            if not p:
-                p = {}
-            if isinstance(p, list):
-                print(f"Product {name} in set {set_file.stem} formatted incorrectly")
-                failed = True
-                continue
-            if set(p.keys()) == {"copy"}:
-                p = contents["products"][p["copy"]]
             try:
+                if isinstance(p, dict) and set(p) == {"copy"}:
+                    p = contents["products"][p["copy"]]
+                validate_content_fields(p)
                 pc.product(p, contents["code"], name)
-            except:
-                print(f"Product {name} in set {set_file.stem} failed")
+            except (KeyError, TypeError, ValueError, AttributeError) as exc:
+                print(f"Product {name} in set {set_file.stem} failed: {exc}")
                 failed = True
     if failed:
         raise ImportError()

--- a/scripts/load_new_products.py
+++ b/scripts/load_new_products.py
@@ -1031,7 +1031,12 @@ def main(secret):
         ignore = yaml.safe_load(ignore_file)
 
     ids = dict()
-    reviews = dict()
+    review_path = Path("data/review.yaml")
+    if review_path.exists():
+        with review_path.open() as review_file:
+            reviews = yaml.safe_load(review_file) or {}
+    else:
+        reviews = {}
 
     # Set up the list of ids and items to review for each provider
     for key, provider in providers_dict.items():
@@ -1039,7 +1044,7 @@ def main(secret):
         if ignore.get(key):
             provider_ids = set(str(x) for x in ignore[key].keys())
         ids[key] = provider_ids
-        reviews[key] = dict()
+        reviews.setdefault(key, {})
 
     # Load data from the known products
     for known_file in Path("data/products").glob("*.yaml"):
@@ -1069,11 +1074,11 @@ def main(secret):
         except Exception as e:
             print(f"Could not load provider {key}")
             print(repr(e))
-            products = [{
-                "name": f"Could not load provider {key}",
-                "id": ""
-            }]
+            # Keep the previous queue when this provider is unavailable.
+            continue
 
+        # Refresh only providers that were actually loaded successfully.
+        reviews[key] = {}
         for product in products:
             if str(product["id"]) in ids[key]:
                 continue

--- a/scripts/tokens/main.py
+++ b/scripts/tokens/main.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from collections import defaultdict
 
 import pathlib
@@ -117,14 +118,21 @@ def filter_tokens_without_uuids(
     """
     output_dict_of_tokens = defaultdict(list)
     for output_token in output_tokens:
-        for token_part in output_token["tokenParts"]:
-            if "uuids" in token_part:
-                # These entities are for internal use only
-                token_part.pop("tokenType")
-                token_part.pop("faceId")
-                token_part.pop("faceName")
-                for uuid in token_part["uuids"]:
-                    output_dict_of_tokens[uuid].append(output_token)
+        # Collect the keys before copying so a UUID appearing on both faces
+        # receives this marketplace product only once.
+        uuids = dict.fromkeys(
+            uuid
+            for part in output_token["tokenParts"]
+            for uuid in part.get("uuids", [])
+        )
+        for uuid in uuids:
+            entry = deepcopy(output_token)
+            for part in entry["tokenParts"]:
+                if "uuids" in part:
+                    for key in ("tokenType", "faceId", "faceName"):
+                        part.pop(key, None)
+            # Conversion below mutates tokenParts for this specific UUID.
+            output_dict_of_tokens[uuid].append(entry)
 
     return output_dict_of_tokens
 

--- a/tests/test_contents_validation.py
+++ b/tests/test_contents_validation.py
@@ -1,0 +1,48 @@
+import contextlib
+import io
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+import yaml
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from contents_validator import validate_content_fields, validate_structure
+
+
+class ContentsValidationTests(unittest.TestCase):
+    def test_rejects_unknown_fields_and_invalid_counts_recursively(self):
+        for content in (
+            {"crad": []}, {"card count": 30},
+            {"sealed": [{"name": "Box", "set": "tst", "count": -1}]},
+            {"sealed": [{"name": "Box", "set": "tst", "count": True}]},
+            {"card": [{"name": "Card", "set": "tst", "number": 1, "fiol": True}]},
+            {"variable": [{"crad": []}]},
+            {"variable": [], "variable_mode": {"count": 0}},
+            {"variable": [], "variable_mode": {"replacement": "false"}},
+        ):
+            with self.subTest(content=content), self.assertRaises(ValueError):
+                validate_content_fields(content)
+
+    def test_accepts_placeholders_and_variable_contents(self):
+        for content in (None, [], {}, {"card_count": 0}, {
+            "variable": [{"sealed": [{"name": "Box", "set": "tst", "count": 2}]}],
+            "variable_mode": {"count": 1, "replacement": False, "weight": 1},
+        }):
+            validate_content_fields(content)
+
+    def test_ci_gate_rejects_typo_in_copied_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            previous = Path.cwd()
+            os.chdir(tmp)
+            try:
+                Path("data/contents").mkdir(parents=True)
+                Path("data/products").mkdir()
+                Path("data/contents/TST.yaml").write_text(yaml.safe_dump({
+                    "code": "tst", "products": {"Original": {"crad": []}, "Copy": {"copy": "Original"}},
+                }))
+                with contextlib.redirect_stdout(io.StringIO()), self.assertRaises(ImportError):
+                    validate_structure()
+            finally:
+                os.chdir(previous)

--- a/tests/test_review_queues.py
+++ b/tests/test_review_queues.py
@@ -1,0 +1,40 @@
+import contextlib
+import io
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import yaml
+from scripts import load_new_products
+
+
+class ReviewQueueTests(unittest.TestCase):
+    def test_skipped_and_failed_queues_survive_successful_refresh(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            previous = Path.cwd()
+            os.chdir(tmp)
+            try:
+                Path("data/products").mkdir(parents=True)
+                Path("data/contents").mkdir()
+                Path("data/ignore.yaml").write_text("{}")
+                old = {key: {"Pending": {"identifiers": {key: "123"}}}
+                       for key in ("skipped", "failed", "active", "unregistered")}
+                Path("data/review.yaml").write_text(yaml.safe_dump(old))
+                def fail(_):
+                    raise RuntimeError("offline")
+                providers = {
+                    "skipped": {"disabled": True, "identifier": "skipped"},
+                    "failed": {"identifier": "failed", "load_func": fail},
+                    "active": {"identifier": "active", "load_func": lambda _: [{"name": "New", "id": "456"}]},
+                }
+                with patch.object(load_new_products, "providers_dict", providers), contextlib.redirect_stdout(io.StringIO()):
+                    load_new_products.main({})
+                result = yaml.safe_load(Path("data/review.yaml").read_text())
+                for key in ("skipped", "failed", "unregistered"):
+                    self.assertEqual(result[key], old[key])
+                self.assertEqual(set(result["active"]), {"New"})
+                self.assertEqual(result["active"]["New"]["identifiers"], {"active": "456"})
+            finally:
+                os.chdir(previous)

--- a/tests/test_token_mappings.py
+++ b/tests/test_token_mappings.py
@@ -1,0 +1,27 @@
+from copy import deepcopy
+import unittest
+
+from scripts.tokens.main import filter_tokens_without_uuids, map_uuids_back_to_single_uuid
+
+
+class TokenMappingTests(unittest.TestCase):
+    def test_each_uuid_gets_its_own_face_and_preserves_input(self):
+        tokens = [{"tokenParts": [
+            {"uuids": ["A", "B"], "tokenType": "token", "faceId": "front", "faceName": "Front"},
+            {"uuids": ["C"], "tokenType": "token", "faceId": "back", "faceName": "Back"},
+        ]}]
+        original = deepcopy(tokens)
+        mapped = map_uuids_back_to_single_uuid(filter_tokens_without_uuids(tokens))
+        self.assertEqual(mapped["A"][0]["tokenParts"], [{"uuid": "A"}, {"uuid": "C"}])
+        self.assertEqual(mapped["B"][0]["tokenParts"], [{"uuid": "B"}, {"uuid": "C"}])
+        self.assertEqual(mapped["C"][0]["tokenParts"], [{"uuid": "A"}, {"uuid": "C"}])
+        self.assertEqual(tokens, original)
+
+    def test_same_uuid_on_both_faces_is_not_duplicated(self):
+        tokens = [{"tokenParts": [{"uuids": ["A"]}, {"uuids": ["A"]}]}]
+        mapped = map_uuids_back_to_single_uuid(filter_tokens_without_uuids(tokens))
+        self.assertEqual(len(mapped["A"]), 1)
+        self.assertEqual(mapped["A"][0]["tokenParts"], [{"uuid": "A"}, {"uuid": "A"}])
+
+    def test_unmatched_product_is_omitted(self):
+        self.assertEqual(filter_tokens_without_uuids([{"tokenParts": [{}]}]), {})


### PR DESCRIPTION
Token entries shared across UUIDs could resolve to the first UUID processed, selected-provider scrapes cleared unrelated pending reviews, and content validation accepted misspelled fields and invalid counts.

This change:
- Copies token mappings per UUID and deduplicates products when both faces match the same UUID.
- Preserves review queues for skipped and failed providers, refreshing only successfully loaded providers.
- Rejects unknown content fields and invalid counts, including nested variable contents, and reports specific validation errors.
- Corrects 30 existing `card count` keys to `card_count` across six content files.

Validation: all 12 unit tests pass, including new regressions for each issue; full repository contents validation and `git diff --check` pass. Live scrapers were not run.
