### PR TITLE
Make Secret Lair review safe to import

### DIFF
--- a/scripts/sld_auto.py
+++ b/scripts/sld_auto.py
@@ -5,113 +5,118 @@ import ijson
 import requests
 import sys
 
-url = r"https://mtgjson.com/api/v5/SLD.json"
-r = requests.get(url, stream=True, timeout=(10, 60))
-r.raise_for_status()
-uuids = {}
-parser = ijson.parse(r.content)
+def main():
+    url = r"https://mtgjson.com/api/v5/SLD.json"
+    r = requests.get(url, stream=True, timeout=(10, 60))
+    r.raise_for_status()
+    uuids = {}
+    parser = ijson.parse(r.content)
 
-decks = []
+    decks = []
 
-for prefix, event, value in parser:
-    if prefix == "data.decks.item" and event == "start_map":
-        decks.append({"count": 0})
-    elif prefix == "data.decks.item.name" and event == "string":
-        decks[-1]["name"] = value
-    elif prefix == "data.decks.item.mainBoard.item.count" and event == "number":
-        decks[-1]["count"] += int(value)
-    elif prefix == "data.decks.item.commander.item.count" and event == "number":
-        decks[-1]["count"] += int(value)
-    elif prefix == "data.decks.item.sideBoard.item.count" and event == "number":
-        decks[-1]["count"] += int(value)
+    for prefix, event, value in parser:
+        if prefix == "data.decks.item" and event == "start_map":
+            decks.append({"count": 0})
+        elif prefix == "data.decks.item.name" and event == "string":
+            decks[-1]["name"] = value
+        elif prefix == "data.decks.item.mainBoard.item.count" and event == "number":
+            decks[-1]["count"] += int(value)
+        elif prefix == "data.decks.item.commander.item.count" and event == "number":
+            decks[-1]["count"] += int(value)
+        elif prefix == "data.decks.item.sideBoard.item.count" and event == "number":
+            decks[-1]["count"] += int(value)
 
-with open("data/contents/SLD.yaml", 'r') as sfile:
-    sld_products = yaml.safe_load(sfile)
+    with open("data/contents/SLD.yaml", 'r') as sfile:
+        sld_products = yaml.safe_load(sfile)
 
-product_names = list(sld_products["products"].keys())
-mapped_decks = {}
-for k, v in sld_products["products"].items():
-    if "deck" in v:
-        for dk in v["deck"]:
-            mapped_decks[dk["name"]] = k
+    product_names = list(sld_products["products"].keys())
+    mapped_decks = {}
+    for k, v in sld_products["products"].items():
+        if "deck" in v:
+            for dk in v["deck"]:
+                mapped_decks[dk["name"]] = k
 
-index = 0
-offset = 0
-while index < len(decks):
-    deck = decks[index]
-    index += 1
+    index = 0
+    offset = 0
+    while index < len(decks):
+        deck = decks[index]
+        index += 1
 
-    if deck["name"] in mapped_decks:
-        continue
+        if deck["name"] in mapped_decks:
+            continue
 
-    print(f"Finding similar products for {deck['name']}")
-    product_names.sort(key=lambda x: fuzz.token_sort_ratio(x, deck["name"]), reverse=True)
-    for i in range(5):
-        print(f"  {i} - {product_names[i + offset]}")
+        print(f"Finding similar products for {deck['name']}")
+        product_names.sort(key=lambda x: fuzz.token_sort_ratio(x, deck["name"]), reverse=True)
+        for i in range(5):
+            print(f"  {i} - {product_names[i + offset]}")
     
-    try:
-        product_check = input("Select action ('h' for help): ")
-    except EOFError:
-        sys.exit(1)
+        try:
+            product_check = input("Select action ('h' for help): ")
+        except EOFError:
+            sys.exit(1)
     
-    # Look for the product name itself
-    for i in range(len(product_names)):
-        if product_check.strip().lower() == product_names[i].lower():
-            product_check = "0"
-            offset = i
+        # Look for the product name itself
+        for i in range(len(product_names)):
+            if product_check.strip().lower() == product_names[i].lower():
+                product_check = "0"
+                offset = i
 
-    if product_check == "q":
-        break
-    elif product_check == "s":
-        offset = 0
-        continue
-    elif product_check == "m":
-        index -= 1
-        offset += 5
-        if offset + 5 > len(product_names):
+        if product_check == "q":
+            break
+        elif product_check == "s":
             offset = 0
-    elif product_check == "u":
-        index -= 2
-        if index < 0:
-            print("NOTE: There is no product before this one")
-            index = 0
-        offset = 0
-    elif product_check in "01234":
-        if product_check == "":
-            product_check = "0"
+            continue
+        elif product_check == "m":
+            index -= 1
+            offset += 5
+            if offset + 5 > len(product_names):
+                offset = 0
+        elif product_check == "u":
+            index -= 2
+            if index < 0:
+                print("NOTE: There is no product before this one")
+                index = 0
+            offset = 0
+        elif product_check in "01234":
+            if product_check == "":
+                product_check = "0"
 
-        check_index = int(product_check) + offset
-        p_name = product_names[check_index]
-        if isinstance(sld_products["products"][p_name], list):
-            sld_products["products"][p_name] = {}
-        if "card_count" in sld_products["products"][p_name]:
-            keep = True
-            if sld_products["products"][p_name]['card_count'] != deck["count"]:
-                try:
-                    ask = input(f"Replace count {sld_products['products'][p_name]['card_count']} with {deck['count']}? [Y]: ")
-                    keep = ask == "y" or ask == ""
-                except EOFError:
-                    sys.exit(1)
-            if keep:
+            check_index = int(product_check) + offset
+            p_name = product_names[check_index]
+            if isinstance(sld_products["products"][p_name], list):
+                sld_products["products"][p_name] = {}
+            if "card_count" in sld_products["products"][p_name]:
+                keep = True
+                if sld_products["products"][p_name]['card_count'] != deck["count"]:
+                    try:
+                        ask = input(f"Replace count {sld_products['products'][p_name]['card_count']} with {deck['count']}? [Y]: ")
+                        keep = ask == "y" or ask == ""
+                    except EOFError:
+                        sys.exit(1)
+                if keep:
+                    sld_products["products"][p_name]['card_count'] = deck["count"]
+            else:
                 sld_products["products"][p_name]['card_count'] = deck["count"]
+
+            if "deck" not in sld_products["products"][p_name]:
+                sld_products["products"][p_name]["deck"] = [{"name": deck["name"], "set": "sld"}]
+
+            if ("card" not in sld_products["products"][p_name]) and ("pack" not in sld_products["products"][p_name]) and ("variable" not in sld_products["products"][p_name]):
+                sld_products["products"][p_name]["other"] = [{"name": "Bonus card unknown"}]
+
+            print(sld_products["products"][p_name])
         else:
-            sld_products["products"][p_name]['card_count'] = deck["count"]
+            index -= 1
+            if product_check != "h":
+                print(f"Invalid action: {product_check}")
+            print("Available actions: q - quit / s - skip / m - more / u - undo / [0]124 - pick / use the exact name of the product")
 
-        if "deck" not in sld_products["products"][p_name]:
-            sld_products["products"][p_name]["deck"] = [{"name": deck["name"], "set": "sld"}]
+        if product_check not in "mb":
+            offset = 0
 
-        if ("card" not in sld_products["products"][p_name]) and ("pack" not in sld_products["products"][p_name]) and ("variable" not in sld_products["products"][p_name]):
-            sld_products["products"][p_name]["other"] = [{"name": "Bonus card unknown"}]
+    with open("data/contents/SLD.yaml", 'w') as sfile:
+        yaml.dump(sld_products, sfile)
 
-        print(sld_products["products"][p_name])
-    else:
-        index -= 1
-        if product_check != "h":
-            print(f"Invalid action: {product_check}")
-        print("Available actions: q - quit / s - skip / m - more / u - undo / [0]124 - pick / use the exact name of the product")
 
-    if product_check not in "mb":
-        offset = 0
-
-with open("data/contents/SLD.yaml", 'w') as sfile:
-    yaml.dump(sld_products, sfile)
+if __name__ == "__main__":
+    main()

--- a/tests/test_sld_auto_entrypoint.py
+++ b/tests/test_sld_auto_entrypoint.py
@@ -1,0 +1,71 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SldEntrypointTests(unittest.TestCase):
+    def run_python(self, arguments, directory):
+        return subprocess.run(
+            [sys.executable, *arguments], cwd=directory,
+            env={**os.environ, 'PYTHONPATH': str(ROOT)},
+            text=True, capture_output=True, timeout=20,
+        )
+
+
+    def test_imports_do_not_fetch_read_data_or_prompt(self):
+        code = '''
+import argparse
+import importlib
+import requests
+import yaml
+from thefuzz import fuzz
+from unittest.mock import patch
+from pathlib import Path
+with patch('requests.sessions.Session.request', side_effect=AssertionError('network')), \\
+     patch('builtins.open', side_effect=AssertionError('file access')), \\
+     patch.object(Path, 'open', side_effect=AssertionError('path access')), \\
+     patch.object(Path, 'glob', side_effect=AssertionError('directory scan')), \\
+     patch('builtins.input', side_effect=AssertionError('prompt')), \\
+     patch.object(argparse.ArgumentParser, 'parse_args', side_effect=AssertionError('CLI parsing')):
+    for name in ('sld_auto',):
+        module = importlib.import_module('scripts.' + name)
+        assert callable(module.main)
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_python(['-c', code], directory)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, '')
+
+
+    def test_explicit_review_still_loads_decks_and_accepts_quit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            (base / 'data/contents').mkdir(parents=True)
+            target = base / 'data/contents/SLD.yaml'
+            original = {'code': 'sld', 'products': {f'Product {i}': {} for i in range(5)}}
+            target.write_text(yaml.safe_dump(original))
+            code = '''
+import json
+import runpy
+import requests
+from unittest.mock import patch
+response = requests.Response()
+response.status_code = 200
+response._content = json.dumps({'data': {'decks': [{'name': 'Example', 'mainBoard': [{'count': 1}]}]}}).encode()
+with patch('requests.get', return_value=response) as get, patch('builtins.input', return_value='q') as prompt:
+    runpy.run_module('scripts.sld_auto', run_name='__main__')
+    get.assert_called_once()
+    prompt.assert_called_once()
+'''
+            result = self.run_python(['-c', code], directory)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn('Finding similar products for Example', result.stdout)
+            self.assertEqual(yaml.safe_load(target.read_text()), original)


### PR DESCRIPTION
Importing sld_auto.py previously downloaded deck data and started interactive review. Move execution behind main() while retaining the existing script command.

Tests cover side-effect-free import and explicitly running the review command with a mocked deck response and quit input. All 33 tests on this branch and git diff --check pass.

Split from #573. This PR changes only the Secret Lair review script and its tests; it is based directly on current main and preserves already-merged fixes.
