### PR TITLE
Remove six 2023 Secret Lair bundles and add token contents

### DIFF
--- a/data/contents/SLD.yaml
+++ b/data/contents/SLD.yaml
@@ -1323,16 +1323,6 @@ products:
     - count: 1
       name: Secret Lair Drop PixelLands_v02jpg
       set: sld
-  Secret Lair Bundle Spring Superdrop 2023 Its Raining Foils And Non Foils:
-    sealed:
-    - count: 1
-      name: Secret Lair Bundle Spring Superdrop 2023 Those Foils Are Really Coming
-        Down
-      set: sld
-    - count: 1
-      name: Secret Lair Bundle Spring Superdrop 2023 Those Non Foils Just Wont Let
-        Up
-      set: sld
   Secret Lair Bundle Spring Superdrop 2023 March of the Machine:
     sealed:
     - count: 1
@@ -1344,8 +1334,6 @@ products:
     - count: 1
       name: Secret Lair Drop Showcase March of the Machine Vol 3
       set: sld
-  Secret Lair Bundle Spring Superdrop 2023 Those Foils Are Really Coming Down: []
-  Secret Lair Bundle Spring Superdrop 2023 Those Non Foils Just Wont Let Up: []
   Secret Lair Bundle Summer Superdrop 2023 Carving Up A Barrel of Foils:
     sealed:
     - count: 1
@@ -1557,16 +1545,6 @@ products:
     - count: 1
       name: Secret Lair Drop Theros Stargazing Vol V Nylea
       set: sld
-  Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted: []
-  Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Everything:
-    sealed:
-    - count: 1
-      name: Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted
-      set: sld
-    - count: 1
-      name: Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Foil
-      set: sld
-  Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Foil: []
   Secret Lair Commander Deck 20 Ways to Win:
     card:
     - foil: true
@@ -1589,6 +1567,8 @@ products:
     deck:
     - name: 'Angels: They''re Just Like Us but Cooler and with Wings'
       set: sld
+    other:
+    - name: 10 double faced tokens (including the token faces mapped in the deck)
   Secret Lair Commander Deck Everyones Invited!:
     card:
     - foil: true
@@ -1609,6 +1589,8 @@ products:
     deck:
     - name: From Cute to Brute
       set: sld
+    other:
+    - name: 15 double faced tokens
   Secret Lair Commander Deck Goblin Storm:
     card:
     - foil: true

--- a/data/products/SLD.yaml
+++ b/data/products/SLD.yaml
@@ -587,29 +587,11 @@ products:
       tcgplayerProductId: 518840
     release_date: '2023-12-18'
     subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2023 Its Raining Foils And Non Foils:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '493793'
-    release_date: '2023-04-28'
-    subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Spring Superdrop 2023 March of the Machine:
     category: BOX_SET
     identifiers:
       tcgplayerProductId: '493796'
     release_date: '2023-04-28'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2023 Those Foils Are Really Coming Down:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '493794'
-    release_date: '2023-04-28'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Spring Superdrop 2023 Those Non Foils Just Wont Let Up:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '493795'
-    release_date: '2023-08-11'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Bundle Summer Superdrop 2023 Carving Up A Barrel of Foils:
     category: BOX_SET
@@ -688,24 +670,6 @@ products:
       tcgplayerProductId: '209384'
       tntId: '1655972'
     release_date: '2020-02-14'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '480451'
-    release_date: '2023-04-14'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Everything:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '480439'
-    release_date: '2023-04-14'
-    subtype: SECRET_LAIR_BUNDLE
-  Secret Lair Bundle Winter Superdrop 2023 The Prophets Predicted Foil:
-    category: BOX_SET
-    identifiers:
-      tcgplayerProductId: '480444'
-    release_date: '2023-04-14'
     subtype: SECRET_LAIR_BUNDLE
   Secret Lair Commander Deck 20 Ways to Win:
     category: DECK


### PR DESCRIPTION
Remove six Winter/Spring 2023 Secret Lair bundles: the four empty component bundles and the two larger bundles that referenced them. Remove all six from products and contents. The loader already skips bundles, so no ignore entries are needed. No references to the removed products remain.

Record From Cute to Brute’s 15 tokens and Angels’ ten-token assortment. The Angels entry includes the token faces already mapped in the deck; physical face pairing remains unspecified.

Sources for token contents:
- https://magic.wizards.com/en/news/announcements/commander-returns-to-secret-lair-with-from-cute-to-brute
- https://magic.wizards.com/en/news/announcements/secret-lairs-next-commander-deck-takes-flight

Validation: contents_validator.py passes with pre-existing unrelated category/subtype warnings. Checked for references to the removed products and ran git diff --check. No new tests added.
