### PR TITLE
Complete Ixalan Bundle Jurassic cards and Gift lands

### DIFF
--- a/data/contents/LCC.yaml
+++ b/data/contents/LCC.yaml
@@ -7,9 +7,9 @@ products:
       set: lcc
     other:
     - name: 10 double faced tokens
-    - name: foil etched display commander
     - name: deck box
     - name: spindown life counter
+    - name: Strategy insert
     sealed:
     - count: 1
       name: The Lost Caverns of Ixalan Collector Booster Sample Pack
@@ -21,9 +21,9 @@ products:
       set: lcc
     other:
     - name: 10 double faced tokens
-    - name: foil etched display commander
     - name: deck box
     - name: spindown life counter
+    - name: Strategy insert
     sealed:
     - count: 1
       name: The Lost Caverns of Ixalan Collector Booster Sample Pack
@@ -49,9 +49,9 @@ products:
       set: lcc
     other:
     - name: 10 double faced tokens
-    - name: foil etched display commander
     - name: deck box
     - name: spindown life counter
+    - name: Strategy insert
     sealed:
     - count: 1
       name: The Lost Caverns of Ixalan Collector Booster Sample Pack
@@ -77,9 +77,9 @@ products:
       set: lcc
     other:
     - name: 10 double faced tokens
-    - name: foil etched display commander
     - name: deck box
     - name: spindown life counter
+    - name: Strategy insert
     sealed:
     - count: 1
       name: The Lost Caverns of Ixalan Collector Booster Sample Pack

--- a/data/contents/LCI.yaml
+++ b/data/contents/LCI.yaml
@@ -6,16 +6,20 @@ products:
       name: Hit the Mother Lode
       number: 404
       set: lci
-    card_count: 1
+    card_count: 2
     deck:
     - name: The Lost Caverns of Ixalan Bundle Land Pack
       set: lci
     other:
     - name: Lost Caverns of Ixalan Spindown
     - name: Card storage box
+    - name: 2 reference cards
     sealed:
     - count: 8
       name: The Lost Caverns of Ixalan Set Booster Pack
+      set: lci
+    pack:
+    - code: bundle-promo
       set: lci
   The Lost Caverns of Ixalan Bundle Case:
     sealed:
@@ -74,19 +78,23 @@ products:
       name: Hit the Mother Lode
       number: 404
       set: lci
-    card_count: 1
+    card_count: 2
     deck:
-    - name: The Lost Caverns of Ixalan Bundle Land Pack
+    - name: The Lost Caverns of Ixalan Gift Bundle Land Pack
       set: lci
     other:
     - name: Lost Caverns of Ixalan Spindown
     - name: Card storage box
+    - name: 2 reference cards
     sealed:
     - count: 8
       name: The Lost Caverns of Ixalan Set Booster Pack
       set: lci
     - count: 1
       name: The Lost Caverns of Ixalan Collector Booster Pack
+      set: lci
+    pack:
+    - code: bundle-promo-foil
       set: lci
   The Lost Caverns of Ixalan Gift Bundle Case:
     sealed:
@@ -112,6 +120,8 @@ products:
     card_count: 1
     other:
     - name: Lost Caverns of Ixalan Spindown
+    - name: Punchout counter card
+    - name: MTG Arena code card (available in select regions)
     pack:
     - code: prerelease
       set: lci


### PR DESCRIPTION
Add the random Jurassic World rare to the regular Bundle in nonfoil and the Gift Bundle in foil, alongside the existing fixed promo. Reference the distinct Gift land deck. Add reference cards, Prerelease counter/Arena cards and Commander strategy inserts; remove display commanders already represented in deck lists.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-the-lost-caverns-of-ixalan

Validation: Existing contents validator passes (pre-existing unrelated category/subtype warnings remain). Checked changed references, quantities and git diff --check. No new tests added.

Companion PRs (merge/import these before resolving the new references):
- https://github.com/taw/magic-search-engine/pull/572
- https://github.com/taw/magic-preconstructed-decks/pull/317
