### PR TITLE
Add 2024 Costco March of the Machine Commander kits

### DIFF
--- a/data/contents/MOC.yaml
+++ b/data/contents/MOC.yaml
@@ -89,3 +89,118 @@ products:
     - count: 1
       name: March of the Machine Commander Deck Tinker Time
       set: moc
+  March of the Machine Deluxe Commander Kit Call For Backup:
+    card:
+    - foil: true
+      name: Jace, Memory Adept
+      number: 2024-2
+      set: pmei
+    - foil: true
+      name: Ajani, Mentor of Heroes
+      number: 2024-3
+      set: pmei
+    sealed:
+    - count: 1
+      name: March of the Machine Commander Deck Call For Backup
+      set: moc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: March of the Machine Set Booster Pack
+      set: mom
+    - count: 1
+      name: Commander Masters Set Booster Pack
+      set: cmm
+  March of the Machine Deluxe Commander Kit Cavalry Charge:
+    card:
+    - foil: true
+      name: Jace, Memory Adept
+      number: 2024-2
+      set: pmei
+    - foil: true
+      name: Ajani, Mentor of Heroes
+      number: 2024-3
+      set: pmei
+    sealed:
+    - count: 1
+      name: March of the Machine Commander Deck Cavalry Charge
+      set: moc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: March of the Machine Set Booster Pack
+      set: mom
+    - count: 1
+      name: Commander Masters Set Booster Pack
+      set: cmm
+  March of the Machine Deluxe Commander Kit Divine Convocation:
+    card:
+    - foil: true
+      name: Jace, Memory Adept
+      number: 2024-2
+      set: pmei
+    - foil: true
+      name: Ajani, Mentor of Heroes
+      number: 2024-3
+      set: pmei
+    sealed:
+    - count: 1
+      name: March of the Machine Commander Deck Divine Convocation
+      set: moc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: March of the Machine Set Booster Pack
+      set: mom
+    - count: 1
+      name: Commander Masters Set Booster Pack
+      set: cmm
+  March of the Machine Deluxe Commander Kit Growing Threat:
+    card:
+    - foil: true
+      name: Jace, Memory Adept
+      number: 2024-2
+      set: pmei
+    - foil: true
+      name: Ajani, Mentor of Heroes
+      number: 2024-3
+      set: pmei
+    sealed:
+    - count: 1
+      name: March of the Machine Commander Deck Growing Threat
+      set: moc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: March of the Machine Set Booster Pack
+      set: mom
+    - count: 1
+      name: Commander Masters Set Booster Pack
+      set: cmm
+  March of the Machine Deluxe Commander Kit Tinker Time:
+    card:
+    - foil: true
+      name: Jace, Memory Adept
+      number: 2024-2
+      set: pmei
+    - foil: true
+      name: Ajani, Mentor of Heroes
+      number: 2024-3
+      set: pmei
+    sealed:
+    - count: 1
+      name: March of the Machine Commander Deck Tinker Time
+      set: moc
+    - count: 1
+      name: Bloomburrow Play Booster Pack
+      set: blb
+    - count: 1
+      name: March of the Machine Set Booster Pack
+      set: mom
+    - count: 1
+      name: Commander Masters Set Booster Pack
+      set: cmm

--- a/data/products/MOC.yaml
+++ b/data/products/MOC.yaml
@@ -82,3 +82,29 @@ products:
       tntId: '1774248'
     release_date: '2023-02-20'
     subtype: COMMANDER
+  # Costco kits launched in early September 2024; an exact release day is not published.
+  March of the Machine Deluxe Commander Kit Call For Backup:
+    category: SUBSET
+    identifiers:
+      tcgplayerProductId: '602883'
+    subtype: COMMANDER
+  March of the Machine Deluxe Commander Kit Cavalry Charge:
+    category: SUBSET
+    identifiers:
+      tcgplayerProductId: '602881'
+    subtype: COMMANDER
+  March of the Machine Deluxe Commander Kit Divine Convocation:
+    category: SUBSET
+    identifiers:
+      tcgplayerProductId: '602882'
+    subtype: COMMANDER
+  March of the Machine Deluxe Commander Kit Growing Threat:
+    category: SUBSET
+    identifiers:
+      tcgplayerProductId: '602880'
+    subtype: COMMANDER
+  March of the Machine Deluxe Commander Kit Tinker Time:
+    category: SUBSET
+    identifiers:
+      tcgplayerProductId: '602884'
+    subtype: COMMANDER


### PR DESCRIPTION
Add all five missing 2024 Costco March of the Machine Deluxe Commander Kits. Each kit maps its corresponding Commander deck, one BLB Play Booster, one MOM Set Booster, one CMM Set Booster, and foil PMEI 2024-2 Jace, Memory Adept / 2024-3 Ajani, Mentor of Heroes. Include the five TCGplayer catalog IDs.

[Wizards' announcement](https://magic.wizards.com/en/news/announcements/fall-2024-promo-cards-arrive-in-new-bundles) confirms the contents and early-September 2024 launch. Leave the exact release-date field unset because the announcement does not establish a day; a source comment records the month rather than inventing a date. Catalog IDs were resolved from the kits' TCGplayer links on MTG Sea; the exact promo numbers and foil availability were verified in the current card index.

Validation: contents validator and git diff --check passed; all five kits resolve their four nested products and two promos. Existing unrelated category/subtype warnings remain. No new test files.
