### PR TITLE
Map Duskmourn Nightmare lands and add missing product extras

### DIFF
--- a/data/contents/DSC.yaml
+++ b/data/contents/DSC.yaml
@@ -7,6 +7,7 @@ products:
       set: dsc
     other:
     - name: 10 Double-sided tokens
+    - name: Strategy insert
     - name: Deck box
     sealed:
     - count: 1
@@ -19,6 +20,7 @@ products:
       set: dsc
     other:
     - name: 10 Double-sided tokens
+    - name: Strategy insert
     - name: Deck box
     sealed:
     - count: 1
@@ -31,6 +33,7 @@ products:
       set: dsc
     other:
     - name: 10 Double-sided tokens
+    - name: Strategy insert
     - name: Deck box
     sealed:
     - count: 1
@@ -43,6 +46,7 @@ products:
       set: dsc
     other:
     - name: 10 Double-sided tokens
+    - name: Strategy insert
     - name: Deck box
     sealed:
     - count: 1

--- a/data/contents/DSK.yaml
+++ b/data/contents/DSK.yaml
@@ -11,6 +11,7 @@ products:
       set: dsk
     other:
     - name: Duskmourn Spindown
+    - name: 2 Reference cards
     - name: Deck Box
     sealed:
     - count: 9
@@ -47,11 +48,14 @@ products:
     - name: 'Duskmourn: House of Horror Redemption'
       set: dsk
   Duskmourn House of Horror Nightmare Bundle:
+    deck:
+    - name: 'Duskmourn: House of Horror Nightmare Bundle Land Pack'
+      set: dsk
     other:
     - name: 3 double-sided movie posters
     - name: Glow-in-the-dark spindown die
     - name: Deck box
-    - name: 20 foil full-art lands
+    - name: 2 Reference cards
     sealed:
     - count: 6
       name: Duskmourn House of Horror Play Booster Pack
@@ -92,6 +96,7 @@ products:
     other:
     - name: Deck box
     - name: Duskmourn spindown
+    - name: MTG Arena code card (available in select regions)
     pack:
     - code: prerelease
       set: dsk


### PR DESCRIPTION
The Duskmourn Nightmare Bundle lists its 20 foil full-art lands as accessories, leaving them unmapped. Replace that placeholder with a dedicated land-pack deck reference. Also add both Bundles' two reference cards, four Commander strategy inserts, and the regional prerelease Arena code card.

The new deck is provided by [companion deck PR #314](https://github.com/taw/magic-preconstructed-decks/pull/314): four foil copies each of DSK 272–276. That deck change must propagate before the new reference can resolve downstream.

Sources: [collecting Duskmourn](https://magic.wizards.com/en/news/feature/collecting-duskmourn), [Commander contents](https://magic.wizards.com/en/news/announcements/duskmourn-house-of-horror-commander-decklists), and [WPN product guide](https://media.wizards.com/2024/wpn/marketing_materials/dsk/dsk_product_guide_en.pdf). The corrected Commander article supersedes the PDF's life-wheel claim. Scheme cards are already mapped in the decks.

Validation: contents validator and git diff --check passed; existing unrelated category/subtype warnings remain. The new deck export resolves the reference to exactly 20 foil lands, four per specified printing.
