### PR TITLE
Correct Phyrexia Compleat Bundle lands and product contents

### DIFF
--- a/data/contents/ONC.yaml
+++ b/data/contents/ONC.yaml
@@ -7,8 +7,9 @@ products:
       set: onc
     other:
     - name: Phyrexia All Will Be One Life Wheel
-    - name: Foil Etched Cardstock Display Commander
     - name: 10 Double Sided Tokens
+    - name: Strategy insert
+    - name: Reference card
     sealed:
     - count: 1
       name: Phyrexia All Will Be One Collector Booster Sample Pack
@@ -28,9 +29,9 @@ products:
       set: onc
     other:
     - name: Phyrexia All Will Be One Life Wheel
-    - name: Foil Etched Cardstock Display Commander
     - name: 10 Double Sided Tokens
-    - name: Life Wheel
+    - name: Strategy insert
+    - name: Reference card
     sealed:
     - count: 1
       name: Phyrexia All Will Be One Collector Booster Sample Pack

--- a/data/contents/ONE.yaml
+++ b/data/contents/ONE.yaml
@@ -11,6 +11,7 @@ products:
       set: one
     other:
     - name: Phyrexia All Will Be One Spindown
+    - name: 2 reference cards
     sealed:
     - count: 8
       name: Phyrexia All Will Be One Set Booster Pack
@@ -47,7 +48,7 @@ products:
       number: 283
       set: one
     deck:
-    - name: 'Phyrexia: All Will Be One Bundle Land Pack'
+    - name: 'Phyrexia: All Will Be One Compleat Bundle Land Pack'
       set: one
     sealed:
     - count: 12
@@ -110,6 +111,7 @@ products:
     card_count: 1
     other:
     - name: Phyrexia All Will Be One Spindown
+    - name: MTG Arena code card (available in select regions)
     pack:
     - code: prerelease
       set: one


### PR DESCRIPTION
Reference the dedicated 40-foil Compleat land deck, add regular Bundle reference cards and the regional Prerelease Arena code. Remove Commander display duplicates and Rebellion Rising’s duplicate life wheel; add the documented strategy/reference inserts. No deck-box additions.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-phyrexia-all-will-be-one
- https://www.tcgplayer.com/product/475568

Validation: Existing contents validator passes (pre-existing unrelated category/subtype warnings remain). Checked changed references, quantities and git diff --check. No new tests added.

Companion PRs (merge/import these before resolving the new references):
- https://github.com/taw/magic-preconstructed-decks/pull/315
