### PR TITLE
Bound standalone HTTP calls and reject failed downloads

### DIFF
--- a/scripts/card_to_product_compiler.py
+++ b/scripts/card_to_product_compiler.py
@@ -66,7 +66,7 @@ class MtgjsonCardLinker:
     @staticmethod
     def _fetch_all_printings(url: str) -> Dict[str, Any]:
         print(f"Downloading AllPrintings from {url}")
-        request_wrapper = requests.get(url)
+        request_wrapper = requests.get(url, timeout=(10, 60))
         request_wrapper.raise_for_status()
 
         content = request_wrapper.content

--- a/scripts/contents_validator.py
+++ b/scripts/contents_validator.py
@@ -31,7 +31,8 @@ def build_uuid_map(mtgjson_path):
         else:
             print("⚙️  downloading AllPrintings.json")
             url = "https://mtgjson.com/api/v5/AllPrintings.json"
-            r = requests.get(url, stream=True)
+            r = requests.get(url, stream=True, timeout=(10, 60))
+            r.raise_for_status()
             parser = ijson.parse(r.content)
     except:
         print("Could not load AllPrintings")

--- a/scripts/gatherer_original_printing_details_generator.py
+++ b/scripts/gatherer_original_printing_details_generator.py
@@ -48,6 +48,11 @@ class GathererDownloader:
     def __del__(self) -> None:
         self.session.close()
 
+    def _get(self, url):
+        response = self.session.get(url, timeout=(10, 60))
+        response.raise_for_status()
+        return response
+
     def get_set_codes(self) -> List[str]:
         url = "https://gatherer.wizards.com/sets?page={0}"
 
@@ -55,7 +60,7 @@ class GathererDownloader:
 
         for page_number in range(1, 25):
             formatted_url = url.format(page_number)
-            paged_response = self.session.get(formatted_url)
+            paged_response = self._get(formatted_url)
 
             soup = bs4.BeautifulSoup(paged_response.text, "html.parser")
 
@@ -78,7 +83,7 @@ class GathererDownloader:
 
         for page_number in range(1, 100):
             formatted_url = url.format(set_code, page_number)
-            paged_response = self.session.get(formatted_url)
+            paged_response = self._get(formatted_url)
 
             soup = bs4.BeautifulSoup(paged_response.content, "html.parser")
 
@@ -95,7 +100,7 @@ class GathererDownloader:
         return card_urls
 
     def get_card_multiverse_id(self, card_url: str) -> Optional[int]:
-        card_data_response = self.session.get(card_url).content.decode("utf-8")
+        card_data_response = self._get(card_url).content.decode("utf-8")
         multiverse_ids = self.multiverse_id_text_regex.findall(card_data_response)
         if multiverse_ids:
             return int(multiverse_ids[0])
@@ -105,7 +110,7 @@ class GathererDownloader:
 
     def _get_decoded_card_response(self, card_url: str) -> str:
         return html.unescape(
-            self.session.get(card_url)
+            self._get(card_url)
             .content.decode("unicode_escape")
             .replace("\u2028", "")  # Exception case for WWK #4 - Battle Hurda
             .encode("latin1")

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -44,7 +44,11 @@ if local_decks and Path(local_decks).exists():
         decks = json.load(f)
     print(f"Loaded {len(decks)} decks from local build {local_decks}")
 else:
-    gh_request = requests.get("https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json")
+    gh_request = requests.get(
+        "https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json",
+        timeout=(10, 60),
+    )
+    gh_request.raise_for_status()
 
     try:
         decks = json.loads(gh_request.content)

--- a/scripts/legacy/product_compiler.py
+++ b/scripts/legacy/product_compiler.py
@@ -34,7 +34,8 @@ def main():
     jsonFile = "mtgJson/AllPrintings.json"
     if path.getmtime(jsonFile) < time.time() - 24 * 60 * 60:
         url = "https://mtgjson.com/api/v5/AllPrintings.json"
-        r = requests.get(url)
+        r = requests.get(url, timeout=(10, 60))
+        r.raise_for_status()
         open(jsonFile, "wb").write(r.content)
         logger.info("Downloaded new MTGJson content")
 

--- a/scripts/load_new_products.py
+++ b/scripts/load_new_products.py
@@ -17,7 +17,8 @@ DEFAULT_TCGAPI_VERSION = "v1.39.0"
 
 def get_cardKingdom():
     sealed_url = "https://api.cardkingdom.com/api/sealed_pricelist"
-    r = requests.get(sealed_url)
+    r = requests.get(sealed_url, timeout=(10, 60))
+    r.raise_for_status()
     ck_data = json.loads(r.content)
     output_data = ck_data['data']
     output_data = [x for x in output_data if "Pure Bulk:" not in x['name']]
@@ -30,8 +31,10 @@ def tcgdownload(url, params, api_version, auth_code):
     }  # Need to figure out the correct headers for TCG API
     # Need to figure out the correct version for TCG API
     r = requests.get(
-        url.replace("[API_VERSION]", api_version), params=params, headers=header
+        url.replace("[API_VERSION]", api_version), params=params,
+        headers=header, timeout=(10, 60),
     )
+    r.raise_for_status()
     # print(r.ok)
     return r.content
 
@@ -183,7 +186,8 @@ def get_tcg_auth_code(secret):
 
 def get_cardmarket():
     product_list_url = "https://downloads.s3.cardmarket.com/productCatalog/productList/products_nonsingles_1.json"
-    r = requests.get(product_list_url)
+    r = requests.get(product_list_url, timeout=(10, 60))
+    r.raise_for_status()
     mkm_data = json.loads(r.content)
     product_list = mkm_data["products"]
 
@@ -290,7 +294,8 @@ def ctdownload(url, params, token):
     header = {
         "Authorization": f"Bearer {token}"
     }
-    r = requests.get(url, params=params, headers=header)
+    r = requests.get(url, params=params, headers=header, timeout=(10, 60))
+    r.raise_for_status()
     return r.content
 
 
@@ -412,7 +417,8 @@ def load_miniaturemarket(secret):
         header = {
             "User-Agent": "curl/8.6",
         }
-        r = requests.get(link, headers=header)
+        r = requests.get(link, headers=header, timeout=(10, 60))
+        r.raise_for_status()
         soup = BeautifulSoup(r.content, 'html.parser')
 
         for div in soup.find_all('div', attrs={"class": "card-body"}):
@@ -458,7 +464,11 @@ def scgretaildownload(guid, page):
     payload["clientguid"] = guid
     payload["FacetSelections"] = facet
 
-    r = requests.post("https://starcitygamesv2.searchapi-na.hawksearch.com/api/v2/search", json=payload, headers=header)
+    r = requests.post(
+        "https://starcitygamesv2.searchapi-na.hawksearch.com/api/v2/search",
+        json=payload, headers=header, timeout=(10, 60),
+    )
+    r.raise_for_status()
     return json.loads(r.content)
 
 
@@ -476,7 +486,11 @@ def scgbuylistdownload(bearer, offset, limit):
     payload["limit"] = limit
     payload["sort"] = ["name:asc", "set_name:asc", "finish:desc"]
 
-    r = requests.post("https://search.starcitygames.com/indexes/sell_list_products_v2/search", json=payload, headers=header)
+    r = requests.post(
+        "https://search.starcitygames.com/indexes/sell_list_products_v2/search",
+        json=payload, headers=header, timeout=(10, 60),
+    )
+    r.raise_for_status()
     return json.loads(r.content)
 
 
@@ -600,7 +614,8 @@ def load_coolstuffinc_retail(skip_tags):
         header = {
             "User-Agent": "curl/8.6",
         }
-        r = requests.get(link, headers=header)
+        r = requests.get(link, headers=header, timeout=(10, 60))
+        r.raise_for_status()
         soup = BeautifulSoup(r.content, 'html.parser')
 
         for div in soup.find_all('div', attrs={"class": "row product-search-row main-container"}):
@@ -637,7 +652,11 @@ def load_coolstuffinc_buylist(skip_tags):
     header = {
         "User-Agent": "curl/8.6",
     }
-    r = requests.get("https://www.coolstuffinc.com/GeneratedFiles/SellList/Section-mtg.json", headers=header)
+    r = requests.get(
+        "https://www.coolstuffinc.com/GeneratedFiles/SellList/Section-mtg.json",
+        headers=header, timeout=(10, 60),
+    )
+    r.raise_for_status()
     buylist = json.loads(r.content)
 
     for product in buylist:
@@ -679,7 +698,8 @@ def load_abugames(_):
         header = {
             "User-Agent": "curl/8.6",
         }
-        r = requests.get(link, headers=header)
+        r = requests.get(link, headers=header, timeout=(10, 60))
+        r.raise_for_status()
         data = json.loads(r.content)
         response = data.get("response")
 
@@ -750,7 +770,8 @@ def load_tnt(_):
         header = {
             "User-Agent": "curl/8.6",
         }
-        r = requests.get(link, headers=header)
+        r = requests.get(link, headers=header, timeout=(10, 60))
+        r.raise_for_status()
         soup = BeautifulSoup(r.content, 'html.parser')
 
         for div in soup.find_all('div', attrs={"class": "product-info card-body col pl-0 pl-sm-3"}):
@@ -891,7 +912,8 @@ def load_hareruya(_):
         header = {
             "User-Agent": "curl/8.6",
         }
-        r = requests.get(link, headers=header)
+        r = requests.get(link, headers=header, timeout=(10, 60))
+        r.raise_for_status()
         docs = json.loads(r.content).get("response", {}).get("docs", [])
 
         # Exit loop condition: stop once a page returns no more products

--- a/scripts/redemption_decks.py
+++ b/scripts/redemption_decks.py
@@ -5,7 +5,8 @@ import string
 def get_decks(setup=""):
     if not setup:
         url = "https://mtgjson.com/api/v5/AllPrintings.json"
-        r = requests.get(url, stream=True)
+        r = requests.get(url, stream=True, timeout=(10, 60))
+        r.raise_for_status()
         parser = ijson.parse(r.content)
     else:
         ifile = open(setup, 'r')

--- a/scripts/sld_auto.py
+++ b/scripts/sld_auto.py
@@ -6,7 +6,8 @@ import requests
 import sys
 
 url = r"https://mtgjson.com/api/v5/SLD.json"
-r = requests.get(url, stream=True)
+r = requests.get(url, stream=True, timeout=(10, 60))
+r.raise_for_status()
 uuids = {}
 parser = ijson.parse(r.content)
 

--- a/tests/test_standalone_http.py
+++ b/tests/test_standalone_http.py
@@ -1,0 +1,73 @@
+import contextlib
+import io
+from pathlib import Path
+import runpy
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+from scripts import load_new_products
+from scripts.card_to_product_compiler import MtgjsonCardLinker
+from scripts.gatherer_original_printing_details_generator import GathererDownloader
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from contents_validator import build_uuid_map
+
+
+def response(status, content):
+    result = requests.Response()
+    result.status_code = status
+    result._content = content
+    result._content_consumed = True
+    result.url = "https://example.test"
+    return result
+
+
+class StandaloneHttpTests(unittest.TestCase):
+    def test_error_pages_do_not_become_empty_catalogs(self):
+        for loader in (load_new_products.load_miniaturemarket, load_new_products.load_tnt,
+                       load_new_products.load_hareruya):
+            with self.subTest(loader=loader.__name__), patch.object(
+                load_new_products.requests, "get", return_value=response(503, b"maintenance")
+            ) as get, contextlib.redirect_stdout(io.StringIO()), self.assertRaises(requests.HTTPError):
+                loader(None)
+            self.assertEqual(get.call_args.kwargs["timeout"], (10, 60))
+
+    def test_post_search_errors_raise_before_json_parsing(self):
+        with patch.object(load_new_products.requests, "post", return_value=response(503, b"maintenance")) as post:
+            with self.assertRaises(requests.HTTPError):
+                load_new_products.scgbuylistdownload("test", 0, 100)
+        self.assertEqual(post.call_args.kwargs["timeout"], (10, 60))
+        self.assertEqual(post.call_args.kwargs["json"]["limit"], 100)
+
+    def test_gatherer_failed_second_page_does_not_return_partial_sets(self):
+        session = Mock()
+        session.get.side_effect = [response(200, b'<a href="/sets/abc">ABC</a>'), response(503, b"maintenance")]
+        downloader = GathererDownloader(session)
+        with self.assertRaises(requests.HTTPError):
+            downloader.get_set_codes()
+        self.assertEqual(session.get.call_count, 2)
+        self.assertEqual(session.get.call_args.kwargs["timeout"], (10, 60))
+
+    def test_allprintings_timeout_uses_backup(self):
+        linker = MtgjsonCardLinker.__new__(MtgjsonCardLinker)
+        payload = b'{"data":{"ABC":{"sealedProduct":[{}],"decks":[{}]}}}'
+        with patch.object(linker, "PRIMARY_URL", "https://example.test/primary.json"), patch.object(
+            linker, "BACKUP_URL", "https://example.test/backup.json"
+        ), patch("scripts.card_to_product_compiler.requests.get", side_effect=[requests.Timeout(), response(200, payload)]) as get, contextlib.redirect_stdout(io.StringIO()):
+            result = linker._download_mtgjson_data()
+        self.assertIn("ABC", result)
+        self.assertEqual(get.call_count, 2)
+        self.assertEqual(get.call_args.args[0], "https://example.test/backup.json")
+        self.assertEqual(get.call_args.kwargs["timeout"], (10, 60))
+
+    def test_status_download_failure_is_not_parsed(self):
+        with patch("requests.get", return_value=response(503, b'{"data":{}}')), patch("ijson.parse") as parse, contextlib.redirect_stdout(io.StringIO()):
+            self.assertIsNone(build_uuid_map(None))
+        parse.assert_not_called()
+
+    def test_deck_import_download_failure_stops_before_writing(self):
+        root = Path(__file__).resolve().parents[1]
+        with patch.dict("os.environ", {"DECKS_JSON": ""}), patch("requests.get", return_value=response(503, b"[]")), patch("builtins.open", side_effect=AssertionError("unexpected file access")), patch("pathlib.Path.glob", return_value=[]), self.assertRaises(requests.HTTPError):
+            runpy.run_path(str(root / "scripts/import_new_decks.py"), run_name="__main__")


### PR DESCRIPTION
Standalone HTTP calls could wait indefinitely, and failed catalog pages could be interpreted as an empty final page. Failed downloads could also reach parsers or overwrite cached data.

Add explicit connect/read timeouts to the remaining standalone Requests calls and Gatherer's cached requests. Check HTTP status before parsing catalog responses, importing decks, or writing downloaded files. Keep the existing authentication-specific error handling and MTGJSON backup behavior.

Validation: all 23 unit tests pass, including six new regression tests for catalog HTTP failures, POST search failures, Gatherer pagination failure, MTGJSON timeout fallback, status-download rejection, and deck-import failure before file access. A source audit confirms all 19 standalone Requests calls specify timeouts; `git diff --check` passes. Tests use mocked responses and do not call live services.
