### PR TITLE
Validate local product references and indirect cycles

### DIFF
--- a/scripts/contents_validator.py
+++ b/scripts/contents_validator.py
@@ -19,6 +19,11 @@ import yaml
 import product_classes as pc
 from pathlib import Path
 
+if __package__:
+    from .reference_validator import validate_references
+else:
+    from reference_validator import validate_references
+
 def build_uuid_map(mtgjson_path):
     import ijson
     import requests
@@ -269,6 +274,7 @@ def validate_structure():
                     failed = True
     if failed:
         raise ImportError()
+    validate_references()
     print("All products validated")
 
 def rebuild_status_and_deck_map(uuid_map):

--- a/scripts/reference_validator.py
+++ b/scripts/reference_validator.py
@@ -1,0 +1,71 @@
+"""Validate local sealed/copy references without requiring MTGJSON downloads."""
+from pathlib import Path
+import yaml
+
+
+def reference_errors(product_names, contents):
+    errors = []
+    graph = {key: set() for key in contents}
+
+    def visit_contents(source, value):
+        if not isinstance(value, dict):
+            return
+        if set(value) == {'copy'}:
+            target = (source[0], value['copy'])
+            if target not in contents:
+                errors.append(f'{source}: missing copy target {target}')
+            else:
+                graph[source].add(target)
+            return
+        for entry in value.get('sealed', []):
+            target = (entry['set'].lower(), entry['name'])
+            if target not in product_names:
+                errors.append(f'{source}: missing sealed product {target}')
+            if target in contents:
+                graph[source].add(target)
+        for choice in value.get('variable', []):
+            visit_contents(source, choice)
+
+    for source, value in contents.items():
+        visit_contents(source, value)
+
+    completed = set()
+    active = set()
+    trail = []
+
+    def visit(node):
+        if node in active:
+            cycle = trail[trail.index(node):] + [node]
+            errors.append('Product reference cycle: ' + ' -> '.join(f'{s}/{n}' for s, n in cycle))
+            return
+        if node in completed:
+            return
+        active.add(node)
+        trail.append(node)
+        for target in sorted(graph[node]):
+            visit(target)
+        trail.pop()
+        active.remove(node)
+        completed.add(node)
+
+    for node in sorted(graph):
+        visit(node)
+    return errors
+
+
+def validate_references():
+    product_names = set()
+    contents = {}
+    for folder, target in (('products', product_names), ('contents', contents)):
+        for path in sorted(Path('data', folder).glob('*.yaml')):
+            with path.open() as stream:
+                data = yaml.safe_load(stream)
+            for name, value in data['products'].items():
+                key = (data['code'].lower(), name)
+                if folder == 'products':
+                    target.add(key)
+                else:
+                    target[key] = value
+    errors = reference_errors(product_names, contents)
+    if errors:
+        raise ValueError('\n'.join(errors))

--- a/tests/test_product_references.py
+++ b/tests/test_product_references.py
@@ -1,0 +1,47 @@
+import unittest
+from scripts.reference_validator import reference_errors
+
+
+class ProductReferenceTests(unittest.TestCase):
+    def test_valid_cross_set_shared_and_placeholder_targets(self):
+        a, b, c = ('a', 'Box'), ('b', 'Pack'), ('c', 'Box')
+        products = {a, b, c}
+        contents = {
+            a: {'sealed': [{'set': 'B', 'name': 'Pack'}]},
+            b: {},
+            c: {'variable': [{'sealed': [{'set': 'b', 'name': 'Pack'}]}]},
+        }
+        self.assertEqual(reference_errors(products, contents), [])
+        del contents[b]  # Known product with contents still awaiting research.
+        self.assertEqual(reference_errors(products, contents), [])
+
+    def test_missing_sealed_reference_inside_nested_variable(self):
+        key = ('a', 'Box')
+        errors = reference_errors({key}, {key: {'variable': [{'variable': [
+            {'sealed': [{'set': 'b', 'name': 'Missing'}]}
+        ]}]}})
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing sealed product', errors[0])
+        self.assertIn('Missing', errors[0])
+
+    def test_copy_target_must_have_contents(self):
+        a, b = ('a', 'Copy'), ('a', 'Original')
+        errors = reference_errors({a, b}, {a: {'copy': 'Original'}})
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing copy target', errors[0])
+        self.assertEqual(reference_errors({a, b}, {a: {'copy': 'Original'}, b: {}}), [])
+
+    def test_cross_set_cycle_through_variable_and_copy(self):
+        a, b, c = ('a', 'Box'), ('b', 'Box'), ('b', 'Alias')
+        errors = reference_errors({a, b, c}, {
+            a: {'variable': [{'sealed': [{'set': 'b', 'name': 'Alias'}]}]},
+            c: {'copy': 'Box'},
+            b: {'sealed': [{'set': 'a', 'name': 'Box'}]},
+        })
+        self.assertEqual(len(errors), 1)
+        self.assertIn('a/Box -> b/Alias -> b/Box -> a/Box', errors[0])
+
+    def test_direct_self_reference(self):
+        a = ('a', 'Box')
+        errors = reference_errors({a}, {a: {'sealed': [{'set': 'a', 'name': 'Box'}]}})
+        self.assertIn('a/Box -> a/Box', errors[0])


### PR DESCRIPTION
Structural validation could accept references to nonexistent sealed products and indirect cycles that later break recursive mapping. Add a local reference graph check to the normal contents validation gate.

Check sealed targets against product definitions, copy targets against contents, and cycles across sets, copies, and nested variable choices. Known products with missing or empty contents remain valid research placeholders. Errors identify the source/target or full cycle path.

Validation: all 31 tests pass, including five new graph regression tests; full repository validation passes without data changes. git diff --check passes. No MTGJSON download is required.
