### PR TITLE
Bound HTTP waits and Scryfall response retries

### DIFF
--- a/scripts/retryable_session.py
+++ b/scripts/retryable_session.py
@@ -3,17 +3,25 @@ import requests.adapters
 import urllib3.util.retry
 
 
+class TimeoutSession(requests.Session):
+    """Use bounded connect/read waits unless the caller supplies a timeout."""
+
+    def request(self, method, url, **kwargs):
+        kwargs.setdefault("timeout", (10, 60))
+        return super().request(method, url, **kwargs)
+
+
 def retryable_session(
     retries: int = 8,
 ) -> requests.Session:
-    session = requests.Session()
+    session = TimeoutSession()
 
     retry = urllib3.util.retry.Retry(
         total=retries,
         read=retries,
         connect=retries,
         backoff_factor=0.3,
-        status_forcelist=(500, 502, 504),
+        status_forcelist=(429, 500, 502, 503, 504),
     )
 
     adapter = requests.adapters.HTTPAdapter(max_retries=retry)

--- a/scripts/scryfall_provider.py
+++ b/scripts/scryfall_provider.py
@@ -1,5 +1,4 @@
 import re
-import sys
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -64,33 +63,26 @@ class ScryfallProvider:
         Api calls always return JSON from Scryfall
         :param url: URL to download from
         :param params: Options for URL download
-        :param retry_ttl: How many times to retry if Chunk Error
+        :param retry_ttl: Maximum retries for interrupted bodies or invalid JSON
         """
-        session = retryable_session()
+        if retry_ttl < 0:
+            raise ValueError("retry_ttl must be non-negative")
 
-        try:
-            response = session.get(url)
-        except requests.exceptions.ChunkedEncodingError as error:
-            if retry_ttl:
-                print(f"Download failed: {error}... Retrying")
-                time.sleep(3 - retry_ttl)
-                return self.download(url, params, retry_ttl - 1)
-
-            print(f"Download failed: {error}... Maxed out retries")
-            sys.exit(1)
-
-        try:
-            return response.json()
-        except ValueError as error:
-            if "504" in response.text:
-                print("Scryfall 504 error, sleeping...")
-            else:
-                print(
-                    f"Unable to convert response to JSON for URL: {url} -> {error}; Message = {response.text}"
-                )
-
-            time.sleep(5)
-            return self.download(url, params)
+        # Adapter retries cover transient HTTP status/connect failures. This
+        # separate budget covers interrupted bodies and malformed JSON only.
+        with retryable_session() as session:
+            for attempt in range(retry_ttl + 1):
+                try:
+                    with session.get(url, params=params) as response:
+                        # A 404 is Scryfall's normal empty-search response;
+                        # retain its structured error for download_all_pages.
+                        if response.status_code != 404:
+                            response.raise_for_status()
+                        return response.json()
+                except (requests.exceptions.ChunkedEncodingError, ValueError):
+                    if attempt == retry_ttl:
+                        raise
+                    time.sleep(5)
 
     def download_cards(self, set_code: str) -> List[Dict[str, Any]]:
         """

--- a/tests/test_http_reliability.py
+++ b/tests/test_http_reliability.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+from urllib3.exceptions import MaxRetryError
+from requests.adapters import BaseAdapter
+from scripts.retryable_session import retryable_session
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from scryfall_provider import ScryfallProvider
+
+
+class RecordingAdapter(BaseAdapter):
+    def send(self, request, **kwargs):
+        self.timeout = kwargs["timeout"]
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b"{}"
+        return response
+
+    def close(self):
+        pass
+
+
+class HttpReliabilityTests(unittest.TestCase):
+    def test_default_timeout_and_caller_override_reach_transport(self):
+        with retryable_session() as session:
+            adapter = RecordingAdapter()
+            session.mount("https://", adapter)
+            session.get("https://example.test")
+            self.assertEqual(adapter.timeout, (10, 60))
+            session.get("https://example.test", timeout=7)
+            self.assertEqual(adapter.timeout, 7)
+
+    def test_transient_status_retries_are_bounded_and_exclude_post(self):
+        with retryable_session(retries=2) as session:
+            retry = session.get_adapter("https://").max_retries
+            for status in (429, 500, 502, 503, 504):
+                self.assertTrue(retry.is_retry("GET", status))
+                self.assertFalse(retry.is_retry("POST", status))
+            self.assertFalse(retry.is_retry("GET", 401))
+            retry = retry.increment(method="GET", error=Exception("offline"))
+            retry = retry.increment(method="GET", error=Exception("offline"))
+            with self.assertRaises(MaxRetryError):
+                retry.increment(method="GET", error=Exception("offline"))
+
+    def response(self, payload, status=200):
+        response = requests.Response()
+        response.status_code = status
+        response._content = payload
+        response._content_consumed = True
+        response.url = "https://example.test"
+        return response
+
+    def download(self, outcomes):
+        session = Mock()
+        session.__enter__ = Mock(return_value=session)
+        session.__exit__ = Mock(return_value=False)
+        session.get.side_effect = outcomes
+        return session, patch("scryfall_provider.retryable_session", return_value=session)
+
+    @patch("scryfall_provider.time.sleep")
+    def test_invalid_json_exhausts_budget(self, sleep):
+        session, factory = self.download([self.response(b"blocked") for _ in range(3)])
+        with factory, self.assertRaises(ValueError):
+            ScryfallProvider().download("https://example.test", retry_ttl=2)
+        self.assertEqual(session.get.call_count, 3)
+        self.assertEqual(sleep.call_count, 2)
+        session.__exit__.assert_called_once()
+
+    @patch("scryfall_provider.time.sleep")
+    def test_mixed_body_failures_share_budget_and_preserve_params(self, sleep):
+        session, factory = self.download([
+            requests.exceptions.ChunkedEncodingError("interrupted"),
+            self.response(b"not json"), self.response(b'{"data": []}'),
+        ])
+        with factory:
+            result = ScryfallProvider().download("https://example.test", {"q": "test"}, retry_ttl=2)
+        self.assertEqual(result, {"data": []})
+        self.assertEqual(session.get.call_count, 3)
+        session.get.assert_called_with("https://example.test", params={"q": "test"})
+
+    def test_empty_search_404_is_preserved_but_other_http_errors_raise(self):
+        session, factory = self.download([self.response(b'{"object":"error","code":"not_found"}', 404)])
+        with factory:
+            self.assertEqual(ScryfallProvider().download("https://example.test")["code"], "not_found")
+        session, factory = self.download([self.response(b'{"error":"unauthorized"}', 401)])
+        with factory, self.assertRaises(requests.HTTPError):
+            ScryfallProvider().download("https://example.test")
+        self.assertEqual(session.get.call_count, 1)


### PR DESCRIPTION
Requests made through the shared retry session could wait indefinitely, and Scryfall's malformed-JSON retry path reset its own budget on every attempt.

Set default connect/read timeouts of 10/60 seconds while preserving caller overrides, and include 429 and 503 in the existing bounded status retry policy. Replace Scryfall's recursive body retries with a fixed budget, forward query parameters, close sessions/responses, and raise HTTP failures while preserving structured 404 search responses.

Validation: all 17 unit tests pass, including five new tests covering timeout forwarding, transient-status retry limits, malformed and interrupted responses, parameter preservation, and HTTP errors. `git diff --check` passes. No live services were called during tests.

Scope: the shared retry-session users and Scryfall downloader; standalone requests in other scripts remain for a subsequent pass.
