### PR TITLE
Add missing tokens to 2024 Secret Lair Commander contents

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -1577,6 +1577,8 @@ products:
     deck:
     - name: 20 Ways to Win
       set: sld
+    other:
+    - name: 7 additional nonfoil double-sided tokens
   Secret Lair Commander Deck Angels Theyre Just Like Us but Cooler and with Wings:
     card:
     - foil: true
@@ -1659,6 +1661,8 @@ products:
     deck:
     - name: Raining Cats and Dogs
       set: sld
+    other:
+    - name: 11 nonfoil double-sided tokens
   Secret Lair Drop A Box of Rocks:
     card_count: 5
     deck:


### PR DESCRIPTION
Add the ordinary double-sided tokens omitted from the sealed descriptions of two 2024 Secret Lair Commander decks: seven additional nonfoil tokens in 20 Ways to Win and eleven in Raining Cats and Dogs.

The deck data already maps the special foil tokens and display commanders. [Companion deck PR #313](https://github.com/taw/magic-preconstructed-decks/pull/313) corrects 20 Ways to Win from two to three Spirit tokens; with that correction, its three Spirit tokens, two Shrine tokens and seven additional tokens total twelve. Gameplay card counts remain 100.

Sources: [20 Ways to Win contents](https://magic.wizards.com/en/news/announcements/secret-lair-commander-deck-20-ways-to-win-full-decklist) and [Raining Cats and Dogs contents](https://magic.wizards.com/en/news/announcements/secret-lair-commander-deck-raining-cats-and-dogs).

Validation: contents validator and git diff --check passed; totals checked against the corrected deck export. Existing unrelated category/subtype warnings remain. No new test files.
