### PR TITLE
Make deck import safe to import

### DIFF
--- a/scripts/import_new_decks.py
+++ b/scripts/import_new_decks.py
@@ -4,7 +4,10 @@ import sys
 from pathlib import Path
 import requests
 import yaml
-from deck_card_count import deck_card_count
+if __package__:
+    from .deck_card_count import deck_card_count
+else:
+    from deck_card_count import deck_card_count
 
 
 def load_referenced_decks():
@@ -31,31 +34,32 @@ def load_referenced_decks():
     return referenced
 
 
-referenced_decks = load_referenced_decks()
+def load_decks():
+    # Prefer a locally-built decklist JSON when one is supplied via $DECKS_JSON. The
+    # daily workflow builds it straight from the magic-preconstructed-decks source
+    # (its own bin/build_jsons), so a decklist added today is picked up today rather
+    # than waiting for the separately-scheduled magic-preconstructed-decks-data
+    # export. Fall back to the compiled snapshot when run by hand.
+    local_decks = os.environ.get("DECKS_JSON")
+    if local_decks and Path(local_decks).exists():
+        with open(local_decks) as f:
+            decks = json.load(f)
+        print(f"Loaded {len(decks)} decks from local build {local_decks}")
+    else:
+        gh_request = requests.get(
+            "https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json",
+            timeout=(10, 60),
+        )
+        gh_request.raise_for_status()
 
-# Prefer a locally-built decklist JSON when one is supplied via $DECKS_JSON. The
-# daily workflow builds it straight from the magic-preconstructed-decks source
-# (its own bin/build_jsons), so a decklist added today is picked up today rather
-# than waiting for the separately-scheduled magic-preconstructed-decks-data
-# export. Fall back to the compiled snapshot when run by hand.
-local_decks = os.environ.get("DECKS_JSON")
-if local_decks and Path(local_decks).exists():
-    with open(local_decks) as f:
-        decks = json.load(f)
-    print(f"Loaded {len(decks)} decks from local build {local_decks}")
-else:
-    gh_request = requests.get(
-        "https://raw.githubusercontent.com/taw/magic-preconstructed-decks-data/refs/heads/master/decks_v2.json",
-        timeout=(10, 60),
-    )
-    gh_request.raise_for_status()
+        try:
+            decks = json.loads(gh_request.content)
+        except json.JSONDecodeError:
+            print("unable to load magic-preconstructed-decks-data file, here are the contents")
+            print(gh_request.content)
+            sys.exit(1)
+    return decks
 
-    try:
-        decks = json.loads(gh_request.content)
-    except json.JSONDecodeError:
-        print("unable to load magic-preconstructed-decks-data file, here are the contents")
-        print(gh_request.content)
-        sys.exit(1)
 
 skip_types = [
     # skip mtgo decks
@@ -203,33 +207,40 @@ def add_content(set_code, name, deck):
         yaml.safe_dump(contents, f)
 
 
-for deck in decks:
-    if any(tag in deck["type"] for tag in skip_types):
-        continue
-    if any(tag in deck["set_code"] for tag in skip_sets):
-        continue
-    if any(tag in deck["name"] for tag in skip_names):
-        continue
+def main():
+    referenced_decks = load_referenced_decks()
+    decks = load_decks()
+    for deck in decks:
+        if any(tag in deck["type"] for tag in skip_types):
+            continue
+        if any(tag in deck["set_code"] for tag in skip_sets):
+            continue
+        if any(tag in deck["name"] for tag in skip_names):
+            continue
 
-    set_code = deck["set_code"]
+        set_code = deck["set_code"]
 
-    # If this decklist is already referenced by an existing contents entry, it is
-    # already modeled (often under a hand-authored product name) -- don't create a
-    # duplicate stub product for it.
-    if (set_code, deck["name"]) in referenced_decks:
-        print(f"Skipping {deck['name']} in {set_code}: deck already referenced in contents")
-        continue
+        # If this decklist is already referenced by an existing contents entry, it is
+        # already modeled (often under a hand-authored product name) -- don't create a
+        # duplicate stub product for it.
+        if (set_code, deck["name"]) in referenced_decks:
+            print(f"Skipping {deck['name']} in {set_code}: deck already referenced in contents")
+            continue
 
-    print(f"Adding {deck['name']} to {set_code}")
+        print(f"Adding {deck['name']} to {set_code}")
 
-    name = f"{deck['set_name']} {deck['type']} {deck['name']}"
-    if set_code in ["sld", "slc"]:
-        name = f"{deck['set_name']} {deck['name']}"
-        # TODO: we should really follow upstream instead of tweaking the name
-        name = name.replace(" Edition", "").replace("'", "").replace(":","").replace("-", " ")
+        name = f"{deck['set_name']} {deck['type']} {deck['name']}"
+        if set_code in ["sld", "slc"]:
+            name = f"{deck['set_name']} {deck['name']}"
+            # TODO: we should really follow upstream instead of tweaking the name
+            name = name.replace(" Edition", "").replace("'", "").replace(":","").replace("-", " ")
 
-    # Avoid duplicating the Commander tag from edition name and deck type above
-    name = name.replace("Commander Commander", "Commander")
+        # Avoid duplicating the Commander tag from edition name and deck type above
+        name = name.replace("Commander Commander", "Commander")
 
-    add_product(set_code, name, deck)
-    add_content(set_code, name, deck)
+        add_product(set_code, name, deck)
+        add_content(set_code, name, deck)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_import_new_decks_entrypoint.py
+++ b/tests/test_import_new_decks_entrypoint.py
@@ -1,0 +1,74 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DeckEntrypointTests(unittest.TestCase):
+    def run_python(self, arguments, directory):
+        return subprocess.run(
+            [sys.executable, *arguments], cwd=directory,
+            env={**os.environ, 'PYTHONPATH': str(ROOT)},
+            text=True, capture_output=True, timeout=20,
+        )
+
+
+    def test_imports_do_not_fetch_read_data_or_prompt(self):
+        code = '''
+import argparse
+import importlib
+import requests
+import yaml
+from thefuzz import fuzz
+from unittest.mock import patch
+from pathlib import Path
+with patch('requests.sessions.Session.request', side_effect=AssertionError('network')), \\
+     patch('builtins.open', side_effect=AssertionError('file access')), \\
+     patch.object(Path, 'open', side_effect=AssertionError('path access')), \\
+     patch.object(Path, 'glob', side_effect=AssertionError('directory scan')), \\
+     patch('builtins.input', side_effect=AssertionError('prompt')), \\
+     patch.object(argparse.ArgumentParser, 'parse_args', side_effect=AssertionError('CLI parsing')):
+    for name in ('import_new_decks',):
+        module = importlib.import_module('scripts.' + name)
+        assert callable(module.main)
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_python(['-c', code], directory)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, '')
+
+
+    def test_explicit_deck_import_uses_local_source_and_is_repeatable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            (base / 'data/products').mkdir(parents=True)
+            (base / 'data/contents').mkdir()
+            source = base / 'decks.json'
+            source.write_text(json.dumps([{
+                'name': 'Example', 'set_code': 'tst', 'set_name': 'Test Set',
+                'type': 'Theme Deck', 'category': 'Deck', 'release_date': '2020-01-01',
+                'cards': [{'count': 60}],
+            }]))
+            code = '''
+import os
+from unittest.mock import patch
+from scripts.import_new_decks import main
+os.environ['DECKS_JSON'] = 'decks.json'
+with patch('requests.get', side_effect=AssertionError('unexpected download')):
+    main()
+    main()
+'''
+            result = self.run_python(['-c', code], directory)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            contents = yaml.safe_load((base / 'data/contents/TST.yaml').read_text())['products']
+            self.assertEqual(len(contents), 1)
+            self.assertEqual(contents['Test Set Theme Deck Example']['card_count'], 60)
+            self.assertIn('deck already referenced', result.stdout)
+


### PR DESCRIPTION
Importing import_new_decks.py previously read repository contents and loaded deck data immediately. Move execution behind main(), extract load_decks(), and support package imports for the deck-count helper. Existing command-line behavior is retained.

Tests cover importing without network/file access and explicitly importing a local deck source twice without duplication. All 33 tests on this branch and git diff --check pass.

Split from #573. This PR changes only the deck import script and its tests; it is based directly on current main and preserves already-merged fixes.
