### PR TITLE
Correct Lord of the Rings Jumpstart boxes and accessories

### DIFF
--- a/data/contents/LTC.yaml
+++ b/data/contents/LTC.yaml
@@ -8,7 +8,7 @@ products:
     other:
     - name: 10 Double Sided Tokens
     - name: Tales of Middle Earth Life Wheel
-    - name: 1 Foil Etched Display Commander
+    - name: Helper card
     sealed:
     - count: 1
       name: The Lord of the Rings Tales of Middle earth Collector Booster Sample Pack
@@ -21,7 +21,7 @@ products:
     other:
     - name: 10 Double Sided Tokens
     - name: Tales of Middle Earth Life Wheel
-    - name: 1 Foil Etched Display Commander
+    - name: Helper card
     sealed:
     - count: 1
       name: The Lord of the Rings Tales of Middle earth Collector Booster Sample Pack
@@ -34,7 +34,7 @@ products:
     other:
     - name: 10 Double Sided Tokens
     - name: Tales of Middle Earth Life Wheel
-    - name: 1 Foil Etched Display Commander
+    - name: Helper card
     sealed:
     - count: 1
       name: The Lord of the Rings Tales of Middle earth Collector Booster Sample Pack
@@ -47,7 +47,7 @@ products:
     other:
     - name: 10 Double Sided Tokens
     - name: Tales of Middle Earth Life Wheel
-    - name: 1 Foil Etched Display Commander
+    - name: Helper card
     sealed:
     - count: 1
       name: The Lord of the Rings Tales of Middle earth Collector Booster Sample Pack

--- a/data/contents/LTR.yaml
+++ b/data/contents/LTR.yaml
@@ -33,6 +33,7 @@ products:
       set: ltr
     other:
     - name: Tales of Middle Earth Premium Spindown
+    - name: 2 reference cards
     sealed:
     - count: 8
       name: The Lord of the Rings Tales of Middle earth Set Booster Pack
@@ -106,6 +107,7 @@ products:
       set: ltr
     other:
     - name: Tales of Middle Earth Gift Bundle Spindown
+    - name: 2 reference cards
     sealed:
     - count: 8
       name: The Lord of the Rings Tales of Middle earth Set Booster Pack
@@ -120,7 +122,7 @@ products:
       set: ltr
   The Lord of the Rings Tales of Middle earth Jumpstart Booster Box:
     sealed:
-    - count: 20
+    - count: 18
       name: The Lord of the Rings Tales of Middle earth Jumpstart Booster Pack
       set: ltr
   The Lord of the Rings Tales of Middle earth Jumpstart Booster Box Case:
@@ -140,7 +142,7 @@ products:
       set: ltr
   The Lord of the Rings Tales of Middle earth Jumpstart Vol 2 Booster Box:
     sealed:
-    - count: 20
+    - count: 18
       name: The Lord of the Rings Tales of Middle earth Jumpstart Vol 2 Booster Pack
       set: ltr
   The Lord of the Rings Tales of Middle earth Jumpstart Vol 2 Booster Box Case:
@@ -157,6 +159,8 @@ products:
     card_count: 2
     other:
     - name: Tales of Middle Earth Prerelease Spindown
+    - name: Helper card
+    - name: MTG Arena code card (available in select regions)
     pack:
     - code: prerelease
       set: ltr
@@ -203,6 +207,9 @@ products:
     - count: 3
       name: The Lord of the Rings Tales of Middle earth Set Booster Pack
       set: ltr
+    other:
+    - name: 6 art cards
+    - name: Display easel
   The Lord of the Rings Tales of Middle earth Scene Box Flight of the Witch King:
     card_count: 6
     deck:
@@ -212,6 +219,9 @@ products:
     - count: 3
       name: The Lord of the Rings Tales of Middle earth Set Booster Pack
       set: ltr
+    other:
+    - name: 6 art cards
+    - name: Display easel
   The Lord of the Rings Tales of Middle earth Scene Box Gandalf in the Pelennor Fields:
     card_count: 6
     deck:
@@ -221,6 +231,9 @@ products:
     - count: 3
       name: The Lord of the Rings Tales of Middle earth Set Booster Pack
       set: ltr
+    other:
+    - name: 6 art cards
+    - name: Display easel
   The Lord of the Rings Tales of Middle earth Scene Box The Might of Galadriel:
     card_count: 6
     deck:
@@ -230,6 +243,9 @@ products:
     - count: 3
       name: The Lord of the Rings Tales of Middle earth Set Booster Pack
       set: ltr
+    other:
+    - name: 6 art cards
+    - name: Display easel
   The Lord of the Rings Tales of Middle earth Scene Boxes Set of 4:
     sealed:
     - count: 1


### PR DESCRIPTION
Change both original and Volume 2 Jumpstart boxes from 20 to 18 boosters. Add Scene Box art cards/easels, Bundle reference cards, and Prerelease helper/Arena cards. Add Commander helper cards and remove display duplicates already mapped in the deck lists.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-the-lord-of-the-rings-tales-of-middle-earth

Validation: Existing contents validator passes (pre-existing unrelated category/subtype warnings remain). Checked changed references, quantities and git diff --check. No new tests added.
