### PR TITLE
Add Commander Masters deck tokens and accessories

### DIFF
--- a/data/contents/CMM.yaml
+++ b/data/contents/CMM.yaml
@@ -29,6 +29,10 @@ products:
     - count: 1
       name: Commander Masters Collector Booster Sample Pack
       set: cmm
+    other:
+    - name: 10 double faced tokens
+    - name: Helper card
+    - name: Life tracker
   Commander Masters Commander Deck Enduring Enchantments:
     card_count: 100
     deck:
@@ -38,6 +42,10 @@ products:
     - count: 1
       name: Commander Masters Collector Booster Sample Pack
       set: cmm
+    other:
+    - name: 10 double faced tokens
+    - name: Helper card
+    - name: Life tracker
   Commander Masters Commander Deck Planeswalker Party:
     card_count: 100
     deck:
@@ -47,6 +55,10 @@ products:
     - count: 1
       name: Commander Masters Collector Booster Sample Pack
       set: cmm
+    other:
+    - name: 10 double faced tokens
+    - name: Helper card
+    - name: Life tracker
   Commander Masters Commander Deck Sliver Swarm:
     card_count: 100
     deck:
@@ -56,6 +68,10 @@ products:
     - count: 1
       name: Commander Masters Collector Booster Sample Pack
       set: cmm
+    other:
+    - name: 10 double faced tokens
+    - name: Helper card
+    - name: Life tracker
   Commander Masters Commander Decks Set of 4:
     sealed:
     - count: 1


### PR DESCRIPTION
Record the ten double-faced tokens, helper card and life tracker in each Commander Masters deck. Display commanders are mapped as real printings in the companion deck PR rather than duplicated in other contents.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-commander-masters

Validation: Existing contents validator passes (pre-existing unrelated category/subtype warnings remain). Checked changed references, quantities and git diff --check. No new tests added.

Companion PRs (merge/import these before resolving the new references):
- https://github.com/taw/magic-preconstructed-decks/pull/316
