### PR TITLE
Add missing Foundations product extras

### DIFF
--- a/data/contents/FDN.yaml
+++ b/data/contents/FDN.yaml
@@ -45,6 +45,7 @@ products:
       set: fdn
     other:
     - name: Oversize spindown life counter
+    - name: 2 Reference cards
     - name: Deck box
     sealed:
     - count: 9
@@ -89,6 +90,7 @@ products:
     card_count: 1
     other:
     - name: Foundations Spindown
+    - name: MTG Arena code card (available in select regions)
     pack:
     - code: prerelease
       set: fdn
@@ -105,6 +107,7 @@ products:
     - name: 2 Reference cards
     - name: How to Build Your Deck booklet
     - name: Click wheel
+    - name: 13 Double-sided tokens
     sealed:
     - count: 3
       name: Foundations Play Booster Pack


### PR DESCRIPTION
Add the two reference cards included in the Foundations Bundle, the Starter Collection's 13 double-sided tokens, and the region-dependent prerelease Arena code card.

The fixed card lists already match the [official collecting guide](https://magic.wizards.com/en/news/feature/collecting-foundations): Starter Collection has 387 cards with 26 foils, Beginner Box has ten fixed 20-card packs, and Bundle has 40 lands.

Validation: contents validator and git diff --check passed. Existing unrelated category/subtype warnings remain. No new test files or card-list changes.
