### PR TITLE
Correct Aftermath Epilogue Booster case quantity

### DIFF
--- a/data/contents/MAT.yaml
+++ b/data/contents/MAT.yaml
@@ -42,7 +42,7 @@ products:
       set: mat
   March of the Machine The Aftermath Epilogue Booster Box Case:
     sealed:
-    - count: 6
+    - count: 12
       name: March of the Machine The Aftermath Epilogue Booster Box
       set: mat
   March of the Machine The Aftermath Epilogue Booster Pack:


### PR DESCRIPTION
An Epilogue Booster box case contains 12 boxes, not six. Correct the case reference without changing the 24 boosters per box.

Sources:
- https://wpn.wizards.com/en/products/march-of-the-machine-the-aftermath
- https://www.dacardworld.com/gaming/magic-the-gathering-march-of-the-machine-the-aftermath-epilogue-booster-12-box-case-3

Validation: Existing contents validator passes (pre-existing unrelated category/subtype warnings remain). Checked changed references, quantities and git diff --check. No new tests added.
