### PR TITLE
Make fuzzy review safe to import

### DIFF
--- a/scripts/check_product_fuzzy.py
+++ b/scripts/check_product_fuzzy.py
@@ -13,158 +13,6 @@ BRACKETED_PASTE_RE = re.compile(r"\x1b\[20[01]~")
 def read_input(prompt=""):
     return BRACKETED_PASTE_RE.sub("", input(prompt))
 
-parser = argparse.ArgumentParser(
-    description="Interactively match review entries to known products."
-)
-parser.add_argument(
-    "--skip",
-    action="append",
-    default=[],
-    metavar="PATTERN",
-    help="Skip review entries whose name contains PATTERN (case-insensitive). "
-         "May be passed multiple times.",
-)
-parser.add_argument(
-    "--auto",
-    action="store_true",
-    help="Non-interactively apply only high-confidence, unambiguous matches, "
-         "leaving everything else in review.yaml for a manual pass.",
-)
-parser.add_argument(
-    "--auto-score",
-    type=int,
-    default=96,
-    metavar="N",
-    help="Minimum fuzzy score (0-100) required to auto-match (default: 96).",
-)
-parser.add_argument(
-    "--auto-margin",
-    type=int,
-    default=8,
-    metavar="N",
-    help="Minimum gap between the best and second-best score required to "
-         "auto-match, to avoid false friends (default: 8).",
-)
-parser.add_argument(
-    "--dry-run",
-    action="store_true",
-    help="With --auto, print the matches that would be applied without "
-         "writing any files.",
-)
-args = parser.parse_args()
-skip_patterns = [p.lower() for p in args.skip]
-
-review_path = Path("data/review.yaml")
-with open(review_path) as review_file:
-    review_data = yaml.safe_load(review_file)
-
-
-def remove_from_review(handled):
-    """Drop the just-handled entry from the review data and persist it so a
-    re-run does not prompt for the same product again."""
-    name, identifiers = handled[0], handled[1]
-    removed = False
-    for provider_products in review_data.values():
-        entry = provider_products.get(name)
-        if entry is not None and entry.get("identifiers") == identifiers:
-            del provider_products[name]
-            removed = True
-    if removed:
-        with open(review_path, "w") as review_file:
-            yaml.dump(review_data, review_file)
-
-
-def apply_identifier(handled, target_name, target_file):
-    """Write the review entry's identifier into the chosen known product.
-    Returns (True, None) on success, or (False, existing) without writing when
-    a different value is already set for one of the identifier keys (a conflict
-    a human should resolve)."""
-    with open(target_file) as product_file:
-        import_products = yaml.safe_load(product_file)
-    identifiers = import_products["products"][target_name].setdefault("identifiers", {})
-    for key, value in handled[1].items():
-        if key in identifiers and identifiers[key] != value:
-            return False, identifiers[key]
-    identifiers.update(handled[1])
-    with open(target_file, "w") as product_file:
-        yaml.dump(import_products, product_file)
-    return True, None
-
-
-def run_auto():
-    """Auto-apply only high-confidence, unambiguous matches; anything below
-    the score/margin thresholds is left in review.yaml for the manual pass."""
-    matched = conflicts = ambiguous = 0
-    for handled in list(review_products):
-        # Drop [set code] tags and booster pack counts like "(36Packs)" for
-        # matching (mtgjson names lack them), but keep years, player names and
-        # "(N Starter Pack)" counts -- the count is the only thing telling a
-        # single starter/tournament pack apart from its display box.
-        query = re.sub(r"\[[^\]]*\]|\(\s*\d+\s*Packs?\s*\)", " ", handled[0], flags=re.I)
-        query = re.sub(r"\s+", " ", query).strip()
-
-        best_score = second_score = -1
-        best = None
-        for candidate in known_products:
-            score = fuzz.token_sort_ratio(query, candidate[0])
-            if score > best_score:
-                second_score = best_score
-                best_score, best = score, candidate
-            elif score > second_score:
-                second_score = score
-
-        margin = best_score - second_score
-        if best is None or best_score < args.auto_score or margin < args.auto_margin:
-            ambiguous += 1
-            continue
-
-        # Edition code of the matched product (its data/products/<CODE>.yaml file)
-        code = best[1].stem
-        identifier = "/".join(str(v) for v in handled[1].values())
-
-        if args.dry_run:
-            print(f"[{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
-            matched += 1
-            continue
-
-        ok, _ = apply_identifier(handled, best[0], best[1])
-        if ok:
-            remove_from_review(handled)
-            matched += 1
-            print(f"matched [{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
-        else:
-            conflicts += 1
-
-    print(
-        f"\nAuto-match: {matched} matched, {conflicts} conflicts, "
-        f"{ambiguous + conflicts} left for review"
-        + (" (dry run, nothing written)" if args.dry_run else "")
-    )
-
-review_products = []
-skipped_count = 0
-for provider_name, provider in review_data.items():
-    for name, contents in provider.items():
-        if any(p in name.lower() for p in skip_patterns):
-            skipped_count += 1
-            continue
-        review_products.append((name, contents["identifiers"], contents.get("release_date", False), provider_name))
-
-if skip_patterns:
-    print(f"Skipping {skipped_count} review entries matching: {args.skip}")
-
-known_products = []
-for contentfile in Path("data/products").glob("*.yaml"):
-    with open(contentfile, 'r') as known_file:
-        known_data = yaml.safe_load(known_file)
-    for product_name in known_data["products"].keys():
-        known_products.append((product_name, contentfile))
-
-if args.auto:
-    run_auto()
-    sys.exit(0)
-
-
 def infer_product_definition(product_name):
     category = "UNKNOWN"
     subtype = "UNKNOWN"
@@ -255,171 +103,331 @@ def infer_product_definition(product_name):
 
     return category, subtype
 
-index = 0
-offset = 0
-while index < len(review_products):
-    product = review_products[index]
-    index += 1
 
-    print(f"Finding similar products for {product[0]} {product[1]}")
-    known_products.sort(key=lambda x: fuzz.token_sort_ratio(x[0], product[0]), reverse=True)
-    for i in range(5):
-        name, code_path = known_products[i + offset]
-        print(f"  {i} - [{code_path.stem}] {name}")
 
-    try:
-        product_check = read_input("Select action ('h' for help): ")
-    except EOFError:
-        sys.exit(1)
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Interactively match review entries to known products."
+    )
+    parser.add_argument(
+        "--skip",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="Skip review entries whose name contains PATTERN (case-insensitive). "
+             "May be passed multiple times.",
+    )
+    parser.add_argument(
+        "--auto",
+        action="store_true",
+        help="Non-interactively apply only high-confidence, unambiguous matches, "
+             "leaving everything else in review.yaml for a manual pass.",
+    )
+    parser.add_argument(
+        "--auto-score",
+        type=int,
+        default=96,
+        metavar="N",
+        help="Minimum fuzzy score (0-100) required to auto-match (default: 96).",
+    )
+    parser.add_argument(
+        "--auto-margin",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Minimum gap between the best and second-best score required to "
+             "auto-match, to avoid false friends (default: 8).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --auto, print the matches that would be applied without "
+             "writing any files.",
+    )
+    args = parser.parse_args(argv)
+    skip_patterns = [p.lower() for p in args.skip]
 
-    # Look for the product name itself
-    for i in range(len(known_products)):
-        if product_check.strip().lower() == known_products[i][0].lower():
-            product_check = "0"
-            offset = i
+    review_path = Path("data/review.yaml")
+    with open(review_path) as review_file:
+        review_data = yaml.safe_load(review_file)
 
-    # Default selection
-    if product_check == "":
-        product_check = "0"
 
-    if product_check == "q":
-        break
-    elif product_check == "s":
-        offset = 0
-        continue
-    elif product_check == "m":
-        index -= 1
-        offset += 5
-        if offset + 5 > len(known_products):
-            offset = 0
-    elif product_check == "b":
-        index -= 1
-        if index < 0:
-            index = 0
-        offset -= 5
-        if offset < 0:
-            print("NOTE: No previous choices available")
-            offset = 0
-    elif product_check == "u":
-        index -= 2
-        if index < 0:
-            print("NOTE: There is no product before this one")
-            index = 0
-        offset = 0
-    elif product_check == "i":
-        with open("data/ignore.yaml", "r") as ignore_file:
-            ignore_content = yaml.safe_load(ignore_file) or {}
-        # The review entry's provider name is the ignore.yaml section name
-        section = ignore_content.setdefault(product[3], {})
-        for identifier in product[1].values():
-            section[identifier] = product[0]
-        with open("data/ignore.yaml", "w") as ignore_file:
-            yaml.dump(ignore_content, ignore_file)
-        remove_from_review(product)
-    elif product_check in ["0","1","2","3","4"]:
-        check_index = int(product_check) + offset
-        if check_index >= len(known_products):
-            print(f"NOTE: Selection out of range, max index is {len(known_products) - 1}")
-            index -= 1
-            continue
-        product_link = known_products[check_index]
-        with open(product_link[1], 'r') as product_file:
+    def remove_from_review(handled):
+        """Drop the just-handled entry from the review data and persist it so a
+        re-run does not prompt for the same product again."""
+        name, identifiers = handled[0], handled[1]
+        removed = False
+        for provider_products in review_data.values():
+            entry = provider_products.get(name)
+            if entry is not None and entry.get("identifiers") == identifiers:
+                del provider_products[name]
+                removed = True
+        if removed:
+            with open(review_path, "w") as review_file:
+                yaml.dump(review_data, review_file)
+
+
+    def apply_identifier(handled, target_name, target_file):
+        """Write the review entry's identifier into the chosen known product.
+        Returns (True, None) on success, or (False, existing) without writing when
+        a different value is already set for one of the identifier keys (a conflict
+        a human should resolve)."""
+        with open(target_file) as product_file:
             import_products = yaml.safe_load(product_file)
-        if "identifiers" not in import_products["products"][product_link[0]]:
-            import_products["products"][product_link[0]]["identifiers"] = {}
-        keep = True
-        for key in product[1].keys():
-            if key in import_products["products"][product_link[0]]["identifiers"] and import_products['products'][product_link[0]]['identifiers'][key] != product[1][key]:
-                try:
-                    ask = read_input(f"Confirm overwrite of existing id ({import_products['products'][product_link[0]]['identifiers'][key]})? [Y] ").lower()
-                    keep = ask == "y" or ask == ""
-                except EOFError:
-                    sys.exit(1)
-        if not keep:
-            index -= 1
-            continue
-        import_products["products"][product_link[0]]["identifiers"].update(product[1])
-        with open(product_link[1], 'w') as product_file:
+        identifiers = import_products["products"][target_name].setdefault("identifiers", {})
+        for key, value in handled[1].items():
+            if key in identifiers and identifiers[key] != value:
+                return False, identifiers[key]
+        identifiers.update(handled[1])
+        with open(target_file, "w") as product_file:
             yaml.dump(import_products, product_file)
-        remove_from_review(product)
-    elif product_check == "c":
+        return True, None
+
+
+    def run_auto():
+        """Auto-apply only high-confidence, unambiguous matches; anything below
+        the score/margin thresholds is left in review.yaml for the manual pass."""
+        matched = conflicts = ambiguous = 0
+        for handled in list(review_products):
+            # Drop [set code] tags and booster pack counts like "(36Packs)" for
+            # matching (mtgjson names lack them), but keep years, player names and
+            # "(N Starter Pack)" counts -- the count is the only thing telling a
+            # single starter/tournament pack apart from its display box.
+            query = re.sub(r"\[[^\]]*\]|\(\s*\d+\s*Packs?\s*\)", " ", handled[0], flags=re.I)
+            query = re.sub(r"\s+", " ", query).strip()
+
+            best_score = second_score = -1
+            best = None
+            for candidate in known_products:
+                score = fuzz.token_sort_ratio(query, candidate[0])
+                if score > best_score:
+                    second_score = best_score
+                    best_score, best = score, candidate
+                elif score > second_score:
+                    second_score = score
+
+            margin = best_score - second_score
+            if best is None or best_score < args.auto_score or margin < args.auto_margin:
+                ambiguous += 1
+                continue
+
+            # Edition code of the matched product (its data/products/<CODE>.yaml file)
+            code = best[1].stem
+            identifier = "/".join(str(v) for v in handled[1].values())
+
+            if args.dry_run:
+                print(f"[{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
+                matched += 1
+                continue
+
+            ok, _ = apply_identifier(handled, best[0], best[1])
+            if ok:
+                remove_from_review(handled)
+                matched += 1
+                print(f"matched [{best_score}/{margin}] {handled[0]!r} ({identifier}) -> {best[0]!r} [{code}]")
+            else:
+                conflicts += 1
+
+        print(
+            f"\nAuto-match: {matched} matched, {conflicts} conflicts, "
+            f"{ambiguous + conflicts} left for review"
+            + (" (dry run, nothing written)" if args.dry_run else "")
+        )
+
+    review_products = []
+    skipped_count = 0
+    for provider_name, provider in review_data.items():
+        for name, contents in provider.items():
+            if any(p in name.lower() for p in skip_patterns):
+                skipped_count += 1
+                continue
+            review_products.append((name, contents["identifiers"], contents.get("release_date", False), provider_name))
+
+    if skip_patterns:
+        print(f"Skipping {skipped_count} review entries matching: {args.skip}")
+
+    known_products = []
+    for contentfile in Path("data/products").glob("*.yaml"):
+        with open(contentfile, 'r') as known_file:
+            known_data = yaml.safe_load(known_file)
+        for product_name in known_data["products"].keys():
+            known_products.append((product_name, contentfile))
+
+    if args.auto:
+        run_auto()
+        return
+
+
+
+    index = 0
+    offset = 0
+    while index < len(review_products):
+        product = review_products[index]
+        index += 1
+
+        print(f"Finding similar products for {product[0]} {product[1]}")
+        known_products.sort(key=lambda x: fuzz.token_sort_ratio(x[0], product[0]), reverse=True)
+        for i in range(5):
+            name, code_path = known_products[i + offset]
+            print(f"  {i} - [{code_path.stem}] {name}")
+
         try:
-            set_code = read_input(f"OK, which set code? ").upper().strip()
+            product_check = read_input("Select action ('h' for help): ")
         except EOFError:
             sys.exit(1)
-        if set_code == "":
-            print("set code is required, aborting")
-            index -= 1
-            continue
 
-        # Warn before creating a brand-new set: usually this means the code was
-        # mistyped rather than that a genuinely new set is being introduced.
-        if not Path(f"data/products/{set_code}.yaml").exists():
+        # Look for the product name itself
+        for i in range(len(known_products)):
+            if product_check.strip().lower() == known_products[i][0].lower():
+                product_check = "0"
+                offset = i
+
+        # Default selection
+        if product_check == "":
+            product_check = "0"
+
+        if product_check == "q":
+            break
+        elif product_check == "s":
+            offset = 0
+            continue
+        elif product_check == "m":
+            index -= 1
+            offset += 5
+            if offset + 5 > len(known_products):
+                offset = 0
+        elif product_check == "b":
+            index -= 1
+            if index < 0:
+                index = 0
+            offset -= 5
+            if offset < 0:
+                print("NOTE: No previous choices available")
+                offset = 0
+        elif product_check == "u":
+            index -= 2
+            if index < 0:
+                print("NOTE: There is no product before this one")
+                index = 0
+            offset = 0
+        elif product_check == "i":
+            with open("data/ignore.yaml", "r") as ignore_file:
+                ignore_content = yaml.safe_load(ignore_file) or {}
+            # The review entry's provider name is the ignore.yaml section name
+            section = ignore_content.setdefault(product[3], {})
+            for identifier in product[1].values():
+                section[identifier] = product[0]
+            with open("data/ignore.yaml", "w") as ignore_file:
+                yaml.dump(ignore_content, ignore_file)
+            remove_from_review(product)
+        elif product_check in ["0","1","2","3","4"]:
+            check_index = int(product_check) + offset
+            if check_index >= len(known_products):
+                print(f"NOTE: Selection out of range, max index is {len(known_products) - 1}")
+                index -= 1
+                continue
+            product_link = known_products[check_index]
+            with open(product_link[1], 'r') as product_file:
+                import_products = yaml.safe_load(product_file)
+            if "identifiers" not in import_products["products"][product_link[0]]:
+                import_products["products"][product_link[0]]["identifiers"] = {}
+            keep = True
+            for key in product[1].keys():
+                if key in import_products["products"][product_link[0]]["identifiers"] and import_products['products'][product_link[0]]['identifiers'][key] != product[1][key]:
+                    try:
+                        ask = read_input(f"Confirm overwrite of existing id ({import_products['products'][product_link[0]]['identifiers'][key]})? [Y] ").lower()
+                        keep = ask == "y" or ask == ""
+                    except EOFError:
+                        sys.exit(1)
+            if not keep:
+                index -= 1
+                continue
+            import_products["products"][product_link[0]]["identifiers"].update(product[1])
+            with open(product_link[1], 'w') as product_file:
+                yaml.dump(import_products, product_file)
+            remove_from_review(product)
+        elif product_check == "c":
             try:
-                confirm = read_input(
-                    f"WARNING: no data/products/{set_code}.yaml exists yet -- this creates a NEW set code. Continue? [y/N] "
-                ).strip().lower()
+                set_code = read_input(f"OK, which set code? ").upper().strip()
             except EOFError:
                 sys.exit(1)
-            if confirm != "y":
-                print("Aborting create.")
+            if set_code == "":
+                print("set code is required, aborting")
                 index -= 1
                 continue
 
-        try:
-            product_name = read_input(f"Insert the product name or press Enter to use the loaded one: ").strip()
-            if product_name == "":
-                product_name = product[0]
-        except EOFError:
-            sys.exit(1)
+            # Warn before creating a brand-new set: usually this means the code was
+            # mistyped rather than that a genuinely new set is being introduced.
+            if not Path(f"data/products/{set_code}.yaml").exists():
+                try:
+                    confirm = read_input(
+                        f"WARNING: no data/products/{set_code}.yaml exists yet -- this creates a NEW set code. Continue? [y/N] "
+                    ).strip().lower()
+                except EOFError:
+                    sys.exit(1)
+                if confirm != "y":
+                    print("Aborting create.")
+                    index -= 1
+                    continue
 
-        target_path = Path(f"data/products/{set_code}.yaml")
-        if target_path.exists():
-            with open(target_path, "r") as f:
-                content = yaml.safe_load(f) or {}
-            if product_name in content["products"].keys():
-                print("Product already exists, not creating.")
-                index -= 1
-                continue
+            try:
+                product_name = read_input(f"Insert the product name or press Enter to use the loaded one: ").strip()
+                if product_name == "":
+                    product_name = product[0]
+            except EOFError:
+                sys.exit(1)
+
+            target_path = Path(f"data/products/{set_code}.yaml")
+            if target_path.exists():
+                with open(target_path, "r") as f:
+                    content = yaml.safe_load(f) or {}
+                if product_name in content["products"].keys():
+                    print("Product already exists, not creating.")
+                    index -= 1
+                    continue
+            else:
+                content = {"code": set_code.lower(), "products": {}}
+
+            category, subtype = infer_product_definition(product_name)
+
+            content["products"][product_name] = {
+                "category": category,
+                "identifiers": dict(product[1]),
+                "subtype": subtype,
+            }
+
+            with target_path.open("w") as product_file:
+                yaml.dump(content, product_file)
+
+            # Mirror the new product into the contents file as an empty placeholder,
+            # so it is tracked there too (its contents get filled in separately).
+            contents_path = Path(f"data/contents/{set_code}.yaml")
+            if contents_path.exists():
+                with open(contents_path, "r") as f:
+                    contents_data = yaml.safe_load(f) or {}
+                contents_data.setdefault("code", set_code.lower())
+                contents_data.setdefault("products", {})
+            else:
+                contents_data = {"code": set_code.lower(), "products": {}}
+
+            contents_data["products"].setdefault(product_name, {})
+
+            with contents_path.open("w") as contents_file:
+                yaml.dump(contents_data, contents_file)
+
+            remove_from_review(product)
+            known_products.append((product_name, target_path))
+            print("Product added, don't forget to review and update default fields")
+
         else:
-            content = {"code": set_code.lower(), "products": {}}
+            index -= 1
+            if product_check != "h":
+                print(f"Invalid action: {product_check}")
+            print("Available actions: q - quit / s - skip / i - ignore / m - more / b - back / u - undo / c - create / [0]124 - pick / use the exact name of the product")
 
-        category, subtype = infer_product_definition(product_name)
+        if product_check not in "mb":
+            offset = 0
 
-        content["products"][product_name] = {
-            "category": category,
-            "identifiers": dict(product[1]),
-            "subtype": subtype,
-        }
 
-        with target_path.open("w") as product_file:
-            yaml.dump(content, product_file)
-
-        # Mirror the new product into the contents file as an empty placeholder,
-        # so it is tracked there too (its contents get filled in separately).
-        contents_path = Path(f"data/contents/{set_code}.yaml")
-        if contents_path.exists():
-            with open(contents_path, "r") as f:
-                contents_data = yaml.safe_load(f) or {}
-            contents_data.setdefault("code", set_code.lower())
-            contents_data.setdefault("products", {})
-        else:
-            contents_data = {"code": set_code.lower(), "products": {}}
-
-        contents_data["products"].setdefault(product_name, {})
-
-        with contents_path.open("w") as contents_file:
-            yaml.dump(contents_data, contents_file)
-
-        remove_from_review(product)
-        known_products.append((product_name, target_path))
-        print("Product added, don't forget to review and update default fields")
-
-    else:
-        index -= 1
-        if product_check != "h":
-            print(f"Invalid action: {product_check}")
-        print("Available actions: q - quit / s - skip / i - ignore / m - more / b - back / u - undo / c - create / [0]124 - pick / use the exact name of the product")
-
-    if product_check not in "mb":
-        offset = 0
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_product_fuzzy_entrypoint.py
+++ b/tests/test_check_product_fuzzy_entrypoint.py
@@ -1,0 +1,63 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class FuzzyEntrypointTests(unittest.TestCase):
+    def run_python(self, arguments, directory):
+        return subprocess.run(
+            [sys.executable, *arguments], cwd=directory,
+            env={**os.environ, 'PYTHONPATH': str(ROOT)},
+            text=True, capture_output=True, timeout=20,
+        )
+
+
+    def test_imports_do_not_fetch_read_data_or_prompt(self):
+        code = '''
+import argparse
+import importlib
+import requests
+import yaml
+from thefuzz import fuzz
+from unittest.mock import patch
+from pathlib import Path
+with patch('requests.sessions.Session.request', side_effect=AssertionError('network')), \\
+     patch('builtins.open', side_effect=AssertionError('file access')), \\
+     patch.object(Path, 'open', side_effect=AssertionError('path access')), \\
+     patch.object(Path, 'glob', side_effect=AssertionError('directory scan')), \\
+     patch('builtins.input', side_effect=AssertionError('prompt')), \\
+     patch.object(argparse.ArgumentParser, 'parse_args', side_effect=AssertionError('CLI parsing')):
+    for name in ('check_product_fuzzy',):
+        module = importlib.import_module('scripts.' + name)
+        assert callable(module.main)
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_python(['-c', code], directory)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, '')
+
+
+    def test_fuzzy_cli_still_applies_match(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            (base / 'data/products').mkdir(parents=True)
+            name = 'Example Set Collector Booster Box'
+            path = base / 'data/products/TST.yaml'
+            path.write_text(yaml.safe_dump({'code': 'tst', 'products': {
+                name: {'category': 'BOOSTER_BOX', 'subtype': 'COLLECTOR', 'identifiers': {}},
+            }}))
+            review = base / 'data/review.yaml'
+            review.write_text(yaml.safe_dump({'vendor': {name: {'identifiers': {'vendorId': '123'}}}}))
+            result = self.run_python([str(ROOT / 'scripts/check_product_fuzzy.py'), '--auto'], directory)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(yaml.safe_load(path.read_text())['products'][name]['identifiers'], {'vendorId': '123'})
+            self.assertEqual(yaml.safe_load(review.read_text()), {'vendor': {}})
+


### PR DESCRIPTION
Importing check_product_fuzzy.py previously parsed arguments, read repository data, and could start interactive review. Move execution behind main(argv=None), keep review state local to each invocation, and leave product-definition inference directly importable.

Tests cover side-effect-free import and the existing auto-match command writing an identifier and removing its review entry. All 33 tests on this branch and git diff --check pass.

Split from #573. This PR changes only the fuzzy review script and its tests; it is based directly on current main and preserves already-merged fixes.
