### PR TITLE
Make deck import and review tools safe to import

### DIFF
--- a/scripts/check_product_fuzzy.py
+++ b/scripts/check_product_fuzzy.py
@@ -13,158 +13,6 @@ BRACKETED_PASTE_RE = re.compile(r"\x1b\[20[01]~")
 def read_input(prompt=""):
     return BRACKETED_PASTE_RE.sub("", input(prompt))
 
-parser = argparse.ArgumentParser(
-    description="Interactively match review entries to known products."
-)
-parser.add_argument(
-    "--skip",
-    action="append",
-    default=[],
-    metavar="PATTERN",
-    help="Skip review entries whose name contains PATTERN (case-insensitive). "
-         "May be passed multiple times.",
-)
-parser.add_argument(
-    "--auto",
-    action="store_true",
-    help="Non-interactively apply only high-confidence, unambiguous matches, "
-         "leaving everything else in review.yaml for a manual pass.",
-)
-parser.add_argument(
-    "--auto-score",
-    type=int,
-    default=96,
-    metavar="N",
-    help="Minimum fuzzy score (0-100) required to auto-match (default: 96).",
-)
-parser.add_argument(
-    "--auto-margin",
-    type=int,
-    default=8,
-    metavar="N",
-    help="Minimum gap between the best and second-best score required to "
-         "auto-match, to avoid false friends (default: 8).",
-)
-parser.add_argument(
-    "--dry-run",
-    action="store_true",
-    help="With --auto, print the matches that would be applied without "
-         "writing any files.",
-)
-args = parser.parse_args()
-skip_patterns = [p.lower() for p in args.skip]
-
-review_path = Path("data/review.yaml")
-with open(review_path) as review_file:
-    review_data = yaml.safe_load(review_file)
-
-
-def remove_from_review(handled):
-    """Drop the just-handled entry from the review data and persist it so a
-    re-run does not prompt for the same product again."""
-    name, identifiers = handled[0], handled[1]
-    removed = False
-    for provider_products in review_data.values():
-        entry = provider_products.get(name)
-        if entry is not None and entry.get("identifiers") == identifiers:
-            del provider_products[name]
-            removed = True
-    if removed:
-        with open(review_path, "w") as review_file:
-            yaml.dump(review_data, review_file)
-
-
-def apply_identifier(handled, target_name, target_file):
-    """Write the review entry's identifier into the chosen known product.
-    Returns (True, None) on success, or (False, existing) without writing when
-    a different value is already set for one of the identifier keys (a conflict
-    a human should resolve)."""
-    with open(target_file) as product_file:
-        import_products = yaml.safe_load(product_file)
-    identifiers = import_products["products"][target_name].setdefault("identifiers", {})
-    for key, value in handled[1].items():
-        if key in identifiers and identifiers[key] != value:
-            return False, identifiers[key]
-    identifiers.update(handled[1])
-    with open(target_file, "w") as product_file:
-        yaml.dump(import_products, product_file)
-    return True, None
-
-
-def run_auto():
-    """Auto-apply only high-confidence, unambiguous matches; anything below
-    the score/margin thresholds is left in review.yaml for the manual pass."""
-    matched = conflicts = ambiguous = 0
-    for handled in list(review_products):
-        # Drop [set code] tags and booster pack counts like "(36Packs)" for
-        # matching (mtgjson names lack them), but keep years, player names and
-        # "(N Starter Pack)" counts -- the count is the only thing telling a
-        # single starter/tournament pack apart from its display box.
-        query = re.sub(r"\[[^\]]*\]|\(\s*\d+\s*Packs?\s*\)", " ", handled[0], flags=re.I)
-        query = re.sub(r"\s+", " ", query).strip()
-
-        best_score = second_score = -1
-        best = None
-        for candidate in known_products:
-            score = fuzz.token_sort_ratio(query, candidate[0])
-            if score > best_score:
-                second_score = best_score
-                best_score, best = score, candidate
-            elif score > second_score:
-                second_score = score
-
-        margin = best_score - second_score
-        if best is None or best_score < args.auto_score or margin < args.auto_margin:
-            ambiguous += 1
-            continue
-
-        # Edition code of the matched product (its data/products/<CODE>.yaml file)
-        code = best[1].stem
-        identifier = "/".join(str(v) for v in handled[1].values())
-
-        if args.dry_run:
-            print(f"[{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
-            matched += 1
-            continue
-
-        ok, _ = apply_identifier(handled, best[0], best[1])
-        if ok:
-            remove_from_review(handled)
-            matched += 1
-            print(f"matched [{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
-        else:
-            conflicts += 1
-
-    print(
-        f"\nAuto-match: {matched} matched, {conflicts} conflicts, "
-        f"{ambiguous + conflicts} left for review"
-        + (" (dry run, nothing written)" if args.dry_run else "")
-    )
-
-review_products = []
-skipped_count = 0
-for provider_name, provider in review_data.items():
-    for name, contents in provider.items():
-        if any(p in name.lower() for p in skip_patterns):
-            skipped_count += 1
-            continue
-        review_products.append((name, contents["identifiers"], contents.get("release_date", False), provider_name))
-
-if skip_patterns:
-    print(f"Skipping {skipped_count} review entries matching: {args.skip}")
-
-known_products = []
-for contentfile in Path("data/products").glob("*.yaml"):
-    with open(contentfile, 'r') as known_file:
-        known_data = yaml.safe_load(known_file)
-    for product_name in known_data["products"].keys():
-        known_products.append((product_name, contentfile))
-
-if args.auto:
-    run_auto()
-    sys.exit(0)
-
-
 def infer_product_definition(product_name):
     category = "UNKNOWN"
     subtype = "UNKNOWN"
@@ -255,171 +103,331 @@ def infer_product_definition(product_name):
 
     return category, subtype
 
-index = 0
-offset = 0
-while index < len(review_products):
-    product = review_products[index]
-    index += 1
 
-    print(f"Finding similar products for {product[0]} {product[1]}")
-    known_products.sort(key=lambda x: fuzz.token_sort_ratio(x[0], product[0]), reverse=True)
-    for i in range(5):
-        name, code_path = known_products[i + offset]
-        print(f"  {i} - [{code_path.stem}] {name}")
 
-    try:
-        product_check = read_input("Select action ('h' for help): ")
-    except EOFError:
-        sys.exit(1)
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Interactively match review entries to known products."
+    )
+    parser.add_argument(
+        "--skip",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="Skip review entries whose name contains PATTERN (case-insensitive). "
+             "May be passed multiple times.",
+    )
+    parser.add_argument(
+        "--auto",
+        action="store_true",
+        help="Non-interactively apply only high-confidence, unambiguous matches, "
+             "leaving everything else in review.yaml for a manual pass.",
+    )
+    parser.add_argument(
+        "--auto-score",
+        type=int,
+        default=96,
+        metavar="N",
+        help="Minimum fuzzy score (0-100) required to auto-match (default: 96).",
+    )
+    parser.add_argument(
+        "--auto-margin",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Minimum gap between the best and second-best score required to "
+             "auto-match, to avoid false friends (default: 8).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --auto, print the matches that would be applied without "
+             "writing any files.",
+    )
+    args = parser.parse_args(argv)
+    skip_patterns = [p.lower() for p in args.skip]
 
-    # Look for the product name itself
-    for i in range(len(known_products)):
-        if product_check.strip().lower() == known_products[i][0].lower():
-            product_check = "0"
-            offset = i
+    review_path = Path("data/review.yaml")
+    with open(review_path) as review_file:
+        review_data = yaml.safe_load(review_file)
 
-    # Default selection
-    if product_check == "":
-        product_check = "0"
 
-    if product_check == "q":
-        break
-    elif product_check == "s":
-        offset = 0
-        continue
-    elif product_check == "m":
-        index -= 1
-        offset += 5
-        if offset + 5 > len(known_products):
-            offset = 0
-    elif product_check == "b":
-        index -= 1
-        if index < 0:
-            index = 0
-        offset -= 5
-        if offset < 0:
-            print("NOTE: No previous choices available")
-            offset = 0
-    elif product_check == "u":
-        index -= 2
-        if index < 0:
-            print("NOTE: There is no product before this one")
-            index = 0
-        offset = 0
-    elif product_check == "i":
-        with open("data/ignore.yaml", "r") as ignore_file:
-            ignore_content = yaml.safe_load(ignore_file) or {}
-        # The review entry's provider name is the ignore.yaml section name
-        section = ignore_content.setdefault(product[3], {})
-        for identifier in product[1].values():
-            section[identifier] = product[0]
-        with open("data/ignore.yaml", "w") as ignore_file:
-            yaml.dump(ignore_content, ignore_file)
-        remove_from_review(product)
-    elif product_check in ["0","1","2","3","4"]:
-        check_index = int(product_check) + offset
-        if check_index >= len(known_products):
-            print(f"NOTE: Selection out of range, max index is {len(known_products) - 1}")
-            index -= 1
-            continue
-        product_link = known_products[check_index]
-        with open(product_link[1], 'r') as product_file:
+    def remove_from_review(handled):
+        """Drop the just-handled entry from the review data and persist it so a
+        re-run does not prompt for the same product again."""
+        name, identifiers = handled[0], handled[1]
+        removed = False
+        for provider_products in review_data.values():
+            entry = provider_products.get(name)
+            if entry is not None and entry.get("identifiers") == identifiers:
+                del provider_products[name]
+                removed = True
+        if removed:
+            with open(review_path, "w") as review_file:
+                yaml.dump(review_data, review_file)
+
+
+    def apply_identifier(handled, target_name, target_file):
+        """Write the review entry's identifier into the chosen known product.
+        Returns (True, None) on success, or (False, existing) without writing when
+        a different value is already set for one of the identifier keys (a conflict
+        a human should resolve)."""
+        with open(target_file) as product_file:
             import_products = yaml.safe_load(product_file)
-        if "identifiers" not in import_products["products"][product_link[0]]:
-            import_products["products"][product_link[0]]["identifiers"] = {}
-        keep = True
-        for key in product[1].keys():
-            if key in import_products["products"][product_link[0]]["identifiers"] and import_products['products'][product_link[0]]['identifiers'][key] != product[1][key]:
-                try:
-                    ask = read_input(f"Confirm overwrite of existing id ({import_products['products'][product_link[0]]['identifiers'][key]})? [Y] ").lower()
-                    keep = ask == "y" or ask == ""
-                except EOFError:
-                    sys.exit(1)
-        if not keep:
-            index -= 1
-            continue
-        import_products["products"][product_link[0]]["identifiers"].update(product[1])
-        with open(product_link[1], 'w') as product_file:
+        identifiers = import_products["products"][target_name].setdefault("identifiers", {})
+        for key, value in handled[1].items():
+            if key in identifiers and identifiers[key] != value:
+                return False, identifiers[key]
+        identifiers.update(handled[1])
+        with open(target_file, "w") as product_file:
             yaml.dump(import_products, product_file)
-        remove_from_review(product)
-    elif product_check == "c":
+        return True, None
+
+
+    def run_auto():
+        """Auto-apply only high-confidence, unambiguous matches; anything below
+        the score/margin thresholds is left in review.yaml for the manual pass."""
+        matched = conflicts = ambiguous = 0
+        for handled in list(review_products):
+            # Drop [set code] tags and booster pack counts like "(36Packs)" for
+            # matching (mtgjson names lack them), but keep years, player names and
+            # "(N Starter Pack)" counts -- the count is the only thing telling a
+            # single starter/tournament pack apart from its display box.
+            query = re.sub(r"\[[^\]]*\]|\(\s*\d+\s*Packs?\s*\)", " ", handled[0], flags=re.I)
+            query = re.sub(r"\s+", " ", query).strip()
+
+            best_score = second_score = -1
+            best = None
+            for candidate in known_products:
+                score = fuzz.token_sort_ratio(query, candidate[0])
+                if score > best_score:
+                    second_score = best_score
+                    best_score, best = score, candidate
+                elif score > second_score:
+                    second_score = score
+
+            margin = best_score - second_score
+            if best is None or best_score < args.auto_score or margin < args.auto_margin:
+                ambiguous += 1
+                continue
+
+            # Edition code of the matched product (its data/products/<CODE>.yaml file)
+            code = best[1].stem
+            identifier = "/".join(str(v) for v in handled[1].values())
+
+            if args.dry_run:
+                print(f"[{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
+                matched += 1
+                continue
+
+            ok, _ = apply_identifier(handled, best[0], best[1])
+            if ok:
+                remove_from_review(handled)
+                matched += 1
+                print(f"matched [{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
+            else:
+                conflicts += 1
+
+        print(
+            f"\nAuto-match: {matched} matched, {conflicts} conflicts, "
+            f"{ambiguous + conflicts} left for review"
+            + (" (dry run, nothing written)" if args.dry_run else "")
+        )
+
+    review_products = []
+    skipped_count = 0
+    for provider_name, provider in review_data.items():
+        for name, contents in provider.items():
+            if any(p in name.lower() for p in skip_patterns):
+                skipped_count += 1
+                continue
+            review_products.append((name, contents["identifiers"], contents.get("release_date", False), provider_name))
+
+    if skip_patterns:
+        print(f"Skipping {skipped_count} review entries matching: {args.skip}")
+
+    known_products = []
+    for contentfile in Path("data/products").glob("*.yaml"):
+        with open(contentfile, 'r') as known_file:
+            known_data = yaml.safe_load(known_file)
+        for product_name in known_data["products"].keys():
+            known_products.append((product_name, contentfile))
+
+    if args.auto:
+        run_auto()
+        return
+
+
+
+    index = 0
+    offset = 0
+    while index < len(review_products):
+        product = review_products[index]
+        index += 1
+
+        print(f"Finding similar products for {product[0]} {product[1]}")
+        known_products.sort(key=lambda x: fuzz.token_sort_ratio(x[0], product[0]), reverse=True)
+        for i in range(5):
+            name, code_path = known_products[i + offset]
+            print(f"  {i} - [{code_path.stem}] {name}")
+
         try:
-            set_code = read_input(f"OK, which set code? ").upper().strip()
+            product_check = read_input("Select action ('h' for help): ")
         except EOFError:
             sys.exit(1)
-        if set_code == "":
-            print("set code is required, aborting")
-            index -= 1
-            continue
 
-        # Warn before creating a brand-new set: usually this means the code was
-        # mistyped rather than that a genuinely new set is being introduced.
-        if not Path(f"data/products/{set_code}.yaml").exists():
+        # Look for the product name itself
+        for i in range(len(known_products)):
+            if product_check.strip().lower() == known_products[i][0].lower():
+                product_check = "0"
+                offset = i
+
+        # Default selection
+        if product_check == "":
+            product_check = "0"
+
+        if product_check == "q":
+            break
+        elif product_check == "s":
+            offset = 0
+            continue
+        elif product_check == "m":
+            index -= 1
+            offset += 5
+            if offset + 5 > len(known_products):
+                offset = 0
+        elif product_check == "b":
+            index -= 1
+            if index < 0:
+                index = 0
+            offset -= 5
+            if offset < 0:
+                print("NOTE: No previous choices available")
+                offset = 0
+        elif product_check == "u":
+            index -= 2
+            if index < 0:
+                print("NOTE: There is no product before this one")
+                index = 0
+            offset = 0
+        elif product_check == "i":
+            with open("data/ignore.yaml", "r") as ignore_file:
+                ignore_content = yaml.safe_load(ignore_file) or {}
+            # The review entry's provider name is the ignore.yaml section name
+            section = ignore_content.setdefault(product[3], {})
+            for identifier in product[1].values():
+                section[identifier] = product[0]
+            with open("data/ignore.yaml", "w") as ignore_file:
+                yaml.dump(ignore_content, ignore_file)
+            remove_from_review(product)
+        elif product_check in ["0","1","2","3","4"]:
+            check_index = int(product_check) + offset
+            if check_index >= len(known_products):
+                print(f"NOTE: Selection out of range, max index is {len(known_products) - 1}")
+                index -= 1
+                continue
+            product_link = known_products[check_index]
+            with open(product_link[1], 'r') as product_file:
+                import_products = yaml.safe_load(product_file)
+            if "identifiers" not in import_products["products"][product_link[0]]:
+                import_products["products"][product_link[0]]["identifiers"] = {}
+            keep = True
+            for key in product[1].keys():
+                if key in import_products["products"][product_link[0]]["identifiers"] and import_products['products'][product_link[0]]['identifiers'][key] != product[1][key]:
+                    try:
+                        ask = read_input(f"Confirm overwrite of existing id ({import_products['products'][product_link[0]]['identifiers'][key]})? [Y] ").lower()
+                        keep = ask == "y" or ask == ""
+                    except EOFError:
+                        sys.exit(1)
+            if not keep:
+                index -= 1
+                continue
+            import_products["products"][product_link[0]]["identifiers"].update(product[1])
+            with open(product_link[1], 'w') as product_file:
+                yaml.dump(import_products, product_file)
+            remove_from_review(product)
+        elif product_check == "c":
             try:
-                confirm = read_input(
-                    f"WARNING: no data/products/{set_code}.yaml exists yet -- this creates a NEW set code. Continue? [y/N] "
-                ).strip().lower()
+                set_code = read_input(f"OK, which set code? ").upper().strip()
             except EOFError:
                 sys.exit(1)
-            if confirm != "y":
-                print("Aborting create.")
+            if set_code == "":
+                print("set code is required, aborting")
                 index -= 1
                 continue
 
-        try:
-            product_name = read_input(f"Insert the product name or press Enter to use the loaded one: ").strip()
-            if product_name == "":
-                product_name = product[0]
-        except EOFError:
-            sys.exit(1)
+            # Warn before creating a brand-new set: usually this means the code was
+            # mistyped rather than that a genuinely new set is being introduced.
+            if not Path(f"data/products/{set_code}.yaml").exists():
+                try:
+                    confirm = read_input(
+                        f"WARNING: no data/products/{set_code}.yaml exists yet -- this creates a NEW set code. Continue? [y/N] "
+                    ).strip().lower()
+                except EOFError:
+                    sys.exit(1)
+                if confirm != "y":
+                    print("Aborting create.")
+                    index -= 1
+                    continue
 
-        target_path = Path(f"data/products/{set_code}.yaml")
-        if target_path.exists():
-            with open(target_path, "r") as f:
-                content = yaml.safe_load(f) or {}
-            if product_name in content["products"].keys():
-                print("Product already exists, not creating.")
-                index -= 1
-                continue
+            try:
+                product_name = read_input(f"Insert the product name or press Enter to use the loaded one: ").strip()
+                if product_name == "":
+                    product_name = product[0]
+            except EOFError:
+                sys.exit(1)
+
+            target_path = Path(f"data/products/{set_code}.yaml")
+            if target_path.exists():
+                with open(target_path, "r") as f:
+                    content = yaml.safe_load(f) or {}
+                if product_name in content["products"].keys():
+                    print("Product already exists, not creating.")
+                    index -= 1
+                    continue
+            else:
+                content = {"code": set_code.lower(), "products": {}}
+
+            category, subtype = infer_product_definition(product_name)
+
+            content["products"][product_name] = {
+                "category": category,
+                "identifiers": dict(product[1]),
+                "subtype": subtype,
+            }
+
+            with target_path.open("w") as product_file:
+                yaml.dump(content, product_file)
+
+            # Mirror the new product into the contents file as an empty placeholder,
+            # so it is tracked there too (its contents get filled in separately).
+            contents_path = Path(f"data/contents/{set_code}.yaml")
+            if contents_path.exists():
+                with open(contents_path, "r") as f:
+                    contents_data = yaml.safe_load(f) or {}
+                contents_data.setdefault("code", set_code.lower())
+                contents_data.setdefault("products", {})
+            else:
+                contents_data = {"code": set_code.lower(), "products": {}}
+
+            contents_data["products"].setdefault(product_name, {})
+
+            with contents_path.open("w") as contents_file:
+                yaml.dump(contents_data, contents_file)
+
+            remove_from_review(product)
+            known_products.append((product_name, target_path))
+            print("Product added, don't forget to review and update default fields")
+
         else:
-            content = {"code": set_code.lower(), "products": {}}
+            index -= 1
+            if product_check != "h":
+                print(f"Invalid action: {product_check}")
+            print("Available actions: q - quit / s - skip / i - ignore / m - more / b - back / u - undo / c - create / [0]124 - pick / use the exact name of the product")
 
-        category, subtype = infer_product_definition(product_name)
+        if product_check not in "mb":
+            offset = 0
 
-        content["products"][product_name] = {
-            "category": category,
-            "identifiers": dict(product[1]),
-            "subtype": subtype,
-        }
 
-        with target_path.open("w") as product_file:
-            yaml.dump(content, product_file)
-
-        # Mirror the new product into the contents file as an empty placeholder,
-        # so it is tracked there too (its contents get filled in separately).
-        contents_path = Path(f"data/contents/{set_code}.yaml")
-        if contents_path.exists():
-            with open(contents_path, "r") as f:
-                contents_data = yaml.safe_load(f) or {}
-            contents_data.setdefault("code", set_code.lower())
-            contents_data.setdefault("products", {})
-        else:
-            contents_data = {"code": set_code.lower(), "products": {}}
-
-        contents_data["products"].setdefault(product_name, {})
-
-        with contents_path.open("w") as contents_file:
-            yaml.dump(contents_data, contents_file)
-
-        remove_from_review(product)
-        known_products.append((product_name, target_path))
-        print("Product added, don't forget to review and update default fields")
-
-    else:
-        index -= 1
-        if product_check != "h":
-            print(f"Invalid action: {product_check}")
-        print("Available actions: q - quit / s - skip / i - ignore / m - more / b - back / u - undo / c - create / [0]124 - pick / use the exact name of the product")
-
-    if product_check not in "mb":
-        offset = 0
+if __name__ == "__main__":
+    main()

--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -4,7 +4,10 @@ import sys
 from pathlib import Path
 import requests
 import yaml
-from deck_card_count import deck_card_count
+if __package__:
+    from .deck_card_count import deck_card_count
+else:
+    from deck_card_count import deck_card_count
 
 
 def load_referenced_decks():
@@ -31,31 +34,32 @@ def load_referenced_decks():
     return referenced
 
 
-referenced_decks = load_referenced_decks()
+def load_decks():
+    # Prefer a locally-built decklist JSON when one is supplied via $DECKS_JSON. The
+    # daily workflow builds it straight from the magic-preconstructed-decks source
+    # (its own bin/build_jsons), so a decklist added today is picked up today rather
+    # than waiting for the separately-scheduled magic-preconstructed-decks-data
+    # export. Fall back to the compiled snapshot when run by hand.
+    local_decks = os.environ.get("DECKS_JSON")
+    if local_decks and Path(local_decks).exists():
+        with open(local_decks) as f:
+            decks = json.load(f)
+        print(f"Loaded {len(decks)} decks from local build {local_decks}")
+    else:
+        gh_request = requests.get(
+            "https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json",
+            timeout=(10, 60),
+        )
+        gh_request.raise_for_status()
 
-# Prefer a locally-built decklist JSON when one is supplied via $DECKS_JSON. The
-# daily workflow builds it straight from the magic-preconstructed-decks source
-# (its own bin/build_jsons), so a decklist added today is picked up today rather
-# than waiting for the separately-scheduled magic-preconstructed-decks-data
-# export. Fall back to the compiled snapshot when run by hand.
-local_decks = os.environ.get("DECKS_JSON")
-if local_decks and Path(local_decks).exists():
-    with open(local_decks) as f:
-        decks = json.load(f)
-    print(f"Loaded {len(decks)} decks from local build {local_decks}")
-else:
-    gh_request = requests.get(
-        "https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json",
-        timeout=(10, 60),
-    )
-    gh_request.raise_for_status()
+        try:
+            decks = json.loads(gh_request.content)
+        except json.JSONDecodeError:
+            print("unable to load magic-preconstructed-decks-data file, here are the contents")
+            print(gh_request.content)
+            sys.exit(1)
+    return decks
 
-    try:
-        decks = json.loads(gh_request.content)
-    except json.JSONDecodeError:
-        print("unable to load magic-preconstructed-decks-data file, here are the contents")
-        print(gh_request.content)
-        sys.exit(1)
 
 skip_types = [
     # skip mtgo decks
@@ -203,33 +207,40 @@ def add_content(set_code, name, deck):
         yaml.safe_dump(contents, f)
 
 
-for deck in decks:
-    if any(tag in deck["type"] for tag in skip_types):
-        continue
-    if any(tag in deck["set_code"] for tag in skip_sets):
-        continue
-    if any(tag in deck["name"] for tag in skip_names):
-        continue
+def main():
+    referenced_decks = load_referenced_decks()
+    decks = load_decks()
+    for deck in decks:
+        if any(tag in deck["type"] for tag in skip_types):
+            continue
+        if any(tag in deck["set_code"] for tag in skip_sets):
+            continue
+        if any(tag in deck["name"] for tag in skip_names):
+            continue
 
-    set_code = deck["set_code"]
+        set_code = deck["set_code"]
 
-    # If this decklist is already referenced by an existing contents entry, it is
-    # already modeled (often under a hand-authored product name) -- don't create a
-    # duplicate stub product for it.
-    if (set_code, deck["name"]) in referenced_decks:
-        print(f"Skipping {deck['name']} in {set_code}: deck already referenced in contents")
-        continue
+        # If this decklist is already referenced by an existing contents entry, it is
+        # already modeled (often under a hand-authored product name) -- don't create a
+        # duplicate stub product for it.
+        if (set_code, deck["name"]) in referenced_decks:
+            print(f"Skipping {deck['name']} in {set_code}: deck already referenced in contents")
+            continue
 
-    print(f"Adding {deck['name']} to {set_code}")
+        print(f"Adding {deck['name']} to {set_code}")
 
-    name = f"{deck['set_name']} {deck['type']} {deck['name']}"
-    if set_code in ["sld", "slc"]:
-        name = f"{deck['set_name']} {deck['name']}"
-        # TODO: we should really follow upstream instead of tweaking the name
-        name = name.replace(" Edition", "").replace("'", "").replace(":","").replace("-", " ")
+        name = f"{deck['set_name']} {deck['type']} {deck['name']}"
+        if set_code in ["sld", "slc"]:
+            name = f"{deck['set_name']} {deck['name']}"
+            # TODO: we should really follow upstream instead of tweaking the name
+            name = name.replace(" Edition", "").replace("'", "").replace(":","").replace("-", " ")
 
-    # Avoid duplicating the Commander tag from edition name and deck type above
-    name = name.replace("Commander Commander", "Commander")
+        # Avoid duplicating the Commander tag from edition name and deck type above
+        name = name.replace("Commander Commander", "Commander")
 
-    add_product(set_code, name, deck)
-    add_content(set_code, name, deck)
+        add_product(set_code, name, deck)
+        add_content(set_code, name, deck)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sld_auto.py
+++ b/scripts/sld_auto.py
@@ -5,113 +5,118 @@ import ijson
 import requests
 import sys
 
-url = r"https://mtgjson.com/api/v5/SLD.json"
-r = requests.get(url, stream=True, timeout=(10, 60))
-r.raise_for_status()
-uuids = {}
-parser = ijson.parse(r.content)
+def main():
+    url = r"https://mtgjson.com/api/v5/SLD.json"
+    r = requests.get(url, stream=True, timeout=(10, 60))
+    r.raise_for_status()
+    uuids = {}
+    parser = ijson.parse(r.content)
 
-decks = []
+    decks = []
 
-for prefix, event, value in parser:
-    if prefix == "data.decks.item" and event == "start_map":
-        decks.append({"count": 0})
-    elif prefix == "data.decks.item.name" and event == "string":
-        decks[-1]["name"] = value
-    elif prefix == "data.decks.item.mainBoard.item.count" and event == "number":
-        decks[-1]["count"] += int(value)
-    elif prefix == "data.decks.item.commander.item.count" and event == "number":
-        decks[-1]["count"] += int(value)
-    elif prefix == "data.decks.item.sideBoard.item.count" and event == "number":
-        decks[-1]["count"] += int(value)
+    for prefix, event, value in parser:
+        if prefix == "data.decks.item" and event == "start_map":
+            decks.append({"count": 0})
+        elif prefix == "data.decks.item.name" and event == "string":
+            decks[-1]["name"] = value
+        elif prefix == "data.decks.item.mainBoard.item.count" and event == "number":
+            decks[-1]["count"] += int(value)
+        elif prefix == "data.decks.item.commander.item.count" and event == "number":
+            decks[-1]["count"] += int(value)
+        elif prefix == "data.decks.item.sideBoard.item.count" and event == "number":
+            decks[-1]["count"] += int(value)
 
-with open("data/contents/SLD.yaml", 'r') as sfile:
-    sld_products = yaml.safe_load(sfile)
+    with open("data/contents/SLD.yaml", 'r') as sfile:
+        sld_products = yaml.safe_load(sfile)
 
-product_names = list(sld_products["products"].keys())
-mapped_decks = {}
-for k, v in sld_products["products"].items():
-    if "deck" in v:
-        for dk in v["deck"]:
-            mapped_decks[dk["name"]] = k
+    product_names = list(sld_products["products"].keys())
+    mapped_decks = {}
+    for k, v in sld_products["products"].items():
+        if "deck" in v:
+            for dk in v["deck"]:
+                mapped_decks[dk["name"]] = k
 
-index = 0
-offset = 0
-while index < len(decks):
-    deck = decks[index]
-    index += 1
+    index = 0
+    offset = 0
+    while index < len(decks):
+        deck = decks[index]
+        index += 1
 
-    if deck["name"] in mapped_decks:
-        continue
+        if deck["name"] in mapped_decks:
+            continue
 
-    print(f"Finding similar products for {deck['name']}")
-    product_names.sort(key=lambda x: fuzz.token_sort_ratio(x, deck["name"]), reverse=True)
-    for i in range(5):
-        print(f"  {i} - {product_names[i + offset]}")
+        print(f"Finding similar products for {deck['name']}")
+        product_names.sort(key=lambda x: fuzz.token_sort_ratio(x, deck["name"]), reverse=True)
+        for i in range(5):
+            print(f"  {i} - {product_names[i + offset]}")
     
-    try:
-        product_check = input("Select action ('h' for help): ")
-    except EOFError:
-        sys.exit(1)
+        try:
+            product_check = input("Select action ('h' for help): ")
+        except EOFError:
+            sys.exit(1)
     
-    # Look for the product name itself
-    for i in range(len(product_names)):
-        if product_check.strip().lower() == product_names[i].lower():
-            product_check = "0"
-            offset = i
+        # Look for the product name itself
+        for i in range(len(product_names)):
+            if product_check.strip().lower() == product_names[i].lower():
+                product_check = "0"
+                offset = i
 
-    if product_check == "q":
-        break
-    elif product_check == "s":
-        offset = 0
-        continue
-    elif product_check == "m":
-        index -= 1
-        offset += 5
-        if offset + 5 > len(product_names):
+        if product_check == "q":
+            break
+        elif product_check == "s":
             offset = 0
-    elif product_check == "u":
-        index -= 2
-        if index < 0:
-            print("NOTE: There is no product before this one")
-            index = 0
-        offset = 0
-    elif product_check in "01234":
-        if product_check == "":
-            product_check = "0"
+            continue
+        elif product_check == "m":
+            index -= 1
+            offset += 5
+            if offset + 5 > len(product_names):
+                offset = 0
+        elif product_check == "u":
+            index -= 2
+            if index < 0:
+                print("NOTE: There is no product before this one")
+                index = 0
+            offset = 0
+        elif product_check in "01234":
+            if product_check == "":
+                product_check = "0"
 
-        check_index = int(product_check) + offset
-        p_name = product_names[check_index]
-        if isinstance(sld_products["products"][p_name], list):
-            sld_products["products"][p_name] = {}
-        if "card_count" in sld_products["products"][p_name]:
-            keep = True
-            if sld_products["products"][p_name]['card_count'] != deck["count"]:
-                try:
-                    ask = input(f"Replace count {sld_products['products'][p_name]['card_count']} with {deck['count']}? [Y]: ")
-                    keep = ask == "y" or ask == ""
-                except EOFError:
-                    sys.exit(1)
-            if keep:
+            check_index = int(product_check) + offset
+            p_name = product_names[check_index]
+            if isinstance(sld_products["products"][p_name], list):
+                sld_products["products"][p_name] = {}
+            if "card_count" in sld_products["products"][p_name]:
+                keep = True
+                if sld_products["products"][p_name]['card_count'] != deck["count"]:
+                    try:
+                        ask = input(f"Replace count {sld_products['products'][p_name]['card_count']} with {deck['count']}? [Y]: ")
+                        keep = ask == "y" or ask == ""
+                    except EOFError:
+                        sys.exit(1)
+                if keep:
+                    sld_products["products"][p_name]['card_count'] = deck["count"]
+            else:
                 sld_products["products"][p_name]['card_count'] = deck["count"]
+
+            if "deck" not in sld_products["products"][p_name]:
+                sld_products["products"][p_name]["deck"] = [{"name": deck["name"], "set": "sld"}]
+
+            if ("card" not in sld_products["products"][p_name]) and ("pack" not in sld_products["products"][p_name]) and ("variable" not in sld_products["products"][p_name]):
+                sld_products["products"][p_name]["other"] = [{"name": "Bonus card unknown"}]
+
+            print(sld_products["products"][p_name])
         else:
-            sld_products["products"][p_name]['card_count'] = deck["count"]
+            index -= 1
+            if product_check != "h":
+                print(f"Invalid action: {product_check}")
+            print("Available actions: q - quit / s - skip / m - more / u - undo / [0]124 - pick / use the exact name of the product")
 
-        if "deck" not in sld_products["products"][p_name]:
-            sld_products["products"][p_name]["deck"] = [{"name": deck["name"], "set": "sld"}]
+        if product_check not in "mb":
+            offset = 0
 
-        if ("card" not in sld_products["products"][p_name]) and ("pack" not in sld_products["products"][p_name]) and ("variable" not in sld_products["products"][p_name]):
-            sld_products["products"][p_name]["other"] = [{"name": "Bonus card unknown"}]
+    with open("data/contents/SLD.yaml", 'w') as sfile:
+        yaml.dump(sld_products, sfile)
 
-        print(sld_products["products"][p_name])
-    else:
-        index -= 1
-        if product_check != "h":
-            print(f"Invalid action: {product_check}")
-        print("Available actions: q - quit / s - skip / m - more / u - undo / [0]124 - pick / use the exact name of the product")
 
-    if product_check not in "mb":
-        offset = 0
-
-with open("data/contents/SLD.yaml", 'w') as sfile:
-    yaml.dump(sld_products, sfile)
+if __name__ == "__main__":
+    main()

--- a/tests/test_script_entrypoints.py
+++ b/tests/test_script_entrypoints.py
@@ -1,0 +1,87 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ScriptEntrypointTests(unittest.TestCase):
+    def run_python(self, arguments, directory):
+        return subprocess.run(
+            [sys.executable, *arguments], cwd=directory,
+            env={**os.environ, 'PYTHONPATH': str(ROOT)},
+            text=True, capture_output=True, timeout=20,
+        )
+
+    def test_imports_do_not_fetch_read_data_or_prompt(self):
+        code = '''
+import argparse
+import importlib
+import requests
+import yaml
+from thefuzz import fuzz
+from unittest.mock import patch
+from pathlib import Path
+with patch('requests.sessions.Session.request', side_effect=AssertionError('network')), \\
+     patch('builtins.open', side_effect=AssertionError('file access')), \\
+     patch.object(Path, 'open', side_effect=AssertionError('path access')), \\
+     patch.object(Path, 'glob', side_effect=AssertionError('directory scan')), \\
+     patch('builtins.input', side_effect=AssertionError('prompt')), \\
+     patch.object(argparse.ArgumentParser, 'parse_args', side_effect=AssertionError('CLI parsing')):
+    for name in ('import_new_decks', 'check_product_fuzzy', 'sld_auto'):
+        module = importlib.import_module('scripts.' + name)
+        assert callable(module.main)
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_python(['-c', code], directory)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, '')
+
+    def test_fuzzy_cli_still_applies_match(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            (base / 'data/products').mkdir(parents=True)
+            name = 'Example Set Collector Booster Box'
+            path = base / 'data/products/TST.yaml'
+            path.write_text(yaml.safe_dump({'code': 'tst', 'products': {
+                name: {'category': 'BOOSTER_BOX', 'subtype': 'COLLECTOR', 'identifiers': {}},
+            }}))
+            review = base / 'data/review.yaml'
+            review.write_text(yaml.safe_dump({'vendor': {name: {'identifiers': {'vendorId': '123'}}}}))
+            result = self.run_python([str(ROOT / 'scripts/check_product_fuzzy.py'), '--auto'], directory)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(yaml.safe_load(path.read_text())['products'][name]['identifiers'], {'vendorId': '123'})
+            self.assertEqual(yaml.safe_load(review.read_text()), {'vendor': {}})
+
+    def test_explicit_deck_import_uses_local_source_and_is_repeatable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            (base / 'data/products').mkdir(parents=True)
+            (base / 'data/contents').mkdir()
+            source = base / 'decks.json'
+            source.write_text(json.dumps([{
+                'name': 'Example', 'set_code': 'tst', 'set_name': 'Test Set',
+                'type': 'Theme Deck', 'category': 'Deck', 'release_date': '2020-01-01',
+                'cards': [{'count': 60}],
+            }]))
+            code = '''
+import os
+from unittest.mock import patch
+from scripts.import_new_decks import main
+os.environ['DECKS_JSON'] = 'decks.json'
+with patch('requests.get', side_effect=AssertionError('unexpected download')):
+    main()
+    main()
+'''
+            result = self.run_python(['-c', code], directory)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            contents = yaml.safe_load((base / 'data/contents/TST.yaml').read_text())['products']
+            self.assertEqual(len(contents), 1)
+            self.assertEqual(contents['Test Set Theme Deck Example']['card_count'], 60)
+            self.assertIn('deck already referenced', result.stdout)


### PR DESCRIPTION
Superseded by separate per-script PRs: #574 (deck import), #575 (fuzzy review), and #576 (Secret Lair review). Each targets main independently.

Importing deck-import, fuzzy-review, or Secret Lair-review modules previously started downloads, read or wrote repository data, parsed command-line arguments, or prompted for input.

Move execution behind explicit main() entry points while preserving the existing script commands. Separate deck-source loading from execution, support package imports for the deck-count helper, and keep fuzzy-review state local to each invocation. Pure product-definition inference remains directly importable.

Validation: all 29 tests pass. New subprocess tests reject network/file/prompt/argument-parsing side effects during imports, exercise the fuzzy auto-match CLI, and run a local deck import twice to verify repeatable behavior. git diff --check passes. Tests use temporary data and no live services.

