### PR TITLE
Remove duplicate March of the Machine Commander accessories

### DIFF
--- a/data/contents/MOC.yaml
+++ b/data/contents/MOC.yaml
@@ -8,7 +8,6 @@ products:
     other:
     - name: March of the Machine Planar Die
     - name: March of the Machine Life Wheel
-    - name: Foil Etched Cardstock Display Commander
     - name: 10 Double Sided Tokens
     sealed:
     - count: 1
@@ -22,7 +21,6 @@ products:
     other:
     - name: March of the Machine Planar Die
     - name: March of the Machine Life Wheel
-    - name: Foil Etched Cardstock Display Commander
     - name: 10 Double Sided Tokens
     sealed:
     - count: 1
@@ -36,7 +34,6 @@ products:
     other:
     - name: March of the Machine Planar Die
     - name: March of the Machine Life Wheel
-    - name: Foil Etched Cardstock Display Commander
     - name: 10 Double Sided Tokens
     sealed:
     - count: 1
@@ -50,7 +47,6 @@ products:
     other:
     - name: March of the Machine Planar Die
     - name: March of the Machine Life Wheel
-    - name: Foil Etched Cardstock Display Commander
     - name: 10 Double Sided Tokens
     sealed:
     - count: 1
@@ -64,10 +60,7 @@ products:
     other:
     - name: March of the Machine Planar Die
     - name: March of the Machine Life Wheel
-    - name: Foil Etched Cardstock Display Commander
     - name: 10 Double Sided Tokens
-    - name: Planar Die
-    - name: Life Wheel
     sealed:
     - count: 1
       name: March of the Machine Collector Booster Sample Pack

--- a/data/contents/MOM.yaml
+++ b/data/contents/MOM.yaml
@@ -84,6 +84,7 @@ products:
     card_count: 2
     other:
     - name: March of the Machine Prerelease Spindown
+    - name: MTG Arena code card (available in select regions)
     pack:
     - code: prerelease
       set: mom


### PR DESCRIPTION
Remove display commanders already mapped in the five deck lists and duplicate planar die/life wheel entries in Tinker Time. Add the regional Prerelease Arena code. Preserve 110-card counts (100-card Commander deck plus ten Planechase cards).

Sources:
- https://magic.wizards.com/en/news/feature/collecting-march-of-the-machine

Validation: Existing contents validator passes (pre-existing unrelated category/subtype warnings remain). Checked changed references, quantities and git diff --check. No new tests added.
