### PR TITLE
Preserve etched finishes and map nested variable contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ name: [str] Full card name
 set: [str] Set code
 number: [str or int] Collector number
 foil: [bool, optional] True if card is traditional or etched foil
+etched: [bool, optional] True if card is etched foil; takes precedence over foil when mapping the finish
 token: [bool, optional] True if the collector number refers to a token instead of a card, ie. SLD 918 "Food"
 uuid: [str, calculated] The card's MTGJson UUID. This is calculated by the compiler and you should not enter this in the YAML.
 ```

--- a/scripts/card_to_product_compiler.py
+++ b/scripts/card_to_product_compiler.py
@@ -129,7 +129,10 @@ class MtgjsonCardLinker:
 
     @staticmethod
     def get_card_obj_from_card(card_content: Dict[str, Any]) -> List[Card]:
-        finish = "foil" if card_content.get("foil") else "nonfoil"
+        if card_content.get("etched"):
+            finish = "etched"
+        else:
+            finish = "foil" if card_content.get("foil") else "nonfoil"
         if "uuid" in card_content:
             return [Card(card_content["uuid"], finish)]
         else:
@@ -215,24 +218,12 @@ class MtgjsonCardLinker:
             """
             return_value = set()
             for config in content["configs"]:
-                for deck in config.get("deck", []):
-                    return_value.update(
-                        self.get_cards_in_deck(deck["set"].upper(), deck["name"])
-                    )
-                for sealed in config.get("sealed", []):
-                    return_value.update(
-                        self.get_cards_in_sealed_product(
-                            sealed["set"].upper(), sealed.get("uuid", None)
-                        )
-                    )
-                for pack in config.get("pack", []):
-                    return_value.update(
-                        self.get_cards_in_pack(
-                            pack["set"].upper(), pack["code"]
-                        )
-                    )
-                for card in config.get("card", []):
-                    return_value.update(self.get_card_obj_from_card(card))
+                # Configurations contain the same content types as products,
+                # including further variable choices. Ignore configuration
+                # metadata such as card_count and variable_config.
+                for kind in ("card", "pack", "sealed", "deck", "variable", "other"):
+                    for entry in config.get(kind, []):
+                        return_value.update(self.get_cards_in_content_type(kind, entry))
 
             return list(return_value)
 

--- a/tests/test_card_to_product_mapping.py
+++ b/tests/test_card_to_product_mapping.py
@@ -1,0 +1,65 @@
+import contextlib
+from copy import deepcopy
+import io
+import unittest
+
+from scripts.card_to_product_compiler import MtgjsonCardLinker, results_to_json
+from scripts.product_classes import card
+
+
+class CardToProductMappingTests(unittest.TestCase):
+    def test_direct_card_finishes_preserve_etched_precedence(self):
+        for flags, expected in (
+            ({}, "nonfoil"), ({"foil": True}, "foil"),
+            ({"etched": True}, "etched"),
+            ({"foil": True, "etched": True}, "etched"),
+            ({"foil": True, "etched": False}, "foil"),
+        ):
+            with self.subTest(flags=flags):
+                # Exercise the card representation produced by this repo.
+                content = card({"name": "Example", "set": "tst", "number": 1,
+                                "uuid": "card-id", **flags}).toJson()
+                mapped = MtgjsonCardLinker.get_card_obj_from_card(content)
+                self.assertEqual([(entry.uuid, entry.finish) for entry in mapped], [("card-id", expected)])
+
+    def test_unresolved_etched_card_is_omitted(self):
+        self.assertEqual(MtgjsonCardLinker.get_card_obj_from_card({"etched": True}), [])
+
+    def test_nested_configurations_map_all_content_types_and_keep_finishes(self):
+        linker = MtgjsonCardLinker.__new__(MtgjsonCardLinker)
+        nested = {"configs": [{
+            "card": [{"uuid": "shared", "etched": True}, {"uuid": "shared", "foil": True}],
+            "sealed": [{"set": "tst", "uuid": "child"}],
+            "deck": [{"set": "tst", "name": "Example Deck"}],
+            "pack": [{"set": "tst", "code": "default"}],
+            "other": [{"name": "Accessories"}],
+            "card_count": 10,
+            "variable_config": [{"chance": 1, "weight": 2}],
+            "variable": [{"configs": [{"card": [{"uuid": "deep", "etched": True}]}]}],
+        }]}
+        linker.mtgjson_data = {"TST": {
+            "sealedProduct": [
+                {"uuid": "parent", "name": "Parent", "contents": {
+                    "card": [{"uuid": "shared"}],
+                    "variable": [{"configs": [{"variable": [nested]}, {"variable": [deepcopy(nested)]}]}],
+                }},
+                {"uuid": "child", "name": "Child", "contents": {"card": [{"uuid": "child-card", "etched": True}]}},
+            ],
+            "cards": [{"uuid": "deck-card", "finishes": ["nonfoil"]}], "tokens": [],
+            "decks": [{"name": "Example Deck", "sourceSetCodes": ["TST"], "cards": [{"uuid": "deck-card"}]}],
+            "booster": {"default": {
+                "boosters": [{"contents": {"common": 1}}],
+                "sheets": {"common": {"foil": False, "cards": {"pack-card": 1}}},
+            }},
+        }}
+        original = deepcopy(linker.mtgjson_data)
+        with contextlib.redirect_stdout(io.StringIO()):
+            mapped = results_to_json(linker.build(None, False))
+        self.assertEqual(mapped, {
+            "shared": {"nonfoil": ["parent"], "foil": ["parent"], "etched": ["parent"]},
+            "deep": {"etched": ["parent"]},
+            "child-card": {"etched": ["child", "parent"]},
+            "deck-card": {"nonfoil": ["parent"]},
+            "pack-card": {"nonfoil": ["parent"]},
+        })
+        self.assertEqual(linker.mtgjson_data, original)


### PR DESCRIPTION
Direct card contents with `etched: true` were mapped as nonfoil (or foil when both flags were set), and nested variable configurations were skipped entirely.

Give the etched flag precedence over foil for direct cards. Traverse nested variable configurations through the existing card, pack, deck, sealed, and variable handlers, preserving finish-specific mappings and deduplicating repeated choices. Document the etched flag and its precedence in the README.

Validation: new regressions reproduced the etched and nested-variable failures before the fix; all 26 tests now pass. Coverage includes direct finish combinations, unresolved cards, nested cards/decks/packs/sealed products, duplicate configurations, and unchanged input data. `git diff --check` passes. Generated mappings were not rebuilt from live AllPrintings.
