### PR TITLE
Prevent failed token downloads from truncating mappings

### DIFF
--- a/scripts/tokens/tcgplayer_provider.py
+++ b/scripts/tokens/tcgplayer_provider.py
@@ -3,6 +3,7 @@ import json
 import multiprocessing
 import os
 import pathlib
+import tempfile
 from typing import Dict, Any, Iterable, List
 
 import requests
@@ -54,24 +55,51 @@ class TcgplayerProvider:
         )
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         if cache_path.exists():
-            # print(f"Using cached response for {url} with params {params}")
-            with cache_path.open("r") as fp:
-                return json.load(fp)
+            try:
+                with cache_path.open("r") as fp:
+                    cached = json.load(fp)
+                # Older runs cached [] for both valid empty pages and API
+                # failures. Re-fetch those rather than trusting an ambiguous
+                # pagination terminator. Corrupt caches also need a refresh.
+                if isinstance(cached, list) and cached and all(
+                    isinstance(item, dict) for item in cached
+                ):
+                    return cached
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                pass
 
         print(f"Downloading {url} with params {params}")
-        response = self.__session.get(url, params=params)
-        response_decoded = response.content.decode()
+        with self.__session.get(url, params=params) as response:
+            response.raise_for_status()
+            payload = response.json()
 
+        # Fail closed: an API error or malformed envelope is not an empty page.
+        # See https://docs.tcgplayer.com/reference/catalog_getproducts-1
+        if not isinstance(payload, dict) or payload.get("success") is not True:
+            raise ValueError("TCGplayer catalog response did not report success")
+        if payload.get("errors"):
+            raise ValueError("TCGplayer catalog response reported errors")
+        results = payload.get("results")
+        if not isinstance(results, list) or not all(
+            isinstance(item, dict) for item in results
+        ):
+            raise ValueError("TCGplayer catalog response must contain a results list of objects")
+
+        # Publish a complete cache file only after validation and serialization.
+        # A failed refresh leaves the previous cache untouched.
+        temporary_path = None
         try:
-            response = json.loads(response_decoded)
-            results = list(response.get("results", []))
-
-            with cache_path.open("w") as fp:
+            with tempfile.NamedTemporaryFile(
+                mode="w", encoding="utf-8", dir=cache_path.parent,
+                prefix=f".{cache_path.name}.", suffix=".tmp", delete=False,
+            ) as fp:
+                temporary_path = pathlib.Path(fp.name)
                 json.dump(results, fp, indent=4, ensure_ascii=False, sort_keys=True)
-            return results
-
-        except json.decoder.JSONDecodeError:
-            return []
+            temporary_path.replace(cache_path)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+        return results
 
     def download_exhaustive(
         self,

--- a/tests/test_token_downloads.py
+++ b/tests/test_token_downloads.py
@@ -1,0 +1,128 @@
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+from scripts.tokens.tcgplayer_provider import TcgplayerProvider
+
+
+class InlinePool:
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def starmap(self, function, args):
+        return [function(*item) for item in args]
+
+
+class TokenDownloadTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.previous = Path.cwd()
+        os.chdir(self.temp.name)
+        self.addCleanup(self.temp.cleanup)
+        self.addCleanup(os.chdir, self.previous)
+        self.provider = TcgplayerProvider.__new__(TcgplayerProvider)
+        self.session = Mock()
+        self.provider._TcgplayerProvider__session = self.session
+        self.params = {"groupId": 1, "offset": 0, "limit": 100}
+        self.cache = Path("caches/tcgplayer/1-0.json")
+        self.output = contextlib.redirect_stdout(io.StringIO())
+        self.output.__enter__()
+        self.addCleanup(self.output.__exit__, None, None, None)
+
+    def response(self, payload, status=200):
+        response = requests.Response()
+        response.status_code = status
+        response.url = "https://example.test/catalog"
+        response._content = payload if isinstance(payload, bytes) else json.dumps(payload).encode()
+        response._content_consumed = True
+        return response
+
+    def download(self):
+        return self.provider.download("https://example.test/catalog", self.params)
+
+    def write_cache(self, contents):
+        self.cache.parent.mkdir(parents=True, exist_ok=True)
+        self.cache.write_text(contents)
+
+    def test_http_and_json_failures_never_create_cache(self):
+        for response in (self.response(b"maintenance", 503), self.response(b"not json")):
+            with self.subTest(status=response.status_code):
+                self.session.get.return_value = response
+                with self.assertRaises((requests.HTTPError, ValueError)):
+                    self.download()
+                self.assertFalse(self.cache.exists())
+
+    def test_invalid_envelopes_never_create_cache(self):
+        for payload in ([], {"success": False, "results": []},
+                        {"results": []}, {"success": True},
+                        {"success": True, "errors": ["partial failure"], "results": []},
+                        {"success": True, "results": {}},
+                        {"success": True, "results": [None]}):
+            with self.subTest(payload=payload):
+                self.session.get.return_value = self.response(payload)
+                with self.assertRaises(ValueError):
+                    self.download()
+                self.assertFalse(self.cache.exists())
+
+    def test_valid_catalog_is_cached_and_reused(self):
+        products = [{"productId": 1, "name": "Example Token"}]
+        self.session.get.return_value = self.response({"success": True, "errors": [], "results": products})
+        self.assertEqual(self.download(), products)
+        self.assertEqual(json.loads(self.cache.read_text()), products)
+        self.assertEqual(self.download(), products)
+        self.session.get.assert_called_once_with("https://example.test/catalog", params=self.params)
+
+    def test_legacy_empty_or_corrupt_cache_is_refetched(self):
+        products = [{"productId": 1}]
+        for old in ("[]", "broken JSON", "{}", "[null]"):
+            with self.subTest(old=old):
+                self.write_cache(old)
+                self.session.get.return_value = self.response({"success": True, "results": products})
+                self.assertEqual(self.download(), products)
+                self.assertEqual(json.loads(self.cache.read_text()), products)
+
+    def test_failed_refresh_leaves_old_cache_unchanged(self):
+        self.write_cache("[]")
+        self.session.get.return_value = self.response({"success": False, "results": []})
+        with self.assertRaises(ValueError):
+            self.download()
+        self.assertEqual(self.cache.read_text(), "[]")
+
+    def test_interrupted_cache_write_does_not_publish_partial_file(self):
+        self.write_cache("[]")
+        self.session.get.return_value = self.response({"success": True, "results": [{"productId": 1}]})
+        def fail_write(value, fp, **kwargs):
+            fp.write("[")
+            raise OSError("disk full")
+        with patch("scripts.tokens.tcgplayer_provider.json.dump", side_effect=fail_write), self.assertRaises(OSError):
+            self.download()
+        self.assertEqual(self.cache.read_text(), "[]")
+        self.assertEqual(list(self.cache.parent.iterdir()), [self.cache])
+
+    def test_valid_empty_page_ends_pagination(self):
+        self.session.get.return_value = self.response({"success": True, "errors": [], "results": []})
+        with patch("scripts.tokens.tcgplayer_provider.multiprocessing.Pool", InlinePool):
+            self.assertEqual(self.provider.download_exhaustive("https://example.test/catalog", self.params, threads=1), [])
+        self.session.get.assert_called_once()
+
+    def test_failed_later_page_does_not_return_partial_catalog(self):
+        self.session.get.side_effect = [
+            self.response({"success": True, "results": [{"productId": 1}]}),
+            self.response(b"maintenance", 503),
+        ]
+        with patch("scripts.tokens.tcgplayer_provider.multiprocessing.Pool", InlinePool), self.assertRaises(requests.HTTPError):
+            self.provider.download_exhaustive("https://example.test/catalog", self.params, threads=1)
+        self.assertTrue(self.cache.exists())
+        self.assertFalse(Path("caches/tcgplayer/1-100.json").exists())


### PR DESCRIPTION
The token downloader treated malformed JSON as an empty page and cached API envelopes without results as empty lists. Either could silently stop pagination and produce incomplete mappings.

Validate HTTP status and the documented TCGplayer success/errors/results envelope before accepting a page. Re-fetch empty or corrupt legacy caches because an old empty cache cannot distinguish an API failure from a valid pagination terminator. Write validated cache contents through a temporary file and atomic replacement, preserving the previous file if a refresh or write fails.

Validation: all 31 unit tests pass, including eight new regression tests for HTTP/JSON/envelope failures, cache reuse and recovery, interrupted writes, successful empty-page termination, and failure after a populated page. `git diff --check` passes.

Response-envelope checks follow https://docs.tcgplayer.com/reference/catalog_getproducts-1. Tests use fixtures; an authenticated live catalog response was not checked because TCGplayer credentials are unavailable locally. Token-matching rules are unchanged. Empty pages are intentionally re-fetched on subsequent runs, which adds requests compared with trusting legacy empty caches.
