### PR TITLE
Complete Wilds of Eldraine and Starter Kit accessories

### DIFF
--- a/data/contents/WOC.yaml
+++ b/data/contents/WOC.yaml
@@ -17,6 +17,10 @@ products:
     - count: 1
       name: Wilds of Eldraine Collector Booster Sample Pack
       set: woe
+    other:
+    - name: 10 double faced tokens
+    - name: Life tracker
+    - name: Strategy insert
   Wilds of Eldraine Commander Deck Virtue and Valor:
     card_count: 100
     deck:
@@ -26,6 +30,10 @@ products:
     - count: 1
       name: Wilds of Eldraine Collector Booster Sample Pack
       set: woe
+    other:
+    - name: 10 double faced tokens
+    - name: Life tracker
+    - name: Strategy insert
   Wilds of Eldraine Commander Decks Set of 2:
     sealed:
     - count: 1

--- a/data/contents/WOE.yaml
+++ b/data/contents/WOE.yaml
@@ -9,7 +9,8 @@ products:
       set: woe
     other:
     - name: Two deck boxes
-    - name: Arena redemption code
+    - name: 2 MTG Arena code cards (available in select regions)
+    - name: 2 reference cards
   Wilds of Eldraine Bundle:
     card:
     - foil: true
@@ -81,6 +82,8 @@ products:
     card_count: 1
     other:
     - name: Wilds of Eldraine Spindown
+    - name: 2 double faced Role tokens
+    - name: MTG Arena code card (available in select regions)
     pack:
     - code: prerelease
       set: woe


### PR DESCRIPTION
Add Commander tokens, life trackers and strategy inserts; Prerelease Role tokens and regional Arena code; and the Starter Kit’s two reference cards and two regional Arena codes. The Starter Kit explicitly has no tokens, and display commanders are already mapped.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-wilds-of-eldraine
- https://magic.wizards.com/en/news/announcements/starter-kit-2023-decklists

Validation: Existing contents validator passes (pre-existing unrelated category/subtype warnings remain). Checked changed references, quantities and git diff --check. No new tests added.
